### PR TITLE
gslc_ElemSetTxtCol: Only update if the new color differs

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -764,6 +764,11 @@ gslc_tsColor gslc_ColorBlend3(gslc_tsColor colStart,gslc_tsColor colMid,gslc_tsC
   return colNew;
 }
 
+bool gslc_ColorEqual(gslc_tsColor a,gslc_tsColor b)
+{
+  return a.r == b.r && a.g == b.g && a.b == b.b;
+}
+
 // ------------------------------------------------------------------------
 // Graphics Primitive Functions
 // ------------------------------------------------------------------------
@@ -2115,10 +2120,13 @@ void gslc_ElemSetTxtCol(gslc_tsElem* pElem,gslc_tsColor colVal)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtCol(%s) called with NULL ptr\n","");
     return;
-  }    
-  pElem->colElemText      = colVal;
-  pElem->colElemTextGlow  = colVal; // Default to same color for glowing state
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
+  }
+  if (!gslc_ColorEqual(pElem->colElemText, colVal) ||
+      !gslc_ColorEqual(pElem->colElemTextGlow, colVal)) {
+    pElem->colElemText      = colVal;
+    pElem->colElemTextGlow  = colVal; // Default to same color for glowing state
+    gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  }
 }
 
 void gslc_ElemSetTxtMem(gslc_tsElem* pElem,gslc_teTxtFlags eFlags)

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -898,6 +898,16 @@ gslc_tsColor gslc_ColorBlend2(gslc_tsColor colStart,gslc_tsColor colEnd,uint16_t
 ///
 gslc_tsColor gslc_ColorBlend3(gslc_tsColor colStart,gslc_tsColor colMid,gslc_tsColor colEnd,uint16_t nMidAmt,uint16_t nBlendAmt);
 
+///
+/// Check whether two colors are equal
+///
+/// \param[in]  a:    First color
+/// \param[in]  b:    Second color
+///
+/// \return True iff a and b are the same color.
+///
+bool gslc_ColorEqual(gslc_tsColor a,gslc_tsColor b);
+
 // ------------------------------------------------------------------------
 // Graphics Primitive Functions
 // - These routines cause immediate drawing to occur on the


### PR DESCRIPTION
This lets the caller be lazy, and simply call `gslc_ElemSetTxtCol` without tracking whether new color has actually changed.

I'm using this in a text that usually shows the time, but may also show an error message if there is one.