### PR TITLE
Support for flash-based elements, 8-bit ILI9341 and Res Touchscreen - update

### DIFF
--- a/arduino_min/gslc_ex02_ard_min/gslc_ex02_ard_min.ino
+++ b/arduino_min/gslc_ex02_ard_min/gslc_ex02_ard_min.ino
@@ -2,8 +2,11 @@
 // GUIslice Library Examples
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
-// - Example 02 (Arduino):
+// - Example 02 (Arduino): [minimum RAM version]
 //   - Accept touch input, text button
+//   - Demonstrates the use of ElemCreate*_P() functions.
+//     These RAM-reduced examples take advantage of the internal
+//     Flash storage (via PROGMEM).
 //
 
 // ARDUINO NOTES:
@@ -28,12 +31,25 @@ bool    m_bQuit = false;
 #define MAX_FONT            1
 #define MAX_ELEM_PG_MAIN    2
 
+// Define the maximum number of elements per page
+// - To enable the same code to run on devices that support storing
+//   data into Flash (PROGMEM) and those that don't, we can make the
+//   number of elements in Flash dependent upon GSLC_USE_PROGMEM
+// - This should allow both Arduino and ARM Cortex to use the same code
+#define MAX_ELEM_PG_MAIN          2                                         // # Elems total
+#if (GSLC_USE_PROGMEM)
+  #define MAX_ELEM_PG_MAIN_PROG   2                                         // # Elems in Flash
+#else
+  #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
+#endif
+#define MAX_ELEM_PG_MAIN_RAM      MAX_ELEM_PG_MAIN - MAX_ELEM_PG_MAIN_PROG  // # Elems in RAM
+
 gslc_tsGui                  m_gui;
 gslc_tsDriver               m_drv;
 gslc_tsFont                 m_asFont[MAX_FONT];
 gslc_tsPage                 m_asPage[MAX_PAGE];
-gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
-gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];   // Storage for all elements in RAM
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];    // References for all elements in GUI
 
 // Define debug message function
 static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
@@ -65,20 +81,17 @@ void setup()
 
   // -----------------------------------
   // Create page elements
-  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN_RAM,m_asPageElemRef,MAX_ELEM_PG_MAIN);
 
   // Background flat color
   gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
 
   // Create background box
-  pElem = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,50,300,150});
-  gslc_ElemSetCol(pElem,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+  gslc_ElemCreateBox_P(&m_gui,E_ELEM_BOX,E_PG_MAIN,10,50,300,150,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true,NULL);
 
   // Create Quit button with text label
-  static const char mstr1[] PROGMEM = "Quit";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
-    (gslc_tsRect){120,100,80,40},(char*)&mstr1,strlen_P(mstr1),E_FONT_BTN,&CbBtnQuit);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,120,100,80,40,"Quit",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnQuit,NULL);
 
 
   // -----------------------------------

--- a/arduino_min/gslc_ex03_ard_min/gslc_ex03_ard_min.ino
+++ b/arduino_min/gslc_ex03_ard_min/gslc_ex03_ard_min.ino
@@ -2,8 +2,14 @@
 // GUIslice Library Examples
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
-// - Example 03 (Arduino):
+// - Example 03 (Arduino): [minimum RAM version]
 //   - Accept touch input, graphic button
+//   - Demonstrates the use of ElemCreate*_P() functions.
+//     These RAM-reduced examples take advantage of the internal
+//     Flash storage (via PROGMEM).
+//   - NOTE: This sketch requires the SD card support library which
+//     adds considerable Flash and RAM requirements. As a result, it
+//     is unlikely to run on basic Arduino devices (eg. ATmega328)
 //
 // ARDUINO NOTES:
 // - GUIslice_config.h must be edited to match the pinout connections
@@ -35,13 +41,25 @@ bool        m_bQuit = false;
 
 // Instantiate the GUI
 #define MAX_PAGE            1
-#define MAX_ELEM_PG_MAIN    2
+
+// Define the maximum number of elements per page
+// - To enable the same code to run on devices that support storing
+//   data into Flash (PROGMEM) and those that don't, we can make the
+//   number of elements in Flash dependent upon GSLC_USE_PROGMEM
+// - This should allow both Arduino and ARM Cortex to use the same code
+#define MAX_ELEM_PG_MAIN          2                                         // # Elems total
+#if (GSLC_USE_PROGMEM)
+  #define MAX_ELEM_PG_MAIN_PROG   1                                         // # Elems in Flash
+#else
+  #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
+#endif
+#define MAX_ELEM_PG_MAIN_RAM      MAX_ELEM_PG_MAIN - MAX_ELEM_PG_MAIN_PROG  // # Elems in RAM
 
 gslc_tsGui                  m_gui;
 gslc_tsDriver               m_drv;
 gslc_tsPage                 m_asPage[MAX_PAGE];
-gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
-gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];   // Storage for all elements in RAM
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];    // References for all elements in GUI
 
 // Define debug message function
 static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
@@ -66,10 +84,10 @@ bool InitOverlays()
   gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
 
   // Create background box
-  pElem = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,50,300,150});
-  gslc_ElemSetCol(pElem,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+  gslc_ElemCreateBox_P(&m_gui,E_ELEM_BOX,E_PG_MAIN,10,50,300,150,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true,NULL);
 
   // Create Quit button with image label
+  // TODO: Add support for image buttons in Flash
   pElem = gslc_ElemCreateBtnImg(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,(gslc_tsRect){258,70,32,32},
           gslc_GetImageFromSD(IMG_BTN_QUIT,GSLC_IMGREF_FMT_BMP24),
           gslc_GetImageFromSD(IMG_BTN_QUIT_SEL,GSLC_IMGREF_FMT_BMP24),

--- a/arduino_min/gslc_ex04_ard_min/gslc_ex04_ard_min.ino
+++ b/arduino_min/gslc_ex04_ard_min/gslc_ex04_ard_min.ino
@@ -195,7 +195,7 @@ void loop()
 
   // Update elements on active page
   snprintf(acTxt,MAX_STR,"%u",m_nCount/5);
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
 
   gslc_ElemXGaugeUpdate(m_pElemProgress,((m_nCount/1)%100));
 
@@ -204,7 +204,7 @@ void loop()
   //       Please see example 07.
   int nPos = gslc_ElemXSliderGetPos(m_pElemSlider);
   snprintf(acTxt,MAX_STR,"Slider: %u",nPos);
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_SLIDER,acTxt);
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_TXT_SLIDER,acTxt);
 
   gslc_ElemXGaugeUpdate(m_pElemProgress1,(nPos*80.0/100.0)-15);
 

--- a/arduino_min/gslc_ex04_ard_min/gslc_ex04_ard_min.ino
+++ b/arduino_min/gslc_ex04_ard_min/gslc_ex04_ard_min.ino
@@ -47,7 +47,7 @@ unsigned    m_nCount = 0;
 // - This should allow both Arduino and ARM Cortex to use the same code
 #define MAX_ELEM_PG_MAIN          15                                        // # Elems total
 #if (GSLC_USE_PROGMEM)
-  #define MAX_ELEM_PG_MAIN_PROG   9                                         // # Elems in Flash
+  #define MAX_ELEM_PG_MAIN_PROG   10                                        // # Elems in Flash
 #else
   #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
 #endif
@@ -130,9 +130,8 @@ bool InitOverlays()
   // Create checkbox 1
   gslc_ElemCreateTxt_P(&m_gui,103,E_PG_MAIN,20,100,20,20,"Check1:",&m_asFont[1], // E_FONT_TXT
           GSLC_COL_YELLOW,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
-  pElem = gslc_ElemXCheckboxCreate(&m_gui,E_ELEM_CHECK1,E_PG_MAIN,&m_asXCheck[0],
-    (gslc_tsRect){80,100,20,20},false,GSLCX_CHECKBOX_STYLE_X,GSLC_COL_BLUE_LT2,false);
-
+  gslc_ElemXCheckboxCreate_P(&m_gui,E_ELEM_CHECK1,E_PG_MAIN,80,100,20,20,false,GSLCX_CHECKBOX_STYLE_X,GSLC_COL_BLUE_LT2,false);
+  
   // Create radio 1
   gslc_ElemCreateTxt_P(&m_gui,104,E_PG_MAIN,20,135,20,20,"Radio1:",&m_asFont[1], // E_FONT_TXT
           GSLC_COL_YELLOW,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);

--- a/arduino_min/gslc_ex04_ard_min/gslc_ex04_ard_min.ino
+++ b/arduino_min/gslc_ex04_ard_min/gslc_ex04_ard_min.ino
@@ -2,9 +2,13 @@
 // GUIslice Library Examples
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
-// - Example 04 (Arduino): Dynamic content
+// - Example 04 (Arduino): Dynamic content [minimum RAM version]
 //   - Demonstrates push buttons, checkboxes and slider controls
 //   - Demonstrates the use of ElemCreate*_P() functions
+//     These RAM-reduced examples take advantage of the internal
+//     Flash storage (via PROGMEM).
+//   - NOTE: This sketch requires moderate program storage in Flash.
+//     As a result, it may not run on basic Arduino devices (eg. ATmega328)
 //
 // ARDUINO NOTES:
 // - GUIslice_config.h must be edited to match the pinout connections
@@ -43,7 +47,7 @@ unsigned    m_nCount = 0;
 // - This should allow both Arduino and ARM Cortex to use the same code
 #define MAX_ELEM_PG_MAIN          15                                        // # Elems total
 #if (GSLC_USE_PROGMEM)
-  #define MAX_ELEM_PG_MAIN_PROG   6                                         // # Elems in Flash
+  #define MAX_ELEM_PG_MAIN_PROG   9                                         // # Elems in Flash
 #else
   #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
 #endif
@@ -95,22 +99,19 @@ bool InitOverlays()
   gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
 
   // Create background box
-  gslc_ElemCreateBox_P(&m_gui,100,E_PG_MAIN,10,50,300,150,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true);
+  gslc_ElemCreateBox_P(&m_gui,100,E_PG_MAIN,10,50,300,150,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true,NULL);
 
   // Create Quit button with text label
-  static const char mstr1[] PROGMEM = "Quit";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
-    (gslc_tsRect){160,80,80,40},(char*)mstr1,strlen_P(mstr1),E_FONT_BTN,&CbBtnQuit);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,160,80,80,40,"Quit",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnQuit,NULL);
+
 
   // Create counter
   gslc_ElemCreateTxt_P(&m_gui,101,E_PG_MAIN,20,60,50,10,"Count:",&m_asFont[1], // E_FONT_TXT
           GSLC_COL_YELLOW,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
   static char mstr3[8] = ""; // Provide space for large counter value
-  pElem = gslc_ElemCreateTxt(&m_gui,E_ELEM_TXT_COUNT,E_PG_MAIN,(gslc_tsRect){80,60,50,10},
-    mstr3,8,E_FONT_TXT);
-  gslc_ElemSetTxtCol(pElem,GSLC_COL_YELLOW);
-  m_pElemCnt = pElem; // Save for quick access
+  gslc_ElemCreateTxt_P_R(&m_gui,E_ELEM_TXT_COUNT,E_PG_MAIN,80,60,50,10,mstr3,8,&m_asFont[1], // E_FONT_TXT
+          GSLC_COL_GRAY_LT2,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
 
   // Create progress bar (horizontal)
   gslc_ElemCreateTxt_P(&m_gui,102,E_PG_MAIN,20,80,50,10,"Progress:",&m_asFont[1], // E_FONT_TXT
@@ -153,9 +154,8 @@ bool InitOverlays()
           5,(gslc_tsColor){64,64,64});
   m_pElemSlider = pElem; // Save for quick access
   static char mstr8[15] = "Slider: ???"; // Provide space for counter value
-  pElem = gslc_ElemCreateTxt(&m_gui,E_ELEM_TXT_SLIDER,E_PG_MAIN,(gslc_tsRect){160,160,80,20},
-    mstr8,15,E_FONT_TXT);
-  m_pElemSliderTxt = pElem; // Save for quick access
+  gslc_ElemCreateTxt_P_R(&m_gui,E_ELEM_TXT_SLIDER,E_PG_MAIN,160,160,80,20,mstr8,15,&m_asFont[1], // E_FONT_TXT
+          GSLC_COL_GRAY_LT2,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
 
   return true;
 }
@@ -196,7 +196,7 @@ void loop()
 
   // Update elements on active page
   snprintf(acTxt,MAX_STR,"%u",m_nCount/5);
-  gslc_ElemSetTxtStr(m_pElemCnt,acTxt);
+  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
 
   gslc_ElemXGaugeUpdate(m_pElemProgress,((m_nCount/1)%100));
 
@@ -205,7 +205,7 @@ void loop()
   //       Please see example 07.
   int nPos = gslc_ElemXSliderGetPos(m_pElemSlider);
   snprintf(acTxt,MAX_STR,"Slider: %u",nPos);
-  gslc_ElemSetTxtStr(m_pElemSliderTxt,acTxt);
+  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_SLIDER,acTxt);
 
   gslc_ElemXGaugeUpdate(m_pElemProgress1,(nPos*80.0/100.0)-15);
 
@@ -224,4 +224,5 @@ void loop()
     while (1) { }
   }
 }
+
 

--- a/arduino_min/gslc_ex05_ard_min/gslc_ex05_ard_min.ino
+++ b/arduino_min/gslc_ex05_ard_min/gslc_ex05_ard_min.ino
@@ -2,12 +2,15 @@
 // GUIslice Library Examples
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
-// - Example 05 (Arduino):
+// - Example 05 (Arduino): [minimum RAM version]
 //   - Multiple page handling
 //   - Background image
 //   - Compound elements
 //   - Demonstrates the use of ElemCreate*_P() functions
-//     NOTE: This sketch requires CPUs with >2KB of RAM
+//     These RAM-reduced examples take advantage of the internal
+//     Flash storage (via PROGMEM).
+//   - NOTE: This sketch requires moderate program storage in Flash.
+//     As a result, it may not run on basic Arduino devices (eg. ATmega328)
 //
 // ARDUINO NOTES:
 // - GUIslice_config.h must be edited to match the pinout connections
@@ -47,8 +50,8 @@ unsigned  m_nCount = 0;
 #define MAX_ELEM_PG_MAIN        9                                         // # Elems total on Main page
 #define MAX_ELEM_PG_EXTRA       7                                         // # Elems total on Extra page
 #if (GSLC_USE_PROGMEM)
-  #define MAX_ELEM_PG_MAIN_PROG   4                                       // # Elems in Flash
-  #define MAX_ELEM_PG_EXTRA_PROG  4                                       // # Elems in Flash
+  #define MAX_ELEM_PG_MAIN_PROG   7                                       // # Elems in Flash
+  #define MAX_ELEM_PG_EXTRA_PROG  5                                       // # Elems in Flash
 #else
   #define MAX_ELEM_PG_MAIN_PROG   0                                       // # Elems in Flash
   #define MAX_ELEM_PG_EXTRA_PROG  0                                       // # Elems in Flash
@@ -116,33 +119,30 @@ bool InitOverlays()
   // PAGE: MAIN
 
   // Create background box
-  gslc_ElemCreateBox_P(&m_gui,100,E_PG_MAIN,20,50,280,150,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true);
+  gslc_ElemCreateBox_P(&m_gui,100,E_PG_MAIN,20,50,280,150,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true,NULL);
 
   // Create title
   gslc_ElemCreateTxt_P(&m_gui,101,E_PG_MAIN,10,10,310,40,"GUIslice Demo",&m_asFont[2], // E_FONT_TITLE
           GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_MID,false,false);
 
   // Create Quit button with text label
-  static const char mstr2[] PROGMEM = "Quit";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
-    (gslc_tsRect){100,140,50,20},(char*)mstr2,strlen_P(mstr2),E_FONT_BTN,&CbBtnCommon);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,100,140,50,20,"Quit",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnCommon,NULL);
+
 
 
   // Create Extra button with text label
-  static const char mstr3[] PROGMEM = "Extra";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_EXTRA,E_PG_MAIN,
-    (gslc_tsRect){170,140,50,20},(char*)mstr3,strlen_P(mstr3),E_FONT_BTN,&CbBtnCommon);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_EXTRA,E_PG_MAIN,170,140,50,20,"Extra",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnCommon,NULL);
+
 
   // Create counter
   gslc_ElemCreateTxt_P(&m_gui,102,E_PG_MAIN,40,60,50,10,"Count",&m_asFont[1], // E_FONT_TXT
           GSLC_COL_YELLOW,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
-  static char mstr5[8] = "";  // Placeholder for counter
-  pElem = gslc_ElemCreateTxt(&m_gui,E_ELEM_TXT_COUNT,E_PG_MAIN,(gslc_tsRect){100,60,50,10},
-    mstr5,8,E_FONT_TXT);
-  gslc_ElemSetTxtCol(pElem,GSLC_COL_YELLOW);
-  m_pElemCnt = pElem; // Save for quick access
+
+  static char mstr5[8] = "????";  // Placeholder for counter
+  gslc_ElemCreateTxt_P_R(&m_gui,E_ELEM_TXT_COUNT,E_PG_MAIN,100,60,50,10,mstr5,8,&m_asFont[1], // E_FONT_TXT
+          GSLC_COL_YELLOW,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
 
 
   // Create progress bar
@@ -161,14 +161,11 @@ bool InitOverlays()
   // PAGE: EXTRA
 
   // Create background box
-  gslc_ElemCreateBox_P(&m_gui,200,E_PG_EXTRA,40,40,240,160,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true);
+  gslc_ElemCreateBox_P(&m_gui,200,E_PG_EXTRA,40,40,240,160,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true,NULL);
 
   // Create Back button with text label
-  static const char mstr7[] PROGMEM = "Back";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_BACK,E_PG_EXTRA,
-    (gslc_tsRect){50,170,50,20},(char*)mstr7,strlen_P(mstr7),E_FONT_BTN,&CbBtnCommon);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
-
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_BACK,E_PG_EXTRA,50,170,50,20,"Back",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnCommon,NULL);
 
   // Create a few labels
   gslc_ElemCreateTxt_P(&m_gui,201,E_PG_EXTRA,60,50,50,10,"Data 1",&m_asFont[1], // E_FONT_TXT
@@ -228,11 +225,8 @@ void loop()
   m_nCount++;
 
   // Perform drawing updates
-  // - Note: we can make the updates conditional on the active
-  //   page by checking gslc_GetPageCur() first.
-
   snprintf(acTxt,MAX_STR,"%u",m_nCount);
-  gslc_ElemSetTxtStr(pElemCnt,acTxt);
+  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
 
   gslc_ElemXGaugeUpdate(pElemProgress,((m_nCount/2)%100));
 

--- a/arduino_min/gslc_ex05_ard_min/gslc_ex05_ard_min.ino
+++ b/arduino_min/gslc_ex05_ard_min/gslc_ex05_ard_min.ino
@@ -226,7 +226,7 @@ void loop()
 
   // Perform drawing updates
   snprintf(acTxt,MAX_STR,"%u",m_nCount);
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
 
   gslc_ElemXGaugeUpdate(pElemProgress,((m_nCount/2)%100));
 

--- a/arduino_min/gslc_ex06_ard_min/gslc_ex06_ard_min.ino
+++ b/arduino_min/gslc_ex06_ard_min/gslc_ex06_ard_min.ino
@@ -56,7 +56,7 @@ float     m_fCoordZ = 0;
 // - This should allow both Arduino and ARM Cortex to use the same code
 #define MAX_ELEM_PG_MAIN          19                                        // # Elems total
 #if (GSLC_USE_PROGMEM)
-  #define MAX_ELEM_PG_MAIN_PROG   16                                        // # Elems in Flash
+  #define MAX_ELEM_PG_MAIN_PROG   17                                        // # Elems in Flash
 #else
   #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
 #endif
@@ -251,8 +251,7 @@ bool InitOverlays()
   gslc_ElemCreateTxt_P(&m_gui,106,E_PG_MAIN,20,170,50,10,"Control:",&m_asFont[1],
           GSLC_COL_ORANGE,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
 
-  pElem = gslc_ElemXCheckboxCreate(&m_gui,E_ELEM_CHECK1,E_PG_MAIN,&m_asXCheck[0],
-    (gslc_tsRect){80,170,20,20},false,GSLCX_CHECKBOX_STYLE_X,GSLC_COL_BLUE_LT2,false);
+  gslc_ElemXCheckboxCreate_P(&m_gui,E_ELEM_CHECK1,E_PG_MAIN,80,170,20,20,false,GSLCX_CHECKBOX_STYLE_X,GSLC_COL_BLUE_LT2,false);
 
   gslc_ElemCreateTxt_P(&m_gui,107,E_PG_MAIN,110,170,50,10,"Enable",&m_asFont[1],
           GSLC_COL_GRAY_LT1,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);

--- a/arduino_min/gslc_ex06_ard_min/gslc_ex06_ard_min.ino
+++ b/arduino_min/gslc_ex06_ard_min/gslc_ex06_ard_min.ino
@@ -321,16 +321,16 @@ void loop()
   // Perform any immediate updates on active page
   snprintf(acTxt,MAX_STR,"%u",m_nCount);
   //gslc_ElemSetTxtStr(m_pElemCount,acTxt);
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT,acTxt);
 
   // By default, Arduino sprintf() doesn't include floating point
   // support, so we're just going to display integers
   snprintf(acTxt,MAX_STR,"%4d",(int16_t)(m_fCoordX-50));
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_DATAX,acTxt);
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_DATAX,acTxt);
   snprintf(acTxt,MAX_STR,"%4d",(int16_t)(m_fCoordY-50));
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_DATAY,acTxt);  
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_DATAY,acTxt);  
   snprintf(acTxt,MAX_STR,"%4d",(int16_t)(m_fCoordZ));
-  gslc_ElemSetTxtStrP1(&m_gui,E_PG_MAIN,E_ELEM_DATAZ,acTxt);    
+  gslc_ElemSetTxtStr_P(&m_gui,E_PG_MAIN,E_ELEM_DATAZ,acTxt);    
 
   gslc_ElemXGaugeUpdate(m_pElemProgress,50+50*sin(m_nCount/5.0));
 

--- a/arduino_min/gslc_ex07_ard_min/gslc_ex07_ard_min.ino
+++ b/arduino_min/gslc_ex07_ard_min/gslc_ex07_ard_min.ino
@@ -5,6 +5,10 @@
 // - Example 07 (Arduino):
 //   - Sliders with dynamic color control and position callback
 //   - Demonstrates the use of ElemCreate*_P() functions
+//   - Also demonstrates the use of ElemCreateBtnTxt_P()
+//     NOTE: this is a alpha-test version of the flash-based
+//     button implementation. Although the buttons work, the
+//     highlight (glowing) state is not implemented yet.
 //
 // ARDUINO NOTES:
 // - GUIslice_config.h must be edited to match the pinout connections
@@ -21,7 +25,7 @@
 // Enumerations for pages, elements, fonts, images
 enum {E_PG_MAIN};
 enum {E_ELEM_BOX,E_ELEM_BTN_QUIT,E_ELEM_COLOR,
-      E_SLIDER_R,E_SLIDER_G,E_SLIDER_B};
+      E_SLIDER_R,E_SLIDER_G,E_SLIDER_B,E_ELEM_BTN_KITCHEN};
 enum {E_FONT_TXT,E_FONT_TITLE};
 
 bool      m_bQuit = false;
@@ -40,7 +44,7 @@ unsigned  m_nCount = 0;
 // - This should allow both Arduino and ARM Cortex to use the same code
 #define MAX_ELEM_PG_MAIN          17                                        // # Elems total
 #if (GSLC_USE_PROGMEM)
-  #define MAX_ELEM_PG_MAIN_PROG   11                                        // # Elems in Flash
+  #define MAX_ELEM_PG_MAIN_PROG   13                                        // # Elems in Flash
 #else
   #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
 #endif
@@ -132,11 +136,11 @@ bool InitOverlays()
 
 
   // Create background box
-  gslc_ElemCreateBox_P(&m_gui,200,E_PG_MAIN,10,50,300,180,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true);
+  gslc_ElemCreateBox_P(&m_gui,200,E_PG_MAIN,10,50,300,180,GSLC_COL_WHITE,GSLC_COL_BLACK,true,true,NULL);
 
   // Create dividers
-  gslc_ElemCreateBox_P(&m_gui,201,E_PG_MAIN,20,100,280,1,GSLC_COL_GRAY_DK3,GSLC_COL_BLACK,true,true);
-  gslc_ElemCreateBox_P(&m_gui,202,E_PG_MAIN,235,60,1,35,GSLC_COL_GRAY_DK3,GSLC_COL_BLACK,true,true);
+  gslc_ElemCreateBox_P(&m_gui,201,E_PG_MAIN,20,100,280,1,GSLC_COL_GRAY_DK3,GSLC_COL_BLACK,true,true,NULL);
+  gslc_ElemCreateBox_P(&m_gui,202,E_PG_MAIN,235,60,1,35,GSLC_COL_GRAY_DK3,GSLC_COL_BLACK,true,true,NULL);
 
 
   // Create color box
@@ -145,23 +149,33 @@ bool InitOverlays()
   gslc_ElemSetCol(pElem,GSLC_COL_WHITE,colRGB,GSLC_COL_WHITE);
 
   // Create Quit button with text label
+  #if 0 // Put button in flash
   static const char mstr2[] PROGMEM = "SAVE";
   pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
     (gslc_tsRect){250,60,50,30},(char*)mstr2,strlen_P(mstr2),E_FONT_TXT,&CbBtnQuit);
   gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
   gslc_ElemSetCol(pElem,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK1);
   gslc_ElemSetTxtCol(pElem,GSLC_COL_WHITE);
+  #else
+  gslc_ElemCreateTxtBtn_P(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,250,60,50,30,"SAVE",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnQuit,NULL);
+  #endif
 
   // Create dummy selector
   gslc_ElemCreateTxt_P(&m_gui,100,E_PG_MAIN,20,65,100,20,"Selected Room:",&m_asFont[0],
           GSLC_COL_GRAY_LT2,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
 
+  #if 0 // Put button in flash
   static const char mstr4[] PROGMEM = "Kitchen...";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,
+  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_KITCHEN,E_PG_MAIN,
     (gslc_tsRect){140,65,80,20},(char*)mstr4,strlen_P(mstr4),E_FONT_TXT,NULL);
   gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
   gslc_ElemSetCol(pElem,GSLC_COL_GRAY_DK2,GSLC_COL_GRAY_DK3,GSLC_COL_BLUE_DK1);
   gslc_ElemSetTxtCol(pElem,GSLC_COL_WHITE);
+  #else
+  gslc_ElemCreateTxtBtn_P(&m_gui,E_ELEM_BTN_KITCHEN,E_PG_MAIN,140,65,80,20,"Kitchen...",&m_asFont[0],
+    GSLC_COL_WHITE,GSLC_COL_GRAY_DK2,GSLC_COL_GRAY_DK3,GSLC_COL_GRAY_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,NULL,NULL);
+  #endif
 
   // Create sliders
   // - Define element arrangement
@@ -262,4 +276,3 @@ void loop()
     while (1) { }
   }
 }
-

--- a/arduino_min/gslc_ex07_ard_min/gslc_ex07_ard_min.ino
+++ b/arduino_min/gslc_ex07_ard_min/gslc_ex07_ard_min.ino
@@ -2,9 +2,11 @@
 // GUIslice Library Examples
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
-// - Example 07 (Arduino):
+// - Example 07 (Arduino): [minimum RAM version]
 //   - Sliders with dynamic color control and position callback
-//   - Demonstrates the use of ElemCreate*_P() functions
+//   - Demonstrates the use of ElemCreate*_P() functions.
+//     These RAM-reduced examples take advantage of the internal
+//     Flash storage (via PROGMEM).
 //
 // ARDUINO NOTES:
 // - GUIslice_config.h must be edited to match the pinout connections
@@ -140,6 +142,8 @@ bool InitOverlays()
 
 
   // Create color box
+  // - This element is created in RAM instead of Flash as we want
+  //   dynamic control over its color fill
   pElem = gslc_ElemCreateBox(&m_gui,E_ELEM_COLOR,E_PG_MAIN,(gslc_tsRect){20,90+30,130,100});
   gslc_tsColor colRGB = (gslc_tsColor){m_nPosR,m_nPosG,m_nPosB};
   gslc_ElemSetCol(pElem,GSLC_COL_WHITE,colRGB,GSLC_COL_WHITE);

--- a/arduino_min/gslc_ex07_ard_min/gslc_ex07_ard_min.ino
+++ b/arduino_min/gslc_ex07_ard_min/gslc_ex07_ard_min.ino
@@ -5,10 +5,6 @@
 // - Example 07 (Arduino):
 //   - Sliders with dynamic color control and position callback
 //   - Demonstrates the use of ElemCreate*_P() functions
-//   - Also demonstrates the use of ElemCreateBtnTxt_P()
-//     NOTE: this is a alpha-test version of the flash-based
-//     button implementation. Although the buttons work, the
-//     highlight (glowing) state is not implemented yet.
 //
 // ARDUINO NOTES:
 // - GUIslice_config.h must be edited to match the pinout connections
@@ -25,7 +21,7 @@
 // Enumerations for pages, elements, fonts, images
 enum {E_PG_MAIN};
 enum {E_ELEM_BOX,E_ELEM_BTN_QUIT,E_ELEM_COLOR,
-      E_SLIDER_R,E_SLIDER_G,E_SLIDER_B,E_ELEM_BTN_KITCHEN};
+      E_SLIDER_R,E_SLIDER_G,E_SLIDER_B,E_ELEM_BTN_ROOM};
 enum {E_FONT_TXT,E_FONT_TITLE};
 
 bool      m_bQuit = false;
@@ -149,33 +145,16 @@ bool InitOverlays()
   gslc_ElemSetCol(pElem,GSLC_COL_WHITE,colRGB,GSLC_COL_WHITE);
 
   // Create Quit button with text label
-  #if 0 // Put button in flash
-  static const char mstr2[] PROGMEM = "SAVE";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
-    (gslc_tsRect){250,60,50,30},(char*)mstr2,strlen_P(mstr2),E_FONT_TXT,&CbBtnQuit);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
-  gslc_ElemSetCol(pElem,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK1);
-  gslc_ElemSetTxtCol(pElem,GSLC_COL_WHITE);
-  #else
-  gslc_ElemCreateTxtBtn_P(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,250,60,50,30,"SAVE",&m_asFont[0],
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,250,60,50,30,"SAVE",&m_asFont[0],
     GSLC_COL_WHITE,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK4,GSLC_COL_BLUE_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,&CbBtnQuit,NULL);
-  #endif
 
   // Create dummy selector
   gslc_ElemCreateTxt_P(&m_gui,100,E_PG_MAIN,20,65,100,20,"Selected Room:",&m_asFont[0],
           GSLC_COL_GRAY_LT2,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_LEFT,false,true);
 
-  #if 0 // Put button in flash
-  static const char mstr4[] PROGMEM = "Kitchen...";
-  pElem = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_KITCHEN,E_PG_MAIN,
-    (gslc_tsRect){140,65,80,20},(char*)mstr4,strlen_P(mstr4),E_FONT_TXT,NULL);
-  gslc_ElemSetTxtMem(pElem,GSLC_TXT_MEM_PROG);
-  gslc_ElemSetCol(pElem,GSLC_COL_GRAY_DK2,GSLC_COL_GRAY_DK3,GSLC_COL_BLUE_DK1);
-  gslc_ElemSetTxtCol(pElem,GSLC_COL_WHITE);
-  #else
-  gslc_ElemCreateTxtBtn_P(&m_gui,E_ELEM_BTN_KITCHEN,E_PG_MAIN,140,65,80,20,"Kitchen...",&m_asFont[0],
+  // Create room button
+  gslc_ElemCreateBtnTxt_P(&m_gui,E_ELEM_BTN_ROOM,E_PG_MAIN,140,65,80,20,"Kitchen...",&m_asFont[0],
     GSLC_COL_WHITE,GSLC_COL_GRAY_DK2,GSLC_COL_GRAY_DK3,GSLC_COL_GRAY_DK2,GSLC_COL_BLUE_DK1,GSLC_ALIGN_MID_MID,true,true,NULL,NULL);
-  #endif
 
   // Create sliders
   // - Define element arrangement

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2214,7 +2214,7 @@ void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr)
 // indexed by Page ID and Element ID
 // - This routine will copy the string from flash to a temporary
 //   element and then force a redraw
-void gslc_ElemSetTxtStrP1(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId,const char* pStr)
+void gslc_ElemSetTxtStr_P(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId,const char* pStr)
 {
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtStrP1(%s) called with NULL ptr\n","");

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -88,7 +88,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
 {
   unsigned  nInd;
   bool      bOk = true;
-  
+
   // Initialize state
   pGui->nDispW          = 0;
   pGui->nDispH          = 0;
@@ -115,7 +115,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   for (nInd=0;nInd<(pGui->nFontMax);nInd++) {
     gslc_ResetFont(&(pGui->asFont[nInd]));
   }
- 
+
   // Initialize temporary element
   gslc_ResetElem(&(pGui->sElemTmp));
 
@@ -126,22 +126,22 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   pGui->nTouchLastPress       = 0;
 
   pGui->pfuncXEvent = NULL;
-  
+
   pGui->sImgRefBkgnd = gslc_ResetImage();
-    
+
   // Save a link to the driver
   pGui->pvDriver = pvDriver;
-  
+
   // Default to no support for partial redraw
   // - This may be overridden by the driver-specific init
   pGui->bRedrawPartialEn = false;
- 
-  
+
+
   #ifdef DBG_FRAME_RATE
   pGui->nFrameRateCnt = 0;
   pGui->nFrameRateStart = time(NULL);
   #endif
-  
+
   // Initialize the display and touch drivers
   if (bOk) { bOk &= gslc_DrvInit(pGui); }
   if (bOk) { bOk &= gslc_InitTouch(pGui,GSLC_DEV_TOUCH); }
@@ -162,7 +162,7 @@ typedef enum {
   GSLC_DEBUG_PRINT_NORM,
   GSLC_DEBUG_PRINT_TOKEN,
   GSLC_DEBUG_PRINT_UINT16,
-  GSLC_DEBUG_PRINT_STR          
+  GSLC_DEBUG_PRINT_STR
 } gslc_teDebugPrintState;
 
 // A lightweight printf() routine that calls user function for
@@ -211,7 +211,7 @@ void gslc_DebugPrintf(const char* pFmt, ...)
     #endif
 
     while (cFmt != 0) {
-  
+
       if (nState == GSLC_DEBUG_PRINT_NORM) {
 
         if (cFmt == '%') {
@@ -223,7 +223,7 @@ void gslc_DebugPrintf(const char* pFmt, ...)
         nFmtInd++; // Advance format index
 
       } else if (nState == GSLC_DEBUG_PRINT_TOKEN) {
-        
+
         // Get token
         if (cFmt == 'd') {
           nState = GSLC_DEBUG_PRINT_UINT16;
@@ -240,14 +240,14 @@ void gslc_DebugPrintf(const char* pFmt, ...)
           }
           bNumStart = false;
           nNumDivisor = nMaxDivisor;
-          
+
         } else if (cFmt == 'u') {
           nState = GSLC_DEBUG_PRINT_UINT16;
           nNumRemain = va_arg(vlist,unsigned);
           bNumNeg = false;
-          bNumStart = false;        
+          bNumStart = false;
           nNumDivisor = nMaxDivisor;
-          
+
         } else if (cFmt == 's') {
           nState = GSLC_DEBUG_PRINT_STR;
           pStr = va_arg(vlist,char*);
@@ -264,7 +264,7 @@ void gslc_DebugPrintf(const char* pFmt, ...)
         }
         nState = GSLC_DEBUG_PRINT_NORM;
         // Don't advance format string index
-        
+
       } else if (nState == GSLC_DEBUG_PRINT_UINT16) {
 
         // Handle the negation flag if required
@@ -339,7 +339,7 @@ void gslc_Update(gslc_tsGui* pGui)
   int16_t   nTouchY = 0;
   uint16_t  nTouchPress = 0;
   bool      bTouchEvent = true;
-  
+
   // Handle touchscreen presses
   // - We clear the event queue here so that we don't fall behind
   // - In the time it takes to update the display, several mouse /
@@ -352,13 +352,13 @@ void gslc_Update(gslc_tsGui* pGui)
   //   the VSYNC, which will effectively insert a delay into the
   //   gslc_PageRedrawGo() call below. It might be possible to
   //   adjust this blocking behavior via SDL_RENDERER_PRESENTVSYNC.
-  
+
   // In case we are flooded with events, limit the maximum number
   // that we handle in one gslc_Update() call.
   bool      bDoneEvts = false;
   uint16_t  nNumEvts  = 0;
   do {
-    bTouchEvent = gslc_GetTouch(pGui,&nTouchX,&nTouchY,&nTouchPress);   
+    bTouchEvent = gslc_GetTouch(pGui,&nTouchX,&nTouchY,&nTouchPress);
     if (bTouchEvent) {
       // Track and handle the touch events
       // - Handle the events on the current page
@@ -368,29 +368,29 @@ void gslc_Update(gslc_tsGui* pGui)
       // Highlight current touch for coordinate debug
       gslc_tsRect rMark = gslc_ExpandRect((gslc_tsRect){(int16_t)nTouchX,(int16_t)nTouchY,1,1},1,1);
       gslc_DrawFrameRect(pGui,rMark,GSLC_COL_YELLOW);
-      #endif    
+      #endif
 
       nNumEvts++;
     }
-    
+
     // Should we stop handling events?
     if ((!bTouchEvent) || (nNumEvts >= GSLC_TOUCH_MAX_EVT)) {
       bDoneEvts = true;
     }
   } while (!bDoneEvts);
-  
+
   // Issue a timer tick to all pages
   uint8_t nPageInd;
   gslc_tsPage* pPage = NULL;
   for (nPageInd=0;nPageInd<pGui->nPageCnt;nPageInd++) {
-    pPage = &pGui->asPage[nPageInd];    
+    pPage = &pGui->asPage[nPageInd];
     gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_TICK,0,(void*)pPage,NULL);
     gslc_PageEvent(pGui,sEvent);
   }
-  
+
   // Perform any redraw required for current page
   gslc_PageRedrawGo(pGui);
-  
+
   // Simple "frame" rate reporting
   // - Note that the rate is based on the number of calls to gslc_Update()
   //   per second, which may or may not redraw the frame
@@ -425,7 +425,7 @@ gslc_tsEvent  gslc_EventCreate(gslc_teEventType eType,uint8_t nSubType,void* pvS
 
 bool gslc_IsInRect(int16_t nSelX,int16_t nSelY,gslc_tsRect rRect)
 {
-  if ( (nSelX >= rRect.x) && (nSelX <= rRect.x+rRect.w) && 
+  if ( (nSelX >= rRect.x) && (nSelX <= rRect.x+rRect.w) &&
      (nSelY >= rRect.y) && (nSelY <= rRect.y+rRect.h) ) {
     return true;
   } else {
@@ -435,7 +435,7 @@ bool gslc_IsInRect(int16_t nSelX,int16_t nSelY,gslc_tsRect rRect)
 
 bool gslc_IsInWH(gslc_tsGui* pGui,int16_t nSelX,int16_t nSelY,uint16_t nWidth,uint16_t nHeight)
 {
-  if ( (nSelX >= 0) && (nSelX <= nWidth-1) && 
+  if ( (nSelX >= 0) && (nSelX <= nWidth-1) &&
      (nSelY >= 0) && (nSelY <= nHeight-1) ) {
     return true;
   } else {
@@ -481,12 +481,12 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
   int16_t nCXMin,nCXMax,nCYMin,nCYMax;
   uint8_t nRegion0,nRegion1,nRegionSel;
   int16_t nLX0,nLY0,nLX1,nLY1;
-  
+
   int16_t nCX0 = pClipRect->x;
   int16_t nCY0 = pClipRect->y;
   int16_t nCX1 = pClipRect->x + pClipRect->w - 1;
   int16_t nCY1 = pClipRect->y + pClipRect->h - 1;
-  
+
   if (nCX0 > nCX1) {
     nCXMin = nCX1;
     nCXMax = nCX0;
@@ -500,11 +500,11 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
   } else {
     nCYMin = nCY0;
     nCYMax = nCY1;
-  }  
-  
+  }
+
   nTmpX = 0;
   nTmpY = 0;
-  while (1) {  
+  while (1) {
     nLX0 = *pnX0;
     nLY0 = *pnY0;
     nLX1 = *pnX1;
@@ -512,7 +512,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
 
     // Step 1: Assign a region code to each endpoint
     nRegion0 = 0;
-    nRegion1 = 0;  
+    nRegion1 = 0;
     if      (nLX0 < nCX0) { nRegion0 |= 1; }
     else if (nLX0 > nCX1) { nRegion0 |= 2; }
     if      (nLY0 < nCY0) { nRegion0 |= 4; }
@@ -531,7 +531,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
     if ((nRegion0 & nRegion1) != 0) {
       return false;
     }
-  
+
     // Step 4: Clipping
     nRegionSel = nRegion0 ? nRegion0 : nRegion1;
     if (nRegionSel & 8) {
@@ -547,7 +547,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
       nTmpY = nLY0 + (nLY1 - nLY0) * (nCXMin - nLX0) / (nLX1 - nLX0);
       nTmpX = nCXMin;
     }
-    
+
     // Update endpoint
     if (nRegionSel == nRegion0) {
       *pnX0 = nTmpX;
@@ -557,7 +557,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
       *pnY1 = nTmpY;
     }
   } // while(1)
-  
+
   return true;
 }
 
@@ -611,7 +611,7 @@ gslc_tsImgRef gslc_GetImageFromFile(const char* pFname,gslc_teImgRefFlags eFmt)
 
 gslc_tsImgRef gslc_GetImageFromSD(const char* pFname,gslc_teImgRefFlags eFmt)
 {
-  gslc_tsImgRef sImgRef;  
+  gslc_tsImgRef sImgRef;
 #if (ADAGFX_SD_EN)
   sImgRef.eImgFlags = GSLC_IMGREF_SRC_SD | (GSLC_IMGREF_FMT & eFmt);
   sImgRef.pFname    = pFname;
@@ -621,8 +621,8 @@ gslc_tsImgRef gslc_GetImageFromSD(const char* pFname,gslc_teImgRefFlags eFmt)
   // TODO: Change message to also handle non-Arduino output
   GSLC_DEBUG_PRINT("ERROR: GetImageFromSD(%s) not supported as Config:ADAGFX_SD_EN=0\n","");
   sImgRef.eImgFlags = GSLC_IMGREF_NONE;
-#endif  
-  return sImgRef;  
+#endif
+  return sImgRef;
 }
 
 gslc_tsImgRef gslc_GetImageFromRam(unsigned char* pImgBuf,gslc_teImgRefFlags eFmt)
@@ -632,7 +632,7 @@ gslc_tsImgRef gslc_GetImageFromRam(unsigned char* pImgBuf,gslc_teImgRefFlags eFm
   sImgRef.pFname    = NULL;
   sImgRef.pImgBuf   = pImgBuf;
   sImgRef.pvImgRaw  = NULL;
-  return sImgRef;  
+  return sImgRef;
 }
 
 
@@ -654,19 +654,19 @@ int16_t gslc_sinFX(int16_t n64Ang)
 
 #if (GSLC_USE_FLOAT)
   // Use floating-point math library function
-  
+
   // Calculate angle in radians
   float fAngRad = n64Ang*GSLC_2PI/(360.0*64.0);
   // Perform floating point calc
   float fSin = sin(fAngRad);
   // Return as fixed point result
   nRetValS = fSin * 32767.0;
-  return nRetValS;  
-  
+  return nRetValS;
+
 #else
   // Use lookup tables
   bool bNegate = false;
-  
+
   // Support multiple waveform periods
   if (n64Ang >= 360*64) {
     // For some reason this modulus is broken!
@@ -689,12 +689,12 @@ int16_t gslc_sinFX(int16_t n64Ang)
   if (n64Ang >= 90*64) {
     n64Ang = 180*64 - n64Ang;
   }
-  
+
   // n64Ang is quarter-phase range [0 .. 90*64]
   // suitable for lookup table indexing
   uint16_t  nLutInd = (n64Ang * 256)/(90*64);
   uint16_t  nLutVal = m_nLUTSinF0X16[nLutInd];
-  
+
   // Leave MSB for the signed bit
   nLutVal /= 2;
   if (bNegate) {
@@ -703,41 +703,41 @@ int16_t gslc_sinFX(int16_t n64Ang)
     nRetValS = nLutVal;
   }
   return nRetValS;
-  
-#endif  
-  
+
+#endif
+
 }
 
 // Cosine function with optional lookup table
 int16_t gslc_cosFX(int16_t n64Ang)
 {
   int16_t   nRetValS;
-  
+
 #if (GSLC_USE_FLOAT)
   // Use floating-point math library function
-  
+
   // Calculate angle in radians
   float fAngRad = n64Ang*GSLC_2PI/(360.0*64.0);
   // Perform floating point calc
   float fCos = cos(fAngRad);
   // Return as fixed point result
   nRetValS = fCos * 32767.0;
-  return nRetValS;  
-  
+  return nRetValS;
+
 #else
   // Use lookup tables
   // Cosine function is equivalent to Sine shifted by 90 degrees
   return gslc_sinFX(n64Ang+90*64);
 
 #endif
-  
+
 }
 
 // Convert from polar to cartesian
 void gslc_PolarToXY(uint16_t nRad,int16_t n64Ang,int16_t* nDX,int16_t* nDY)
 {
   *nDX = (int16_t)nRad *  gslc_sinFX(n64Ang)/(int16_t)32767;
-  *nDY = (int16_t)nRad * -gslc_cosFX(n64Ang)/(int16_t)32767; 
+  *nDY = (int16_t)nRad * -gslc_cosFX(n64Ang)/(int16_t)32767;
 }
 
 // Call with nMidAmt=500 to create simple linear blend between two colors
@@ -755,7 +755,7 @@ gslc_tsColor gslc_ColorBlend3(gslc_tsColor colStart,gslc_tsColor colMid,gslc_tsC
   gslc_tsColor  colNew;
   nMidAmt   = (nMidAmt  >1000)?1000:nMidAmt;
   nBlendAmt = (nBlendAmt>1000)?1000:nBlendAmt;
-  
+
   uint16_t  nRngLow   = nMidAmt;
   uint16_t  nRngHigh  = 1000-nMidAmt;
   uint16_t  nSubBlendAmt;
@@ -784,14 +784,14 @@ bool gslc_ColorEqual(gslc_tsColor a,gslc_tsColor b)
 
 void gslc_DrawSetPixel(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol)
 {
-   
-#if (DRV_HAS_DRAW_POINT) 
+
+#if (DRV_HAS_DRAW_POINT)
   // Call optimized driver point drawing
   gslc_DrvDrawPoint(pGui,nX,nY,nCol);
-#else  
+#else
   GSLC_DEBUG_PRINT("ERROR: Mandatory DrvDrawPoint() is not defined in driver\n");
 #endif
-  
+
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -799,11 +799,11 @@ void gslc_DrawSetPixel(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol)
 // - Algorithm reference: https://rosettacode.org/wiki/Bitmap/Bresenham's_line_algorithm#C
 void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)
 {
-  
-#if (DRV_HAS_DRAW_LINE) 
+
+#if (DRV_HAS_DRAW_LINE)
   // Call optimized driver line drawing
   gslc_DrvDrawLine(pGui,nX0,nY0,nX1,nY1,nCol);
-  
+
 #else
   // Perform Bresenham's line algorithm
   int16_t nDX = abs(nX1-nX0);
@@ -813,7 +813,7 @@ void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t 
   int16_t nSY = (nY0 < nY1)? 1 : -1;
   int16_t nErr = ( (nDX>nDY)? nDX : -nDY )/2;
   int16_t nE2;
-  
+
   // Check for degenerate cases
   // TODO: Need to test these optimizations
   bool bDone = false;
@@ -830,10 +830,10 @@ void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t 
   } else if (nDY == 0) {
     if (nX1-nX0 >= 0) {
       gslc_DrawLineH(pGui,nX0,nY0,nDX+1,nCol);
-      bDone = true;      
+      bDone = true;
     } else {
       gslc_DrawLineH(pGui,nX1,nY1,nDX+1,nCol);
-      bDone = true;      
+      bDone = true;
     }
   }
 
@@ -849,9 +849,9 @@ void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t 
       if (nE2 <  nDY) { nErr += nDX; nY0 += nSY; }
     }
   }
-  gslc_PageFlipSet(pGui,true);   
+  gslc_PageFlipSet(pGui,true);
 #endif
-  
+
 }
 
 
@@ -859,19 +859,19 @@ void gslc_DrawLineH(gslc_tsGui* pGui,int16_t nX, int16_t nY, uint16_t nW,gslc_ts
 {
   uint16_t nOffset;
   for (nOffset=0;nOffset<nW;nOffset++) {
-    gslc_DrvDrawPoint(pGui,nX+nOffset,nY,nCol);    
-  }  
-  
-  gslc_PageFlipSet(pGui,true);  
+    gslc_DrvDrawPoint(pGui,nX+nOffset,nY,nCol);
+  }
+
+  gslc_PageFlipSet(pGui,true);
 }
 
 void gslc_DrawLineV(gslc_tsGui* pGui,int16_t nX, int16_t nY, uint16_t nH,gslc_tsColor nCol)
 {
   uint16_t nOffset;
   for (nOffset=0;nOffset<nH;nOffset++) {
-    gslc_DrvDrawPoint(pGui,nX,nY+nOffset,nCol);    
+    gslc_DrvDrawPoint(pGui,nX,nY+nOffset,nCol);
   }
-  
+
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -884,7 +884,7 @@ void gslc_DrawLinePolar(gslc_tsGui* pGui,int16_t nX,int16_t nY,uint16_t nRadStar
   int16_t nDyS = nRadStart * gslc_cosFX(n64Ang)/32768;
   int16_t nDxE = nRadEnd   * gslc_sinFX(n64Ang)/32768;
   int16_t nDyE = nRadEnd   * gslc_cosFX(n64Ang)/32768;
-  gslc_DrawLine(pGui,nX+nDxS,nY-nDyS,nX+nDxE,nY-nDyE,nCol);  
+  gslc_DrawLine(pGui,nX+nDxS,nY-nDyS,nX+nDxE,nY-nDyE,nCol);
 }
 
 
@@ -911,8 +911,8 @@ void gslc_DrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   gslc_DrawLineV(pGui,nX,nY,nH-1,nCol);                 // Left
   gslc_DrawLineV(pGui,(int16_t)(nX+nW-1),nY,nH-1,nCol); // Right
 #endif
-  
-  gslc_PageFlipSet(pGui,true);  
+
+  gslc_PageFlipSet(pGui,true);
 }
 
 void gslc_DrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
@@ -921,7 +921,7 @@ void gslc_DrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   if ((rRect.w == 0) || (rRect.h == 0)) {
     return;
   }
-  
+
 #if (DRV_HAS_DRAW_RECT_FILL)
   // Call optimized driver implementation
   gslc_DrvDrawFillRect(pGui,rRect,nCol);
@@ -934,8 +934,8 @@ void gslc_DrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   }
 
 #endif
-  
-  gslc_PageFlipSet(pGui,true);    
+
+  gslc_PageFlipSet(pGui,true);
 }
 
 
@@ -977,13 +977,13 @@ gslc_tsRect gslc_ExpandRect(gslc_tsRect rRect,int16_t nExpandW,int16_t nExpandH)
 void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
   uint16_t nRadius,gslc_tsColor nCol)
 {
-  
+
   #if (DRV_HAS_DRAW_CIRCLE_FRAME)
     // Call optimized driver implementation
-    gslc_DrvDrawFrameCircle(pGui,nMidX,nMidY,nRadius,nCol);    
+    gslc_DrvDrawFrameCircle(pGui,nMidX,nMidY,nRadius,nCol);
   #else
     // Emulate circle with point drawing
-    
+
     int16_t nX    = nRadius;
     int16_t nY    = 0;
     int16_t nErr  = 0;
@@ -1010,7 +1010,7 @@ void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
             nErr += 1 - 2*nX;
         }
       } // while
-    
+
     #elif (DRV_HAS_DRAW_POINT)
       while (nX >= nY)
       {
@@ -1037,7 +1037,7 @@ void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
     #endif
 
   #endif
-  
+
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1048,13 +1048,13 @@ void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
 void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
   uint16_t nRadius,gslc_tsColor nCol)
 {
-  
+
   #if (DRV_HAS_DRAW_CIRCLE_FILL)
     // Call optimized driver implementation
-    gslc_DrvDrawFillCircle(pGui,nMidX,nMidY,nRadius,nCol);    
+    gslc_DrvDrawFillCircle(pGui,nMidX,nMidY,nRadius,nCol);
   #else
     // Emulate circle with line drawing
-    
+
     int16_t nX    = nRadius;  // a
     int16_t nY    = 0;        // b
     int16_t nErr  = 0;
@@ -1063,23 +1063,23 @@ void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
     {
 
       // Connect pairs of the reflected points around the circumference
-     
+
       //gslc_DrvDrawPoint(pGui,nMidX - nY, nMidY + nX,nCol);  // (-b,+a)
       //gslc_DrvDrawPoint(pGui,nMidX + nY, nMidY + nX,nCol);  // (+b,+a)
       gslc_DrawLine(pGui,nMidX-nY,nMidY+nX,nMidX+nY,nMidY+nX,nCol);
-              
-      //gslc_DrvDrawPoint(pGui,nMidX - nX, nMidY + nY,nCol);  // (-a,+b)      
+
+      //gslc_DrvDrawPoint(pGui,nMidX - nX, nMidY + nY,nCol);  // (-a,+b)
       //gslc_DrvDrawPoint(pGui,nMidX + nX, nMidY + nY,nCol);  // (+a,+b)
       gslc_DrawLine(pGui,nMidX-nX,nMidY+nY,nMidX+nX,nMidY+nY,nCol);
-      
+
       //gslc_DrvDrawPoint(pGui,nMidX - nX, nMidY - nY,nCol);  // (-a,-b)
       //gslc_DrvDrawPoint(pGui,nMidX + nX, nMidY - nY,nCol);  // (+a,-b)
       gslc_DrawLine(pGui,nMidX-nX,nMidY-nY,nMidX+nX,nMidY-nY,nCol);
-      
-      //gslc_DrvDrawPoint(pGui,nMidX - nY, nMidY - nX,nCol);  // (-b,-a)      
+
+      //gslc_DrvDrawPoint(pGui,nMidX - nY, nMidY - nX,nCol);  // (-b,-a)
       //gslc_DrvDrawPoint(pGui,nMidX + nY, nMidY - nX,nCol);  // (+b,-a)
       gslc_DrawLine(pGui,nMidX-nY,nMidY-nX,nMidX+nY,nMidY-nX,nCol);
-      
+
 
       nY    += 1;
       nErr  += 1 + 2*nY;
@@ -1092,7 +1092,7 @@ void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
 
 
   #endif
-  
+
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1101,10 +1101,10 @@ void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
 void gslc_DrawFrameTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     int16_t nX1,int16_t nY1,int16_t nX2,int16_t nY2,gslc_tsColor nCol)
 {
-  
+
   #if (DRV_HAS_DRAW_TRI_FRAME)
     // Call optimized driver implementation
-    gslc_DrvDrawFrameTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);    
+    gslc_DrvDrawFrameTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);
   #else
     // Draw triangle with three lines
     gslc_DrawLine(pGui,nX0,nY0,nX1,nY1,nCol);
@@ -1112,7 +1112,7 @@ void gslc_DrawFrameTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     gslc_DrawLine(pGui,nX2,nY2,nX0,nY0,nCol);
 
   #endif
-  
+
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1132,14 +1132,14 @@ void gslc_SwapCoords(int16_t* pnXa,int16_t* pnYa,int16_t* pnXb,int16_t* pnYb)
 void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     int16_t nX1,int16_t nY1,int16_t nX2,int16_t nY2,gslc_tsColor nCol)
 {
-  
+
   #if (DRV_HAS_DRAW_TRI_FILL)
     // Call optimized driver implementation
-    gslc_DrvDrawFillTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);    
-    
+    gslc_DrvDrawFillTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);
+
   #else
     // Emulate triangle fill
-    
+
     // Algorithm:
     // - An arbitrary triangle is cut into two portions:
     //   1) a flat bottom triangle
@@ -1152,7 +1152,7 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     // - Walk each scan line and determine the intersection
     //   between triangle side A & B (flat bottom triangle)
     //   and then C and B (flat top triangle) using line slopes.
-        
+
     // Sort vertices
     // - Want nY0 >= nY1 >= nY2
     if (nY2>nY1) { gslc_SwapCoords(&nX2,&nY2,&nX1,&nY1); }
@@ -1161,13 +1161,13 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
 
     // TODO: It is more efficient to calculate row endpoints
     // using incremental additions instead of multiplies/divides
-    
+
     int16_t nXa,nXb,nXc,nYos;
     int16_t nX01,nX20,nY01,nY20,nX21,nY21;
     nX01 = nX0-nX1; nY01 = nY0-nY1;
     nX20 = nX2-nX0; nY20 = nY2-nY0;
     nX21 = nX2-nX1; nY21 = nY2-nY1;
-    
+
     // Flat bottom scenario
     // NOTE: Due to vertex sorting and loop range, it shouldn't
     // be possible to enter loop when nY0 == nY1 or nY2
@@ -1180,10 +1180,10 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
       nXa  = 2*(nYos)*nX01;
       nXa += (nXa>=0)?abs(nY01):-abs(nY01);
       nXa /= 2*nY01;
-      
+
       nXb = 2*(nYos-nY01)*nX20;
       nXb += (nXb>=0)?abs(nY20):-abs(nY20);
-      nXb /= 2*nY20;      
+      nXb /= 2*nY20;
 
       // Draw horizontal line between endpoints
       gslc_DrawLine(pGui,nX1+nXa,nY1+nYos,nX0+nXb,nY1+nYos,nCol);
@@ -1197,22 +1197,22 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
       // Determine row endpoints (no rounding)
       //nXc = (nYos          )*(nX2-nX1)/(nY2-nY1);
       //nXb = (nYos-(nY0-nY1))*(nX2-nX0)/(nY2-nY0);
-      
+
       // Determine row endpoints (using rounding)
       nXc  = 2*(nYos)*nX21;
       nXc += (nXc>=0)?abs(nY21):-abs(nY21);
       nXc /= 2*nY21;
-      
-      nXb = 2*(nYos-nY01)*nX20;      
+
+      nXb = 2*(nYos-nY01)*nX20;
       nXb += (nXb>=0)?abs(nY20):-abs(nY20);
-      nXb /= 2*nY20;      
+      nXb /= 2*nY20;
 
       // Draw horizontal line between endpoints
       gslc_DrawLine(pGui,nX1+nXc,nY1+nYos,nX0+nXb,nY1+nYos,nCol);
     }
-    
+
   #endif  // DRV_HAS_DRAW_TRI_FILL
-  
+
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1231,7 +1231,7 @@ void gslc_DrawFrameQuad(gslc_tsGui* pGui,gslc_tsPt* psPt,gslc_tsColor nCol)
 
   nX0 = psPt[3].x; nY0 = psPt[3].y; nX1 = psPt[0].x; nY1 = psPt[0].y;
   gslc_DrawLine(pGui,nX0,nY0,nX1,nY1,nCol);
-  
+
 }
 
 // Filling a quadrilateral is done by breaking it down into
@@ -1252,7 +1252,7 @@ void gslc_DrawFillQuad(gslc_tsGui* pGui,gslc_tsPt* psPt,gslc_tsColor nCol)
   nX1 = psPt[0].x; nY1 = psPt[0].y;
   nX2 = psPt[3].x; nY2 = psPt[3].y;
   gslc_DrawFillTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);
-  
+
 }
 
 
@@ -1266,7 +1266,7 @@ bool gslc_FontAdd(gslc_tsGui* pGui,int16_t nFontId,gslc_teFontRefType eFontRefTy
   if (pGui->nFontCnt+1 > (pGui->nFontMax)) {
     GSLC_DEBUG_PRINT("ERROR: FontAdd(%s) added too many fonts\n","");
     return false;
-  } else { 
+  } else {
     // Fetch a font resource from the driver
     const void* pvFont = gslc_DrvFontAdd(eFontRefType,pvFontRef,nFontSz);
 
@@ -1309,17 +1309,17 @@ bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent)
   //void*             pvData      = sEvent.pvData;
   gslc_tsPage*        pPage       = (gslc_tsPage*)(sEvent.pvScope);
   gslc_tsCollect*     pCollect    = NULL;
-    
+
   // Handle any page-level events first
   // ...
-  
+
   // A Page only contains one Element Collection, so propagate
-  
+
   // Handle the event types
   switch(sEvent.eType) {
     case GSLC_EVT_DRAW:
-    case GSLC_EVT_TICK:    
-    case GSLC_EVT_TOUCH:      
+    case GSLC_EVT_TICK:
+    case GSLC_EVT_TOUCH:
       pCollect  = &pPage->sCollect;
       // Update scope reference & propagate
       sEvent.pvScope = (void*)(pCollect);
@@ -1329,7 +1329,7 @@ bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent)
     default:
       break;
   } // sEvent.eType
-  
+
   return true;
 }
 
@@ -1340,29 +1340,29 @@ void gslc_PageAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* psElem,uint16_t 
   if (pGui->nPageCnt+1 > (pGui->nPageMax)) {
     GSLC_DEBUG_PRINT("ERROR: PageAdd(%s) added too many pages\n","");
     return;
-  }  
+  }
 
   gslc_tsPage*  pPage = &pGui->asPage[pGui->nPageCnt];
-  
+
   // TODO: Create proper PageReset()
   pPage->bPageNeedRedraw  = true;
   pPage->bPageNeedFlip    = false;
   pPage->pfuncXEvent      = NULL;
-  
+
   // Initialize pPage->sCollect
   gslc_CollectReset(&pPage->sCollect,psElem,nMaxElem,psElemRef,nMaxElemRef);
-  
+
   // Assign the requested Page ID
   pPage->nPageId = nPageId;
-  
+
   // Increment the page count
   pGui->nPageCnt++;
-  
+
   // Default the page pointer to the first page we create
   if (gslc_GetPageCur(pGui) == GSLC_PAGE_NONE) {
     gslc_SetPageCur(pGui,nPageId);
   }
-  
+
   // Force the page to redraw
   gslc_PageRedrawSet(pGui,true);
 
@@ -1383,20 +1383,20 @@ void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId)
   if (pGui->pCurPage != NULL) {
     nPageSaved = pGui->pCurPage->nPageId;
   }
-  
+
   // Find the page
   gslc_tsPage* pPage = gslc_PageFindById(pGui,nPageId);
   if (pPage == NULL) {
     GSLC_DEBUG_PRINT("ERROR: SetPageCur() can't find page (ID=%d)\n",nPageId);
     return;
   }
-  
+
   // Save a reference to the selected page
   pGui->pCurPage = pPage;
-  
+
   // Save a reference to the selected page's element collection
   pGui->pCurPageCollect = &pPage->sCollect;
-  
+
   // A change of page should always force a future redraw
   if (nPageSaved != nPageId) {
     gslc_PageRedrawSet(pGui,true);
@@ -1430,10 +1430,10 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
   int               nInd;
   gslc_tsElem*      pElem = NULL;
   gslc_tsCollect*   pCollect = NULL;
-  
+
   // Only work on current page
   pCollect = pGui->pCurPageCollect;
-  
+
   for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
     gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
     // Only elements in RAM need to be checked for changes
@@ -1443,10 +1443,10 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
     pElem = pCollect->asElemRef[nInd].pElem;
 
     if (pElem->eRedraw != GSLC_REDRAW_NONE) {
-      
+
       // Determine if entire page requires redraw
       bool  bRedrawFullPage = false;
-      
+
       // If partial redraw is supported, then we
       // look out for transparent elements which may
       // still warrant full page redraw.
@@ -1458,14 +1458,14 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
       } else {
         bRedrawFullPage = true;
       }
-      
+
       if (bRedrawFullPage) {
         // Mark the entire page as requiring redraw
         gslc_PageRedrawSet(pGui,true);
-        // No need to check any more elements 
+        // No need to check any more elements
         break;
       }
-      
+
     }
   }
 }
@@ -1477,7 +1477,7 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
 //   the elements that have been marked as needing redraw
 //   are rendered.
 void gslc_PageRedrawGo(gslc_tsGui* pGui)
-{ 
+{
   // Update any page redraw status that may be required
   // - Note that this routine handles cases where an element
   //   marked as requiring update is semi-transparent which can
@@ -1502,23 +1502,23 @@ void gslc_PageRedrawGo(gslc_tsGui* pGui)
     gslc_DrvDrawBkgnd(pGui);
     gslc_PageFlipSet(pGui,true);
   }
-    
+
   // Draw other elements (as needed, unless forced page redraw)
   // TODO: Handle GSLC_EVTSUB_DRAW_NEEDED
   uint32_t nSubType = (bPageRedraw)?GSLC_EVTSUB_DRAW_FORCE:GSLC_EVTSUB_DRAW_NEEDED;
   void* pvData = (void*)(pGui->pCurPage);
   gslc_tsEvent  sEvent = gslc_EventCreate(GSLC_EVT_DRAW,nSubType,pvData,NULL);
   gslc_PageEvent(pGui,sEvent);
-  
- 
+
+
   // Clear the page redraw flag
   gslc_PageRedrawSet(pGui,false);
-  
+
   // Page flip the entire screen
   // - TODO: We could also call Update instead of Flip as that would
   //         limit the region to refresh.
   gslc_PageFlipGo(pGui);
-  
+
 }
 
 
@@ -1543,7 +1543,7 @@ void gslc_PageFlipGo(gslc_tsGui* pGui)
 {
   if (pGui->pCurPage->bPageNeedFlip) {
     gslc_DrvPageFlipNow(pGui);
-    
+
     // Indicate that page flip is no longer required
     gslc_PageFlipSet(pGui,false);
   }
@@ -1553,7 +1553,7 @@ void gslc_PageFlipGo(gslc_tsGui* pGui)
 gslc_tsPage* gslc_PageFindById(gslc_tsGui* pGui,int16_t nPageId)
 {
   int8_t nInd;
-  
+
   // Loop through list of pages
   // Return pointer to page
   gslc_tsPage*  pFoundPage = NULL;
@@ -1563,7 +1563,7 @@ gslc_tsPage* gslc_PageFindById(gslc_tsGui* pGui,int16_t nPageId)
       break;
     }
   }
-  
+
   // Error handling: if not found, make this a fatal error
   // as it shows a serious config error and continued operation
   // is not viable.
@@ -1571,7 +1571,7 @@ gslc_tsPage* gslc_PageFindById(gslc_tsGui* pGui,int16_t nPageId)
     GSLC_DEBUG_PRINT("ERROR: PageGet() can't find page (ID=%d)\n",nPageId);
     return NULL;
   }
-  
+
   return pFoundPage;
 }
 
@@ -1597,7 +1597,7 @@ void gslc_PageSetEventFunc(gslc_tsPage* pPage,GSLC_CB_EVENT funcCb)
   if ((pPage == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: PageSetEventFunc() called with NULL ptr\n",0);
     return;
-  }    
+  }
   pPage->pfuncXEvent       = funcCb;
 }
 
@@ -1636,7 +1636,7 @@ gslc_tsElem* gslc_ElemCreateTxt(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,g
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);      
+    return &(pGui->sElemTmp);
   }
 }
 
@@ -1645,7 +1645,7 @@ gslc_tsElem* gslc_ElemCreateBtnTxt(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
 {
   gslc_tsElem   sElem;
   gslc_tsElem*  pElem = NULL;
-  
+
   // Ensure the Font has been defined
   if (gslc_FontGet(pGui,nFontId) == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemCreateBtnTxt(ID=%d): Font(ID=%d) not loaded\n",nElemId,nFontId);
@@ -1670,7 +1670,7 @@ gslc_tsElem* gslc_ElemCreateBtnTxt(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);       
+    return &(pGui->sElemTmp);
   }
 }
 
@@ -1688,8 +1688,8 @@ gslc_tsElem* gslc_ElemCreateBtnImg(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
   sElem.bFrameEn          = false;
   sElem.bFillEn           = false;
   sElem.bClickEn          = true;
-  sElem.bGlowEn           = true;  
-  sElem.pfuncXTouch       = cbTouch;  
+  sElem.bGlowEn           = true;
+  sElem.pfuncXTouch       = cbTouch;
   gslc_ElemSetImage(pGui,&sElem,sImgRef,sImgRefSel);
   if (nPage != GSLC_PAGE_NONE) {
     pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);
@@ -1697,7 +1697,7 @@ gslc_tsElem* gslc_ElemCreateBtnImg(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);     
+    return &(pGui->sElemTmp);
   }
 }
 
@@ -1714,12 +1714,12 @@ gslc_tsElem* gslc_ElemCreateBox(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,g
   sElem.bFillEn           = true;
   sElem.bFrameEn          = true;
   if (nPage != GSLC_PAGE_NONE) {
-    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);  
+    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);
     return pElem;
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);     
+    return &(pGui->sElemTmp);
   }
 }
 
@@ -1739,12 +1739,12 @@ gslc_tsElem* gslc_ElemCreateLine(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
   sElem.bFillEn           = false;  // Disable boundary box fill
   sElem.bFrameEn          = false;  // Disable boundary box frame
   if (nPage != GSLC_PAGE_NONE) {
-    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);  
+    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);
     return pElem;
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);     
+    return &(pGui->sElemTmp);
   }
 }
 
@@ -1764,7 +1764,7 @@ gslc_tsElem* gslc_ElemCreateImg(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);     
+    return &(pGui->sElemTmp);
   }
 }
 
@@ -1782,19 +1782,19 @@ bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent)
   }
   gslc_tsGui*         pGui          = (gslc_tsGui*)(pvGui);
   void*               pvData        = sEvent.pvData;
-  void*               pvScope       = sEvent.pvScope;  
+  void*               pvScope       = sEvent.pvScope;
   gslc_tsElem*        pElem         = NULL;
   gslc_tsElem*        pElemTracked  = NULL;
   gslc_tsEventTouch*  pTouchRec     = NULL;
   int                 nRelX,nRelY;
   gslc_teTouch        eTouch;
   GSLC_CB_TOUCH       pfuncXTouch   = NULL;
-  
+
   switch(sEvent.eType) {
     case GSLC_EVT_DRAW:
-      // Fetch the parameters      
+      // Fetch the parameters
       pElem = (gslc_tsElem*)(pvScope);
-      
+
       // If redraw needed, call the function that invokes the callback
       if (sEvent.nSubType == GSLC_EVTSUB_DRAW_FORCE) {
         return gslc_ElemDrawByRef(pGui,pElem,GSLC_REDRAW_FULL);
@@ -1805,7 +1805,7 @@ bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent)
         return true;
       }
       break;
-      
+
     case GSLC_EVT_TOUCH:
       // Fetch the parameters
       pTouchRec = (gslc_tsEventTouch*)(pvData);
@@ -1826,21 +1826,21 @@ bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent)
       else
       {
 }
-   
+
       break;
-      
+
     case GSLC_EVT_TICK:
       // Fetch the parameters
       pElem = (gslc_tsElem*)(pvScope);
-      
-      // Invoke the callback function      
+
+      // Invoke the callback function
       if (pElem->pfuncXTick != NULL) {
         // TODO: Confirm that tick functions want pvScope
         (*pElem->pfuncXTick)(pvGui,(void*)(pElem));
         return true;
       }
       break;
-      
+
     default:
       break;
   }
@@ -1876,17 +1876,17 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
     // No redraw to do
     return true;
   }
-  
+
   if ((pGui == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemDrawByRef(%s) called with NULL ptr\n","");
 
     return false;
-  }    
-  
+  }
+
   // --------------------------------------------------------------------------
   // Custom drawing
   // --------------------------------------------------------------------------
-  
+
   // Handle any extended element types
   // - If the pfuncXDraw callback is defined, then let the callback
   //   function supersede all default handling here
@@ -1895,16 +1895,16 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   if (pElem->pfuncXDraw != NULL) {
     (*pElem->pfuncXDraw)((void*)(pGui),(void*)(pElem),eRedraw);
     return true;
-  }  
-  
+  }
+
   // --------------------------------------------------------------------------
   // Init for default drawing
   // --------------------------------------------------------------------------
-  
+
   bool      bGlowEn,bGlowing,bGlowNow;
   int16_t   nElemX,nElemY;
   uint16_t  nElemW,nElemH;
-  
+
   nElemX    = pElem->rElem.x;
   nElemY    = pElem->rElem.y;
   nElemW    = pElem->rElem.w;
@@ -1912,12 +1912,12 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   bGlowEn   = pElem->bGlowEn;     // Does the element support glow state?
   bGlowing  = pElem->bGlowing;    // Element should be glowing (if enabled)
   bGlowNow  = bGlowEn & bGlowing; // Element is currently glowing
-  
-  
+
+
   // --------------------------------------------------------------------------
   // Background
   // --------------------------------------------------------------------------
-  
+
   // Fill in the background
   gslc_tsRect rElemInner = pElem->rElem;
   // - If both fill and frame are enabled then contract
@@ -1952,22 +1952,22 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   }
   #endif
 
-  
+
   // --------------------------------------------------------------------------
   // Handle special element types
   // --------------------------------------------------------------------------
   if (pElem->nType == GSLC_TYPE_LINE) {
     gslc_DrawLine(pGui,nElemX,nElemY,nElemX+nElemW-1,nElemY+nElemH-1,pElem->colElemFill);
   }
-  
-  
+
+
   // --------------------------------------------------------------------------
   // Image overlays
   // --------------------------------------------------------------------------
-  
-  // Draw any images associated with element  
+
+  // Draw any images associated with element
   if (pElem->sImgRefNorm.eImgFlags != GSLC_IMGREF_NONE) {
-    if ((bGlowEn && bGlowing) && (pElem->sImgRefGlow.eImgFlags != GSLC_IMGREF_NONE)) { 
+    if ((bGlowEn && bGlowing) && (pElem->sImgRefGlow.eImgFlags != GSLC_IMGREF_NONE)) {
       gslc_DrvDrawImage(pGui,nElemX,nElemY,pElem->sImgRefGlow);
     } else {
       gslc_DrvDrawImage(pGui,nElemX,nElemY,pElem->sImgRefNorm);
@@ -1977,17 +1977,17 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   // --------------------------------------------------------------------------
   // Text overlays
   // --------------------------------------------------------------------------
- 
+
   // Overlay the text
   bool bRenderTxt = true;
   // Skip text render if buffer pointer not allocated
   if ((bRenderTxt) && (pElem->pStrBuf == NULL)) { bRenderTxt = false; }
   // Skip text render if string is not set
   if ((bRenderTxt) && ((pElem->eTxtFlags & GSLC_TXT_ALLOC) == GSLC_TXT_ALLOC_NONE)) { bRenderTxt = false; }
-  
+
   // Do we still want to render?
   if (bRenderTxt) {
-#if (DRV_HAS_DRAW_TEXT)    
+#if (DRV_HAS_DRAW_TEXT)
     int16_t       nMargin   = pElem->nTxtMargin;
 
     // Determine the text color
@@ -2029,7 +2029,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
 
     // Calculate the text alignment
     int16_t       nTxtX,nTxtY;
-    
+
     // Check for ALIGNH_LEFT & ALIGNH_RIGHT. Default to ALIGNH_MID
     if      (pElem->eTxtAlign & GSLC_ALIGNH_LEFT)     { nTxtX = nElemX+nMargin; }
     else if (pElem->eTxtAlign & GSLC_ALIGNH_RIGHT)    { nTxtX = nElemX+nElemW-nMargin-nTxtSzW; }
@@ -2058,7 +2058,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
 
   // Mark the element as no longer requiring redraw
   gslc_ElemSetRedraw(pElem,GSLC_REDRAW_NONE);
-  
+
   return true;
 }
 
@@ -2073,8 +2073,8 @@ void gslc_ElemSetFillEn(gslc_tsElem* pElem,bool bFillEn)
     GSLC_DEBUG_PRINT("ERROR: ElemSetFillEn(%s) called with NULL ptr\n","");
     return;
   }
-  pElem->bFillEn          = bFillEn;  
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
+  pElem->bFillEn          = bFillEn;
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 
@@ -2084,8 +2084,8 @@ void gslc_ElemSetFrameEn(gslc_tsElem* pElem,bool bFrameEn)
     GSLC_DEBUG_PRINT("ERROR: ElemSetFrameEn(%s) called with NULL ptr\n","");
     return;
   }
-  pElem->bFrameEn         = bFrameEn;  
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
+  pElem->bFrameEn         = bFrameEn;
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 
@@ -2094,11 +2094,11 @@ void gslc_ElemSetCol(gslc_tsElem* pElem,gslc_tsColor colFrame,gslc_tsColor colFi
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetCol(%s) called with NULL ptr\n","");
     return;
-  }  
+  }
   pElem->colElemFrame     = colFrame;
   pElem->colElemFill      = colFill;
   pElem->colElemFillGlow      = colFillGlow;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetGlowCol(gslc_tsElem* pElem,gslc_tsColor colFrameGlow,gslc_tsColor colFillGlow,gslc_tsColor colTxtGlow)
@@ -2106,11 +2106,11 @@ void gslc_ElemSetGlowCol(gslc_tsElem* pElem,gslc_tsColor colFrameGlow,gslc_tsCol
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetColGlow(%s) called with NULL ptr\n","");
     return;
-  }  
+  }
   pElem->colElemFrameGlow   = colFrameGlow;
   pElem->colElemFillGlow    = colFillGlow;
   pElem->colElemTextGlow    = colTxtGlow;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetGroup(gslc_tsElem* pElem,int nGroupId)
@@ -2118,7 +2118,7 @@ void gslc_ElemSetGroup(gslc_tsElem* pElem,int nGroupId)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetGroup(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pElem->nGroup           = nGroupId;
 }
 
@@ -2127,8 +2127,8 @@ int gslc_ElemGetGroup(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetGroup(%s) called with NULL ptr\n","");
     return GSLC_GROUP_ID_NONE;
-  }    
-  return pElem->nGroup;  
+  }
+  return pElem->nGroup;
 }
 
 
@@ -2137,9 +2137,9 @@ void gslc_ElemSetTxtAlign(gslc_tsElem* pElem,unsigned nAlign)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtAlign(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pElem->eTxtAlign        = nAlign;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);  
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetTxtMargin(gslc_tsElem* pElem,unsigned nMargin)
@@ -2147,9 +2147,9 @@ void gslc_ElemSetTxtMargin(gslc_tsElem* pElem,unsigned nMargin)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtMargin(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pElem->nTxtMargin        = nMargin;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);  
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr)
@@ -2157,15 +2157,15 @@ void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtStr(%s) called with NULL ptr\n","");
     return;
-  }    
-  
+  }
+
   // Check for read-only status (in case the string was
   // defined in Flash/PROGMEM)
   if (pElem->nStrBufMax == 0) {
     // String was read-only, so abort now
     return;
   }
-  
+
   // To avoid unnecessary redraw / flicker, only a change in
   // the text content will drive a redraw
 
@@ -2231,12 +2231,12 @@ void gslc_ElemSetTxtMem(gslc_tsElem* pElem,gslc_teTxtFlags eFlags)
       // ERROR: Unsupported mode
       // - We don't support internal buffer mode with initialization
       //   from flash (PROGMEM)
-      GSLC_DEBUG_PRINT("ERROR: ElemSetTxtMem(%s) GSLC_LOCAL_STR can't be used with GSLC_TXT_MEM_PROG\n","");      
+      GSLC_DEBUG_PRINT("ERROR: ElemSetTxtMem(%s) GSLC_LOCAL_STR can't be used with GSLC_TXT_MEM_PROG\n","");
       return;
     }
   }
-  gslc_teTxtFlags eFlagsCur = pElem->eTxtFlags;  
-  pElem->eTxtFlags = (eFlagsCur & ~GSLC_TXT_MEM) | (eFlags & GSLC_TXT_MEM); 
+  gslc_teTxtFlags eFlagsCur = pElem->eTxtFlags;
+  pElem->eTxtFlags = (eFlagsCur & ~GSLC_TXT_MEM) | (eFlags & GSLC_TXT_MEM);
 }
 
 void gslc_ElemUpdateFont(gslc_tsGui* pGui,gslc_tsElem* pElem,int nFontId)
@@ -2254,7 +2254,7 @@ void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetRedraw(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
 
   // Handle request for update of redraw state
   // - We permit the new state to be assigned except in the
@@ -2267,10 +2267,10 @@ void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw)
     pElem->eRedraw = eRedraw;
   }
 
-  
+
   // Now propagate up the element hierarchy
   // (eg. in case of compound elements)
-  
+
   // TODO: Perhaps we need to qualify this with bRedraw=true?
   // - ie. we only want to invalidate the parent element
   //   containers, but we don't want to reset their status
@@ -2284,7 +2284,7 @@ gslc_teRedrawType gslc_ElemGetRedraw(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetRedraw(%s) called with NULL ptr\n","");
     return GSLC_REDRAW_NONE;
-  }    
+  }
   return pElem->eRedraw;
 }
 
@@ -2293,7 +2293,7 @@ void gslc_ElemSetGlow(gslc_tsElem* pElem,bool bGlowing)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetGlow(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   // TODO: Should also check for change in bGlowEn
   bool  bGlowingOld = pElem->bGlowing;
   pElem->bGlowing         = bGlowing;
@@ -2307,7 +2307,7 @@ bool gslc_ElemGetGlow(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetGlow(%s) called with NULL ptr\n","");
     return false;
-  }    
+  }
   return pElem->bGlowing;
 }
 
@@ -2316,7 +2316,7 @@ void gslc_ElemSetGlowEn(gslc_tsElem* pElem,bool bGlowEn)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetGlowEn(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pElem->bGlowEn         = bGlowEn;
   gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
@@ -2326,7 +2326,7 @@ bool gslc_ElemGetGlowEn(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetGlowEn(%s) called with NULL ptr\n","");
     return false;
-  }    
+  }
   return pElem->bGlowEn;
 }
 
@@ -2346,11 +2346,11 @@ void gslc_ElemSetStyleFrom(gslc_tsElem* pElemSrc,gslc_tsElem* pElemDest)
   pElemDest->bGlowing         = pElemSrc->bGlowing;
   pElemDest->sImgRefNorm      = pElemSrc->sImgRefNorm;
   pElemDest->sImgRefGlow      = pElemSrc->sImgRefGlow;
-  
+
   pElemDest->bClickEn         = pElemSrc->bClickEn;
   pElemDest->bFrameEn         = pElemSrc->bFrameEn;
   pElemDest->bFillEn          = pElemSrc->bFillEn;
-  
+
   pElemDest->colElemFill      = pElemSrc->colElemFill;
   pElemDest->colElemFillGlow  = pElemSrc->colElemFillGlow;
   pElemDest->colElemFrame     = pElemSrc->colElemFrame;
@@ -2365,21 +2365,21 @@ void gslc_ElemSetStyleFrom(gslc_tsElem* pElemSrc,gslc_tsElem* pElemDest)
   //  pStr
   //  nStrMax
   //  eTxtFlags
-  
+
   pElemDest->colElemText      = pElemSrc->colElemText;
-  pElemDest->colElemTextGlow  = pElemSrc->colElemTextGlow; 
+  pElemDest->colElemTextGlow  = pElemSrc->colElemTextGlow;
   pElemDest->eTxtAlign        = pElemSrc->eTxtAlign;
   pElemDest->nTxtMargin       = pElemSrc->nTxtMargin;
   pElemDest->pTxtFont         = pElemSrc->pTxtFont;
 
   // pXData
-  
+
   pElemDest->pfuncXEvent      = pElemSrc->pfuncXEvent;
   pElemDest->pfuncXDraw       = pElemSrc->pfuncXDraw;
   pElemDest->pfuncXTouch      = pElemSrc->pfuncXTouch;
   pElemDest->pfuncXTick       = pElemSrc->pfuncXTick;
-   
-  gslc_ElemSetRedraw(pElemDest,GSLC_REDRAW_FULL); 
+
+  gslc_ElemSetRedraw(pElemDest,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetEventFunc(gslc_tsElem* pElem,GSLC_CB_EVENT funcCb)
@@ -2387,7 +2387,7 @@ void gslc_ElemSetEventFunc(gslc_tsElem* pElem,GSLC_CB_EVENT funcCb)
   if ((pElem == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetEventFunc(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pElem->pfuncXEvent       = funcCb;
 }
 
@@ -2397,9 +2397,9 @@ void gslc_ElemSetDrawFunc(gslc_tsElem* pElem,GSLC_CB_DRAW funcCb)
   if ((pElem == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetDrawFunc(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pElem->pfuncXDraw       = funcCb;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);   
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetTickFunc(gslc_tsElem* pElem,GSLC_CB_TICK funcCb)
@@ -2407,8 +2407,8 @@ void gslc_ElemSetTickFunc(gslc_tsElem* pElem,GSLC_CB_TICK funcCb)
   if ((pElem == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTickFunc(%s) called with NULL ptr\n","");
     return;
-  }    
-  pElem->pfuncXTick       = funcCb; 
+  }
+  pElem->pfuncXTick       = funcCb;
 }
 
 bool gslc_ElemOwnsCoord(gslc_tsElem* pElem,int16_t nX,int16_t nY,bool bOnlyClickEn)
@@ -2435,7 +2435,7 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
   int16_t       nX      = pEventTouch->nX;
   int16_t       nY      = pEventTouch->nY;
   gslc_teTouch  eTouch  = pEventTouch->eTouch;
-  
+
   gslc_tsElem*  pTrackedOld = NULL;
   gslc_tsElem*  pTrackedNew = NULL;
 
@@ -2444,24 +2444,24 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
 
   // Reset the in-tracked flag
   bool  bInTracked = false;
-  
+
   if (eTouch == GSLC_TOUCH_DOWN) {
     // ---------------------------------
     // Touch Down Event
     // ---------------------------------
-    
+
     // End glow on previously tracked element (if any)
     // - We shouldn't really enter a "Touch Down" event
     //   with an element still marked as being tracked
     if (pTrackedOld != NULL) {
       gslc_ElemSetGlow(pTrackedOld,false);
     }
-    
+
     // Determine the new element to start tracking
     pTrackedNew = gslc_CollectFindElemFromCoord(pGui,pCollect,nX,nY);
 
     if (pTrackedNew == NULL) {
-      // Didn't find an element, so clear the tracking reference   
+      // Didn't find an element, so clear the tracking reference
       gslc_CollectSetElemTracked(pCollect,NULL);
 
     } else {
@@ -2472,16 +2472,16 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
 
       // Start glow on new element
       gslc_ElemSetGlow(pTrackedNew,true);
-      
+
       // Notify element for optional custom handling
       // - We do this after we have determined which element should
       //   receive the touch tracking
       eTouch = GSLC_TOUCH_DOWN_IN;
 
       gslc_ElemSendEventTouch(pGui,pTrackedNew,eTouch,nX,nY);
- 
+
     }
-   
+
   } else if (eTouch == GSLC_TOUCH_UP) {
     // ---------------------------------
     // Touch Up Event
@@ -2490,7 +2490,7 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
     if (pTrackedOld != NULL) {
       // Are we still over tracked element?
       bInTracked = gslc_ElemOwnsCoord(pTrackedOld,nX,nY,true);
-  
+
       if (!bInTracked) {
         // Released not over tracked element
         eTouch = GSLC_TOUCH_UP_OUT;
@@ -2502,13 +2502,13 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
       }
 
       // Clear glow state
-      gslc_ElemSetGlow(pTrackedOld,false);      
+      gslc_ElemSetGlow(pTrackedOld,false);
 
     }
 
     // Clear the element tracking state
     gslc_CollectSetElemTracked(pCollect,NULL);
-    
+
   } else if (eTouch == GSLC_TOUCH_MOVE) {
     // ---------------------------------
     // Touch Move Event
@@ -2538,11 +2538,11 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
 
         // Ensure it is glowing
         gslc_ElemSetGlow(pTrackedOld,true);
-      }      
-      
-    }   
+      }
 
-  }  
+    }
+
+  }
 }
 
 
@@ -2553,7 +2553,7 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   if ((pGui == NULL) || (pPage == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: TrackTouch(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
 
   // Determine the transitions in the touch events based
   // on the previous touch pressure state
@@ -2564,25 +2564,25 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   gslc_teTouch  eTouch = GSLC_TOUCH_NONE;
   if ((pGui->nTouchLastPress == 0) && (nPress > 0)) {
     eTouch = GSLC_TOUCH_DOWN;
-    #ifdef DBG_TOUCH    
+    #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchDown\n",nX,nY,nPress);
     #endif
   } else if ((pGui->nTouchLastPress > 0) && (nPress == 0)) {
     eTouch = GSLC_TOUCH_UP;
-    #ifdef DBG_TOUCH    
+    #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchUp\n",nX,nY,nPress);
     #endif
-    
+
   } else if ((pGui->nTouchLastX != nX) || (pGui->nTouchLastY != nY)) {
     // We only track movement if touch is "down"
     if (nPress > 0) {
       eTouch = GSLC_TOUCH_MOVE;
-      #ifdef DBG_TOUCH    
+      #ifdef DBG_TOUCH
       GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchMove\n",nX,nY,nPress);
       #endif
     }
   }
-  
+
   gslc_tsEventTouch sEventTouch;
   sEventTouch.eTouch        = eTouch;
   sEventTouch.nX            = nX;
@@ -2590,7 +2590,7 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   void* pvData = (void*)(&sEventTouch);
   gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_TOUCH,0,(void*)pPage,pvData);
   gslc_PageEvent(pGui,sEvent);
-  
+
 
   // Save raw touch status so that we can detect transitions
   pGui->nTouchLastX      = nX;
@@ -2611,7 +2611,7 @@ bool gslc_InitTouch(gslc_tsGui* pGui,const char* acDev)
     GSLC_DEBUG_PRINT("ERROR: InitTouch(%s) called with NULL ptr\n","");
     return false;
   }
-  
+
   // Call driver-specific touchscreen init
   //
   // Determine if touch events are provided by the display driver
@@ -2619,7 +2619,7 @@ bool gslc_InitTouch(gslc_tsGui* pGui,const char* acDev)
 #if defined(DRV_TOUCH_NONE)
   // Touch handling disabled
   bOk = true;
-#elif defined(DRV_TOUCH_IN_DISP)  
+#elif defined(DRV_TOUCH_IN_DISP)
   // Touch handling by display driver
   bOk = gslc_DrvInitTouch(pGui,acDev);
 #else
@@ -2638,19 +2638,19 @@ bool gslc_GetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress)
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: GetTouch(%s) called with NULL ptr\n","");
     return false;
-  }    
-  
+  }
+
 #if defined(DRV_TOUCH_NONE)
   // Touch handling disabled
   return false;
 #elif defined(DRV_TOUCH_IN_DISP)
   // Use display driver for touch events
-  return gslc_DrvGetTouch(pGui,pnX,pnY,pnPress);  
+  return gslc_DrvGetTouch(pGui,pnX,pnY,pnPress);
 #else
   // Use external touch driver for touch events
   return gslc_TDrvGetTouch(pGui,pnX,pnY,pnPress);
 #endif
-    
+
   return false;
 }
 
@@ -2675,15 +2675,15 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
   gslc_tsElem sElem;
   // Assign defaults to the element record
   gslc_ResetElem(&sElem);
-  
+
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemCreate(%s) called with NULL ptr\n","");
     return sElem;
-  }  
+  }
 
   gslc_tsPage*    pPage = NULL;
   gslc_tsCollect* pCollect = NULL;
-  
+
   // If we are going to be adding the element to a page then we
   // perform some additional checks
   if (nPageId == GSLC_PAGE_NONE) {
@@ -2701,9 +2701,9 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
     if (pPage == NULL) {
       GSLC_DEBUG_PRINT("ERROR: ElemCreate() can't find page (ID=%d)\n",nPageId);
       return sElem;
-    }     
+    }
     pCollect  = &pPage->sCollect;
-  
+
     // Validate the user-supplied ID
     if (nElemId == GSLC_ID_AUTO) {
       // Get next auto-generated ID
@@ -2728,7 +2728,7 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
   sElem.rElem           = rElem;
   sElem.nType           = nType;
   gslc_ElemUpdateFont(pGui,&sElem,nFontId);
- 
+
   // Initialize the local string buffer (if enabled via GSLC_LOCAL_STR)
   // otherwise just save a copy of the external string buffer pointer
   // and maximum buffer length from the parameters.
@@ -2749,7 +2749,7 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
     #if (GSLC_LOCAL_STR)
       // NOTE: Assume the string buffer pointer is located in RAM and not PROGMEM
       strncpy(sElem.pStrBuf,pStrBuf,GSLC_LOCAL_STR_LEN-1);
-      sElem.pStrBuf[GSLC_LOCAL_STR_LEN-1] = '\0';  // Force termination    
+      sElem.pStrBuf[GSLC_LOCAL_STR_LEN-1] = '\0';  // Force termination
       sElem.nStrBufMax = GSLC_LOCAL_STR_LEN;
       sElem.eTxtFlags  = (sElem.eTxtFlags & ~GSLC_TXT_ALLOC) | GSLC_TXT_ALLOC_INT;
     #else
@@ -2759,13 +2759,13 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
       sElem.nStrBufMax = nStrBufMax;
       sElem.eTxtFlags  = (sElem.eTxtFlags & ~GSLC_TXT_ALLOC) | GSLC_TXT_ALLOC_EXT;
     #endif
-  }  
-  
+  }
+
   // TODO:
   // - Save pCollect in element?
   //   - This would facilitate any group operations (eg. checkbox)
   //   - Alternately, include pGui in parameters to gslc_ElemXCheckboxToggleState().
-  
+
   // If the element creation was successful, then set the valid flag
   sElem.bValid          = true;
 
@@ -2791,30 +2791,30 @@ bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent)
 
   unsigned        nInd;
   gslc_tsElem*    pElem = NULL;
-  
+
   // Handle any collection-based events first
   // ...
   if (sEvent.eType == GSLC_EVT_TOUCH) {
     // TOUCH is passed to CollectTouch which determines the element
     // in the collection that should receive the event
     gslc_tsEventTouch* pEventTouch = (gslc_tsEventTouch*)(pvData);
-    gslc_CollectTouch(pGui,pCollect,pEventTouch);    
+    gslc_CollectTouch(pGui,pCollect,pEventTouch);
     return true;
-  
+
   } else if ( (sEvent.eType == GSLC_EVT_DRAW) || (sEvent.eType == GSLC_EVT_TICK) ) {
     // DRAW and TICK are propagated down to all elements in collection
-    
+
     for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
       gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
       // Fetch the element pointer from the reference array
-      pElem = pCollect->asElemRef[nInd].pElem; 
-      
+      pElem = pCollect->asElemRef[nInd].pElem;
+
       // Copy event so we can modify it in the loop
       gslc_tsEvent sEventNew = sEvent;
-      
+
       // If it is an external reference (eg. flash), copy to temp element
       if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_PROG) {
-        #if (GSLC_USE_PROGMEM)        
+        #if (GSLC_USE_PROGMEM)
         // Copy from PROGMEM to RAM
         memcpy_P(&pGui->sElemTmp,pElem,sizeof(gslc_tsElem));
         // Update event data reference
@@ -2822,15 +2822,15 @@ bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent)
         #else
         // Ignore PROGMEM and update as if RAM
         // Update event data reference
-        sEventNew.pvScope = (void*)(pElem);        
+        sEventNew.pvScope = (void*)(pElem);
         #endif
       } else {
         // Update event data reference
-        sEventNew.pvScope = (void*)(pElem);        
+        sEventNew.pvScope = (void*)(pElem);
       }
       // Propagate the event to the element
-      gslc_ElemEvent(pvGui,sEventNew);      
-        
+      gslc_ElemEvent(pvGui,sEventNew);
+
     } // nInd
 
   } // eType
@@ -2851,52 +2851,52 @@ gslc_tsElem* gslc_CollectElemAdd(gslc_tsCollect* pCollect,const gslc_tsElem* pEl
   if ((pCollect == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: CollectElemAdd(%s) called with NULL ptr\n","");
     return NULL;
-  }    
-  
+  }
+
   if (pCollect->nElemRefCnt+1 > (pCollect->nElemRefMax)) {
     GSLC_DEBUG_PRINT("ERROR: CollectElemAdd() too many element references (max=%u)\n",pCollect->nElemRefMax);
     return NULL;
   }
-  
+
   // Is the element an external reference?
   // - If no, add to internal element array (asElem) and add a reference
   // - If yes, add a reference
   uint16_t nElemInd;
-  uint16_t nElemRefInd;  
+  uint16_t nElemRefInd;
   if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_RAM) {
-  
+
     // Ensure we have enough space in internal element array
     if (pCollect->nElemCnt+1 > (pCollect->nElemMax)) {
       GSLC_DEBUG_PRINT("ERROR: CollectElemAddExt() too many RAM elements (max=%u)\n",pCollect->nElemMax);
       return NULL;
     }
-    
+
     // Copy the element to the internal array
     // - This performs a copy so that we can discard the element
     //   pointer after the call is complete
-    nElemInd = pCollect->nElemCnt;  
+    nElemInd = pCollect->nElemCnt;
     pCollect->asElem[nElemInd] = *pElem;
     pCollect->nElemCnt++;
-    
+
     // Add a reference
     // - Pointer (pElem) links to an item of internal element array
     nElemRefInd = pCollect->nElemRefCnt;
     pCollect->asElemRef[nElemRefInd].eElemFlags = eFlags;
     pCollect->asElemRef[nElemRefInd].pElem = &(pCollect->asElem[nElemInd]);
     pCollect->nElemRefCnt++;
-    return pCollect->asElemRef[nElemRefInd].pElem;     
+    return pCollect->asElemRef[nElemRefInd].pElem;
   } else {
     // External reference
     // - Pointer (pElem) links to an external variable (must be declared statically)
     // - Provide option for either RAM or PROGMEM pointer
     // - TODO: Support other flags
-    
+
     // Add a reference
     nElemInd = pCollect->nElemRefCnt;
     pCollect->asElemRef[nElemInd].eElemFlags = eFlags;
     pCollect->asElemRef[nElemInd].pElem = (gslc_tsElem*)pElem;  // Typecast to drop const modifier
     pCollect->nElemRefCnt++;
-    // NULL is returned to ensure that we don't attempt to dereference 
+    // NULL is returned to ensure that we don't attempt to dereference
 
     return NULL;
   }
@@ -2916,13 +2916,13 @@ bool gslc_CollectGetRedraw(gslc_tsCollect* pCollect)
   uint16_t      nInd;
   gslc_tsElem*  pSubElem;
   bool          bCollectRedraw = false;
-  
+
   for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
     gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
     // Only elements in RAM can change, so no need to check others
     if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_RAM) {
       // Fetch the element pointer from the reference array
-      pSubElem = pCollect->asElemRef[nInd].pElem;   
+      pSubElem = pCollect->asElemRef[nInd].pElem;
       if (gslc_ElemGetRedraw(pSubElem) != GSLC_REDRAW_NONE) {
         bCollectRedraw = true;
         break;
@@ -2948,15 +2948,15 @@ gslc_tsElem* gslc_ElemAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* pElem,gs
   if ((pGui == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemAdd(%s) called with NULL ptr\n","");
     return NULL;
-  }    
+  }
 
   // Fetch the page containing the item
   gslc_tsPage* pPage = gslc_PageFindById(pGui,nPageId);
   if (pPage == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemAdd() page (ID=%d) was not found\n",nPageId);
     return NULL;
-  }   
-  
+  }
+
   gslc_tsCollect* pCollect = &pPage->sCollect;
   gslc_tsElem* pElemAdd = gslc_CollectElemAdd(pCollect,pElem,eFlags);
   return pElemAdd;
@@ -2970,7 +2970,7 @@ bool gslc_SetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
     // Set to full size of screen
     return gslc_DrvSetClipRect(pGui,NULL);
   } else {
-    // Set to user-specified region    
+    // Set to user-specified region
     return gslc_DrvSetClipRect(pGui,pRect);
   }
 }
@@ -2982,11 +2982,11 @@ void gslc_ElemSetImage(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef
   if ((pGui == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetImage(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
 
   // Update the normal and glowing images
   gslc_DrvSetElemImageNorm(pGui,pElem,sImgRef);
-  gslc_DrvSetElemImageGlow(pGui,pElem,sImgRefSel);    
+  gslc_DrvSetElemImageGlow(pGui,pElem,sImgRefSel);
 }
 
 bool gslc_SetBkgndImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef)
@@ -3004,7 +3004,7 @@ bool gslc_SetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol)
     return false;
   }
   gslc_PageFlipSet(pGui,true);
-  return true;  
+  return true;
 }
 
 
@@ -3018,7 +3018,7 @@ bool gslc_ElemSendEventTouch(gslc_tsGui* pGui,gslc_tsElem* pElemTracked,
   sEventTouch.nY            = nY;
   gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_TOUCH,0,(void*)pElemTracked,&sEventTouch);
 
-  gslc_ElemEvent((void*)pGui,sEvent);  
+  gslc_ElemEvent((void*)pGui,sEvent);
   return true;
 }
 
@@ -3029,7 +3029,7 @@ void gslc_ResetElem(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ResetElem(%s) called with NULL ptr\n","");
     return;
-  }  
+  }
   pElem->bValid           = false;
   pElem->nId              = GSLC_ID_NONE;
   pElem->nType            = GSLC_TYPE_BOX;
@@ -3045,7 +3045,7 @@ void gslc_ResetElem(gslc_tsElem* pElem)
   pElem->eRedraw          = GSLC_REDRAW_FULL;
   pElem->colElemFrame     = GSLC_COL_WHITE;
   pElem->colElemFill      = GSLC_COL_WHITE;
-  pElem->colElemFrameGlow = GSLC_COL_WHITE;  
+  pElem->colElemFrameGlow = GSLC_COL_WHITE;
   pElem->colElemFillGlow  = GSLC_COL_WHITE;
   pElem->eTxtFlags        = GSLC_TXT_DEFAULT;
   #if (GSLC_LOCAL_STR)
@@ -3053,20 +3053,20 @@ void gslc_ResetElem(gslc_tsElem* pElem)
     pElem->nStrBufMax       = 0;
   #else
     pElem->pStrBuf          = NULL;
-    pElem->nStrBufMax       = 0;  
+    pElem->nStrBufMax       = 0;
   #endif
   pElem->colElemText      = GSLC_COL_WHITE;
-  pElem->colElemTextGlow  = GSLC_COL_WHITE;  
+  pElem->colElemTextGlow  = GSLC_COL_WHITE;
   pElem->eTxtAlign        = GSLC_ALIGN_MID_MID;
   pElem->nTxtMargin       = 0;
   pElem->pTxtFont         = NULL;
-  
+
   pElem->pXData           = NULL;
   pElem->pfuncXEvent      = NULL;
   pElem->pfuncXDraw       = NULL;
   pElem->pfuncXTouch      = NULL;
   pElem->pfuncXTick       = NULL;
-  
+
   pElem->pElemParent      = NULL;
 
 }
@@ -3077,7 +3077,7 @@ void gslc_ResetFont(gslc_tsFont* pFont)
   if (pFont == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ResetFont(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pFont->nId            = GSLC_FONT_NONE;
   pFont->eFontRefType   = GSLC_FONTREF_FNAME;
   pFont->pvFont         = NULL;
@@ -3091,20 +3091,20 @@ void gslc_ElemDestruct(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemDestruct(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   if (pElem->sImgRefNorm.pvImgRaw != NULL) {
     gslc_DrvImageDestruct(pElem->sImgRefNorm.pvImgRaw);
     pElem->sImgRefNorm = gslc_ResetImage();
   }
   if (pElem->sImgRefGlow.pvImgRaw != NULL) {
     gslc_DrvImageDestruct(pElem->sImgRefGlow.pvImgRaw);
-    pElem->sImgRefGlow = gslc_ResetImage();  
+    pElem->sImgRefGlow = gslc_ResetImage();
   }
-  
+
   // TODO: Add callback function so that
   // we can support additional closure actions
   // (eg. closing sub-elements of compound element).
-  
+
 }
 
 
@@ -3125,10 +3125,10 @@ void gslc_CollectDestruct(gslc_tsCollect* pCollect)
       continue;
     }
     // Fetch the element pointer from the reference array
-    pElem = pCollect->asElemRef[nInd].pElem;   
+    pElem = pCollect->asElemRef[nInd].pElem;
     gslc_ElemDestruct(pElem);
-  }  
-    
+  }
+
 }
 
 // Close down all in page
@@ -3137,7 +3137,7 @@ void gslc_PageDestruct(gslc_tsPage* pPage)
   if (pPage == NULL) {
     GSLC_DEBUG_PRINT("ERROR: PageDestruct(%s) called with NULL ptr\n","");
     return;
-  }      
+  }
   gslc_tsCollect* pCollect = &pPage->sCollect;
   gslc_CollectDestruct(pCollect);
 }
@@ -3148,7 +3148,7 @@ void gslc_GuiDestruct(gslc_tsGui* pGui)
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: GuiDestruct(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   // Loop through all pages in GUI
   uint8_t nPageInd;
   gslc_tsPage*  pPage = NULL;
@@ -3156,18 +3156,18 @@ void gslc_GuiDestruct(gslc_tsGui* pGui)
     pPage = &pGui->asPage[nPageInd];
     gslc_PageDestruct(pPage);
   }
-  
+
   // TODO: Consider moving into main element array
   if (pGui->sImgRefBkgnd.eImgFlags != GSLC_IMGREF_NONE) {
     gslc_DrvImageDestruct(pGui->sImgRefBkgnd.pvImgRaw);
     pGui->sImgRefBkgnd = gslc_ResetImage();
   }
-  
+
   // Close all fonts
   gslc_DrvFontsDestruct(pGui);
-  
+
   // Close any driver-specific data
-  gslc_DrvDestruct(pGui);  
+  gslc_DrvDestruct(pGui);
 
 }
 
@@ -3181,24 +3181,24 @@ void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nEl
   if (pCollect == NULL) {
     GSLC_DEBUG_PRINT("ERROR: CollectReset(%s) called with NULL ptr\n","");
     return;
-  }  
-  
+  }
+
   pCollect->nElemMax          = nElemMax;
   pCollect->nElemCnt          = 0;
-  
+
   pCollect->nElemAutoIdNext   = GSLC_ID_AUTO_BASE;
-  
+
   pCollect->pElemTracked      = NULL;
   pCollect->pfuncXEvent       = NULL;
-  
+
   // Save the pointer to the element array
   pCollect->asElem = asElem;
-  
+
   uint16_t nInd;
   for (nInd=0;nInd<nElemMax;nInd++) {
     gslc_ResetElem(&(pCollect->asElem[nInd]));
   }
-  
+
   // Initialize element references
   pCollect->nElemRefMax = nElemRefMax;
   pCollect->nElemRefCnt = 0;
@@ -3216,13 +3216,13 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId)
   if (pCollect == NULL) {
     GSLC_DEBUG_PRINT("ERROR: CollectFindElemById(%s) called with NULL ptr\n","");
     return NULL;
-  }  
+  }
   gslc_tsElem*  pElem = NULL;
   gslc_tsElem*  pFoundElem = NULL;
   uint16_t      nInd;
   if (nElemId == GSLC_ID_TEMP) {
     // ERROR: Don't expect to do this
-    GSLC_DEBUG_PRINT("ERROR: CollectFindElemById(%s) searching for temp ID\n","");    
+    GSLC_DEBUG_PRINT("ERROR: CollectFindElemById(%s) searching for temp ID\n","");
     return NULL;
   }
   gslc_tsElem tempFind;
@@ -3345,7 +3345,7 @@ void gslc_CollectSetEventFunc(gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb)
   if ((pCollect == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: CollectSetEventFunc(%s) called with NULL ptr\n","");
     return;
-  }    
+  }
   pCollect->pfuncXEvent       = funcCb;
 }
 gslc_tsGui                  m_gui;

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -3,12 +3,12 @@
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
 //
-// - Version 0.9.2    (2018/01/01)
+// - Version 0.9.1    (2017/09/01)
 // =======================================================================
 //
 // The MIT License
 //
-// Copyright 2018 Calvin Hass
+// Copyright 2017 Calvin Hass
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@
 #include "GUIslice.h"
 #include "GUIslice_ex.h"
 #include "GUIslice_drv.h"
+
 
 #include <stdio.h>
 
@@ -87,7 +88,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
 {
   unsigned  nInd;
   bool      bOk = true;
-
+  
   // Initialize state
   pGui->nDispW          = 0;
   pGui->nDispH          = 0;
@@ -114,7 +115,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   for (nInd=0;nInd<(pGui->nFontMax);nInd++) {
     gslc_ResetFont(&(pGui->asFont[nInd]));
   }
-
+ 
   // Initialize temporary element
   gslc_ResetElem(&(pGui->sElemTmp));
 
@@ -125,22 +126,22 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   pGui->nTouchLastPress       = 0;
 
   pGui->pfuncXEvent = NULL;
-
+  
   pGui->sImgRefBkgnd = gslc_ResetImage();
-
+    
   // Save a link to the driver
   pGui->pvDriver = pvDriver;
-
+  
   // Default to no support for partial redraw
   // - This may be overridden by the driver-specific init
   pGui->bRedrawPartialEn = false;
-
-
+ 
+  
   #ifdef DBG_FRAME_RATE
   pGui->nFrameRateCnt = 0;
   pGui->nFrameRateStart = time(NULL);
   #endif
-
+  
   // Initialize the display and touch drivers
   if (bOk) { bOk &= gslc_DrvInit(pGui); }
   if (bOk) { bOk &= gslc_InitTouch(pGui,GSLC_DEV_TOUCH); }
@@ -161,7 +162,7 @@ typedef enum {
   GSLC_DEBUG_PRINT_NORM,
   GSLC_DEBUG_PRINT_TOKEN,
   GSLC_DEBUG_PRINT_UINT16,
-  GSLC_DEBUG_PRINT_STR
+  GSLC_DEBUG_PRINT_STR          
 } gslc_teDebugPrintState;
 
 // A lightweight printf() routine that calls user function for
@@ -178,6 +179,7 @@ typedef enum {
 //   the stack, causing the remainder of the va_args() to be offset.
 // PRE:
 // - g_pfDebugOut defined
+
 void gslc_DebugPrintf(const char* pFmt, ...)
 {
   if (g_pfDebugOut) {
@@ -209,7 +211,7 @@ void gslc_DebugPrintf(const char* pFmt, ...)
     #endif
 
     while (cFmt != 0) {
-
+  
       if (nState == GSLC_DEBUG_PRINT_NORM) {
 
         if (cFmt == '%') {
@@ -221,7 +223,7 @@ void gslc_DebugPrintf(const char* pFmt, ...)
         nFmtInd++; // Advance format index
 
       } else if (nState == GSLC_DEBUG_PRINT_TOKEN) {
-
+        
         // Get token
         if (cFmt == 'd') {
           nState = GSLC_DEBUG_PRINT_UINT16;
@@ -238,14 +240,14 @@ void gslc_DebugPrintf(const char* pFmt, ...)
           }
           bNumStart = false;
           nNumDivisor = nMaxDivisor;
-
+          
         } else if (cFmt == 'u') {
           nState = GSLC_DEBUG_PRINT_UINT16;
           nNumRemain = va_arg(vlist,unsigned);
           bNumNeg = false;
-          bNumStart = false;
+          bNumStart = false;        
           nNumDivisor = nMaxDivisor;
-
+          
         } else if (cFmt == 's') {
           nState = GSLC_DEBUG_PRINT_STR;
           pStr = va_arg(vlist,char*);
@@ -262,7 +264,7 @@ void gslc_DebugPrintf(const char* pFmt, ...)
         }
         nState = GSLC_DEBUG_PRINT_NORM;
         // Don't advance format string index
-
+        
       } else if (nState == GSLC_DEBUG_PRINT_UINT16) {
 
         // Handle the negation flag if required
@@ -337,7 +339,7 @@ void gslc_Update(gslc_tsGui* pGui)
   int16_t   nTouchY = 0;
   uint16_t  nTouchPress = 0;
   bool      bTouchEvent = true;
-
+  
   // Handle touchscreen presses
   // - We clear the event queue here so that we don't fall behind
   // - In the time it takes to update the display, several mouse /
@@ -346,19 +348,17 @@ void gslc_Update(gslc_tsGui* pGui)
   //   lagging responsiveness from the controls.
   // - Instead, we drain the even queue before proceeding on to the
   //   display update, giving rise to a much more responsive GUI.
-  //   The maximum number of touch events that can be handled per
-  //   main loop is defined by the GSLC_TOUCH_MAX_EVT config param.
   // - Note that SDL2 may synchronize the RenderPresent call to
   //   the VSYNC, which will effectively insert a delay into the
   //   gslc_PageRedrawGo() call below. It might be possible to
   //   adjust this blocking behavior via SDL_RENDERER_PRESENTVSYNC.
-
+  
   // In case we are flooded with events, limit the maximum number
   // that we handle in one gslc_Update() call.
   bool      bDoneEvts = false;
   uint16_t  nNumEvts  = 0;
   do {
-    bTouchEvent = gslc_GetTouch(pGui,&nTouchX,&nTouchY,&nTouchPress);
+    bTouchEvent = gslc_GetTouch(pGui,&nTouchX,&nTouchY,&nTouchPress);   
     if (bTouchEvent) {
       // Track and handle the touch events
       // - Handle the events on the current page
@@ -368,29 +368,29 @@ void gslc_Update(gslc_tsGui* pGui)
       // Highlight current touch for coordinate debug
       gslc_tsRect rMark = gslc_ExpandRect((gslc_tsRect){(int16_t)nTouchX,(int16_t)nTouchY,1,1},1,1);
       gslc_DrawFrameRect(pGui,rMark,GSLC_COL_YELLOW);
-      #endif
+      #endif    
 
       nNumEvts++;
     }
-
+    
     // Should we stop handling events?
     if ((!bTouchEvent) || (nNumEvts >= GSLC_TOUCH_MAX_EVT)) {
       bDoneEvts = true;
     }
   } while (!bDoneEvts);
-
+  
   // Issue a timer tick to all pages
   uint8_t nPageInd;
   gslc_tsPage* pPage = NULL;
   for (nPageInd=0;nPageInd<pGui->nPageCnt;nPageInd++) {
-    pPage = &pGui->asPage[nPageInd];
+    pPage = &pGui->asPage[nPageInd];    
     gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_TICK,0,(void*)pPage,NULL);
     gslc_PageEvent(pGui,sEvent);
   }
-
+  
   // Perform any redraw required for current page
   gslc_PageRedrawGo(pGui);
-
+  
   // Simple "frame" rate reporting
   // - Note that the rate is based on the number of calls to gslc_Update()
   //   per second, which may or may not redraw the frame
@@ -425,7 +425,7 @@ gslc_tsEvent  gslc_EventCreate(gslc_teEventType eType,uint8_t nSubType,void* pvS
 
 bool gslc_IsInRect(int16_t nSelX,int16_t nSelY,gslc_tsRect rRect)
 {
-  if ( (nSelX >= rRect.x) && (nSelX <= rRect.x+rRect.w) &&
+  if ( (nSelX >= rRect.x) && (nSelX <= rRect.x+rRect.w) && 
      (nSelY >= rRect.y) && (nSelY <= rRect.y+rRect.h) ) {
     return true;
   } else {
@@ -435,7 +435,7 @@ bool gslc_IsInRect(int16_t nSelX,int16_t nSelY,gslc_tsRect rRect)
 
 bool gslc_IsInWH(gslc_tsGui* pGui,int16_t nSelX,int16_t nSelY,uint16_t nWidth,uint16_t nHeight)
 {
-  if ( (nSelX >= 0) && (nSelX <= nWidth-1) &&
+  if ( (nSelX >= 0) && (nSelX <= nWidth-1) && 
      (nSelY >= 0) && (nSelY <= nHeight-1) ) {
     return true;
   } else {
@@ -481,12 +481,12 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
   int16_t nCXMin,nCXMax,nCYMin,nCYMax;
   uint8_t nRegion0,nRegion1,nRegionSel;
   int16_t nLX0,nLY0,nLX1,nLY1;
-
+  
   int16_t nCX0 = pClipRect->x;
   int16_t nCY0 = pClipRect->y;
   int16_t nCX1 = pClipRect->x + pClipRect->w - 1;
   int16_t nCY1 = pClipRect->y + pClipRect->h - 1;
-
+  
   if (nCX0 > nCX1) {
     nCXMin = nCX1;
     nCXMax = nCX0;
@@ -500,11 +500,11 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
   } else {
     nCYMin = nCY0;
     nCYMax = nCY1;
-  }
-
+  }  
+  
   nTmpX = 0;
   nTmpY = 0;
-  while (1) {
+  while (1) {  
     nLX0 = *pnX0;
     nLY0 = *pnY0;
     nLX1 = *pnX1;
@@ -512,7 +512,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
 
     // Step 1: Assign a region code to each endpoint
     nRegion0 = 0;
-    nRegion1 = 0;
+    nRegion1 = 0;  
     if      (nLX0 < nCX0) { nRegion0 |= 1; }
     else if (nLX0 > nCX1) { nRegion0 |= 2; }
     if      (nLY0 < nCY0) { nRegion0 |= 4; }
@@ -531,7 +531,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
     if ((nRegion0 & nRegion1) != 0) {
       return false;
     }
-
+  
     // Step 4: Clipping
     nRegionSel = nRegion0 ? nRegion0 : nRegion1;
     if (nRegionSel & 8) {
@@ -547,7 +547,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
       nTmpY = nLY0 + (nLY1 - nLY0) * (nCXMin - nLX0) / (nLX1 - nLX0);
       nTmpX = nCXMin;
     }
-
+    
     // Update endpoint
     if (nRegionSel == nRegion0) {
       *pnX0 = nTmpX;
@@ -557,7 +557,7 @@ bool gslc_ClipLine(gslc_tsRect* pClipRect,int16_t* pnX0,int16_t* pnY0,int16_t* p
       *pnY1 = nTmpY;
     }
   } // while(1)
-
+  
   return true;
 }
 
@@ -611,7 +611,7 @@ gslc_tsImgRef gslc_GetImageFromFile(const char* pFname,gslc_teImgRefFlags eFmt)
 
 gslc_tsImgRef gslc_GetImageFromSD(const char* pFname,gslc_teImgRefFlags eFmt)
 {
-  gslc_tsImgRef sImgRef;
+  gslc_tsImgRef sImgRef;  
 #if (ADAGFX_SD_EN)
   sImgRef.eImgFlags = GSLC_IMGREF_SRC_SD | (GSLC_IMGREF_FMT & eFmt);
   sImgRef.pFname    = pFname;
@@ -621,8 +621,8 @@ gslc_tsImgRef gslc_GetImageFromSD(const char* pFname,gslc_teImgRefFlags eFmt)
   // TODO: Change message to also handle non-Arduino output
   GSLC_DEBUG_PRINT("ERROR: GetImageFromSD(%s) not supported as Config:ADAGFX_SD_EN=0\n","");
   sImgRef.eImgFlags = GSLC_IMGREF_NONE;
-#endif
-  return sImgRef;
+#endif  
+  return sImgRef;  
 }
 
 gslc_tsImgRef gslc_GetImageFromRam(unsigned char* pImgBuf,gslc_teImgRefFlags eFmt)
@@ -632,7 +632,7 @@ gslc_tsImgRef gslc_GetImageFromRam(unsigned char* pImgBuf,gslc_teImgRefFlags eFm
   sImgRef.pFname    = NULL;
   sImgRef.pImgBuf   = pImgBuf;
   sImgRef.pvImgRaw  = NULL;
-  return sImgRef;
+  return sImgRef;  
 }
 
 
@@ -654,19 +654,19 @@ int16_t gslc_sinFX(int16_t n64Ang)
 
 #if (GSLC_USE_FLOAT)
   // Use floating-point math library function
-
+  
   // Calculate angle in radians
   float fAngRad = n64Ang*GSLC_2PI/(360.0*64.0);
   // Perform floating point calc
   float fSin = sin(fAngRad);
   // Return as fixed point result
   nRetValS = fSin * 32767.0;
-  return nRetValS;
-
+  return nRetValS;  
+  
 #else
   // Use lookup tables
   bool bNegate = false;
-
+  
   // Support multiple waveform periods
   if (n64Ang >= 360*64) {
     // For some reason this modulus is broken!
@@ -689,12 +689,12 @@ int16_t gslc_sinFX(int16_t n64Ang)
   if (n64Ang >= 90*64) {
     n64Ang = 180*64 - n64Ang;
   }
-
+  
   // n64Ang is quarter-phase range [0 .. 90*64]
   // suitable for lookup table indexing
   uint16_t  nLutInd = (n64Ang * 256)/(90*64);
   uint16_t  nLutVal = m_nLUTSinF0X16[nLutInd];
-
+  
   // Leave MSB for the signed bit
   nLutVal /= 2;
   if (bNegate) {
@@ -703,41 +703,41 @@ int16_t gslc_sinFX(int16_t n64Ang)
     nRetValS = nLutVal;
   }
   return nRetValS;
-
-#endif
-
+  
+#endif  
+  
 }
 
 // Cosine function with optional lookup table
 int16_t gslc_cosFX(int16_t n64Ang)
 {
   int16_t   nRetValS;
-
+  
 #if (GSLC_USE_FLOAT)
   // Use floating-point math library function
-
+  
   // Calculate angle in radians
   float fAngRad = n64Ang*GSLC_2PI/(360.0*64.0);
   // Perform floating point calc
   float fCos = cos(fAngRad);
   // Return as fixed point result
   nRetValS = fCos * 32767.0;
-  return nRetValS;
-
+  return nRetValS;  
+  
 #else
   // Use lookup tables
   // Cosine function is equivalent to Sine shifted by 90 degrees
   return gslc_sinFX(n64Ang+90*64);
 
 #endif
-
+  
 }
 
 // Convert from polar to cartesian
 void gslc_PolarToXY(uint16_t nRad,int16_t n64Ang,int16_t* nDX,int16_t* nDY)
 {
   *nDX = (int16_t)nRad *  gslc_sinFX(n64Ang)/(int16_t)32767;
-  *nDY = (int16_t)nRad * -gslc_cosFX(n64Ang)/(int16_t)32767;
+  *nDY = (int16_t)nRad * -gslc_cosFX(n64Ang)/(int16_t)32767; 
 }
 
 // Call with nMidAmt=500 to create simple linear blend between two colors
@@ -755,7 +755,7 @@ gslc_tsColor gslc_ColorBlend3(gslc_tsColor colStart,gslc_tsColor colMid,gslc_tsC
   gslc_tsColor  colNew;
   nMidAmt   = (nMidAmt  >1000)?1000:nMidAmt;
   nBlendAmt = (nBlendAmt>1000)?1000:nBlendAmt;
-
+  
   uint16_t  nRngLow   = nMidAmt;
   uint16_t  nRngHigh  = 1000-nMidAmt;
   uint16_t  nSubBlendAmt;
@@ -784,14 +784,14 @@ bool gslc_ColorEqual(gslc_tsColor a,gslc_tsColor b)
 
 void gslc_DrawSetPixel(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol)
 {
-
-#if (DRV_HAS_DRAW_POINT)
+   
+#if (DRV_HAS_DRAW_POINT) 
   // Call optimized driver point drawing
   gslc_DrvDrawPoint(pGui,nX,nY,nCol);
-#else
+#else  
   GSLC_DEBUG_PRINT("ERROR: Mandatory DrvDrawPoint() is not defined in driver\n");
 #endif
-
+  
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -799,11 +799,11 @@ void gslc_DrawSetPixel(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol)
 // - Algorithm reference: https://rosettacode.org/wiki/Bitmap/Bresenham's_line_algorithm#C
 void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)
 {
-
-#if (DRV_HAS_DRAW_LINE)
+  
+#if (DRV_HAS_DRAW_LINE) 
   // Call optimized driver line drawing
   gslc_DrvDrawLine(pGui,nX0,nY0,nX1,nY1,nCol);
-
+  
 #else
   // Perform Bresenham's line algorithm
   int16_t nDX = abs(nX1-nX0);
@@ -813,7 +813,7 @@ void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t 
   int16_t nSY = (nY0 < nY1)? 1 : -1;
   int16_t nErr = ( (nDX>nDY)? nDX : -nDY )/2;
   int16_t nE2;
-
+  
   // Check for degenerate cases
   // TODO: Need to test these optimizations
   bool bDone = false;
@@ -830,10 +830,10 @@ void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t 
   } else if (nDY == 0) {
     if (nX1-nX0 >= 0) {
       gslc_DrawLineH(pGui,nX0,nY0,nDX+1,nCol);
-      bDone = true;
+      bDone = true;      
     } else {
       gslc_DrawLineH(pGui,nX1,nY1,nDX+1,nCol);
-      bDone = true;
+      bDone = true;      
     }
   }
 
@@ -849,9 +849,9 @@ void gslc_DrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t 
       if (nE2 <  nDY) { nErr += nDX; nY0 += nSY; }
     }
   }
-  gslc_PageFlipSet(pGui,true);
+  gslc_PageFlipSet(pGui,true);   
 #endif
-
+  
 }
 
 
@@ -859,19 +859,19 @@ void gslc_DrawLineH(gslc_tsGui* pGui,int16_t nX, int16_t nY, uint16_t nW,gslc_ts
 {
   uint16_t nOffset;
   for (nOffset=0;nOffset<nW;nOffset++) {
-    gslc_DrvDrawPoint(pGui,nX+nOffset,nY,nCol);
-  }
-
-  gslc_PageFlipSet(pGui,true);
+    gslc_DrvDrawPoint(pGui,nX+nOffset,nY,nCol);    
+  }  
+  
+  gslc_PageFlipSet(pGui,true);  
 }
 
 void gslc_DrawLineV(gslc_tsGui* pGui,int16_t nX, int16_t nY, uint16_t nH,gslc_tsColor nCol)
 {
   uint16_t nOffset;
   for (nOffset=0;nOffset<nH;nOffset++) {
-    gslc_DrvDrawPoint(pGui,nX,nY+nOffset,nCol);
+    gslc_DrvDrawPoint(pGui,nX,nY+nOffset,nCol);    
   }
-
+  
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -884,7 +884,7 @@ void gslc_DrawLinePolar(gslc_tsGui* pGui,int16_t nX,int16_t nY,uint16_t nRadStar
   int16_t nDyS = nRadStart * gslc_cosFX(n64Ang)/32768;
   int16_t nDxE = nRadEnd   * gslc_sinFX(n64Ang)/32768;
   int16_t nDyE = nRadEnd   * gslc_cosFX(n64Ang)/32768;
-  gslc_DrawLine(pGui,nX+nDxS,nY-nDyS,nX+nDxE,nY-nDyE,nCol);
+  gslc_DrawLine(pGui,nX+nDxS,nY-nDyS,nX+nDxE,nY-nDyE,nCol);  
 }
 
 
@@ -911,8 +911,8 @@ void gslc_DrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   gslc_DrawLineV(pGui,nX,nY,nH-1,nCol);                 // Left
   gslc_DrawLineV(pGui,(int16_t)(nX+nW-1),nY,nH-1,nCol); // Right
 #endif
-
-  gslc_PageFlipSet(pGui,true);
+  
+  gslc_PageFlipSet(pGui,true);  
 }
 
 void gslc_DrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
@@ -921,7 +921,7 @@ void gslc_DrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   if ((rRect.w == 0) || (rRect.h == 0)) {
     return;
   }
-
+  
 #if (DRV_HAS_DRAW_RECT_FILL)
   // Call optimized driver implementation
   gslc_DrvDrawFillRect(pGui,rRect,nCol);
@@ -934,8 +934,8 @@ void gslc_DrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   }
 
 #endif
-
-  gslc_PageFlipSet(pGui,true);
+  
+  gslc_PageFlipSet(pGui,true);    
 }
 
 
@@ -977,13 +977,13 @@ gslc_tsRect gslc_ExpandRect(gslc_tsRect rRect,int16_t nExpandW,int16_t nExpandH)
 void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
   uint16_t nRadius,gslc_tsColor nCol)
 {
-
+  
   #if (DRV_HAS_DRAW_CIRCLE_FRAME)
     // Call optimized driver implementation
-    gslc_DrvDrawFrameCircle(pGui,nMidX,nMidY,nRadius,nCol);
+    gslc_DrvDrawFrameCircle(pGui,nMidX,nMidY,nRadius,nCol);    
   #else
     // Emulate circle with point drawing
-
+    
     int16_t nX    = nRadius;
     int16_t nY    = 0;
     int16_t nErr  = 0;
@@ -1010,7 +1010,7 @@ void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
             nErr += 1 - 2*nX;
         }
       } // while
-
+    
     #elif (DRV_HAS_DRAW_POINT)
       while (nX >= nY)
       {
@@ -1037,7 +1037,7 @@ void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
     #endif
 
   #endif
-
+  
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1048,13 +1048,13 @@ void gslc_DrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
 void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
   uint16_t nRadius,gslc_tsColor nCol)
 {
-
+  
   #if (DRV_HAS_DRAW_CIRCLE_FILL)
     // Call optimized driver implementation
-    gslc_DrvDrawFillCircle(pGui,nMidX,nMidY,nRadius,nCol);
+    gslc_DrvDrawFillCircle(pGui,nMidX,nMidY,nRadius,nCol);    
   #else
     // Emulate circle with line drawing
-
+    
     int16_t nX    = nRadius;  // a
     int16_t nY    = 0;        // b
     int16_t nErr  = 0;
@@ -1063,23 +1063,23 @@ void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
     {
 
       // Connect pairs of the reflected points around the circumference
-
+     
       //gslc_DrvDrawPoint(pGui,nMidX - nY, nMidY + nX,nCol);  // (-b,+a)
       //gslc_DrvDrawPoint(pGui,nMidX + nY, nMidY + nX,nCol);  // (+b,+a)
       gslc_DrawLine(pGui,nMidX-nY,nMidY+nX,nMidX+nY,nMidY+nX,nCol);
-
-      //gslc_DrvDrawPoint(pGui,nMidX - nX, nMidY + nY,nCol);  // (-a,+b)
+              
+      //gslc_DrvDrawPoint(pGui,nMidX - nX, nMidY + nY,nCol);  // (-a,+b)      
       //gslc_DrvDrawPoint(pGui,nMidX + nX, nMidY + nY,nCol);  // (+a,+b)
       gslc_DrawLine(pGui,nMidX-nX,nMidY+nY,nMidX+nX,nMidY+nY,nCol);
-
+      
       //gslc_DrvDrawPoint(pGui,nMidX - nX, nMidY - nY,nCol);  // (-a,-b)
       //gslc_DrvDrawPoint(pGui,nMidX + nX, nMidY - nY,nCol);  // (+a,-b)
       gslc_DrawLine(pGui,nMidX-nX,nMidY-nY,nMidX+nX,nMidY-nY,nCol);
-
-      //gslc_DrvDrawPoint(pGui,nMidX - nY, nMidY - nX,nCol);  // (-b,-a)
+      
+      //gslc_DrvDrawPoint(pGui,nMidX - nY, nMidY - nX,nCol);  // (-b,-a)      
       //gslc_DrvDrawPoint(pGui,nMidX + nY, nMidY - nX,nCol);  // (+b,-a)
       gslc_DrawLine(pGui,nMidX-nY,nMidY-nX,nMidX+nY,nMidY-nX,nCol);
-
+      
 
       nY    += 1;
       nErr  += 1 + 2*nY;
@@ -1092,7 +1092,7 @@ void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
 
 
   #endif
-
+  
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1101,10 +1101,10 @@ void gslc_DrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,
 void gslc_DrawFrameTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     int16_t nX1,int16_t nY1,int16_t nX2,int16_t nY2,gslc_tsColor nCol)
 {
-
+  
   #if (DRV_HAS_DRAW_TRI_FRAME)
     // Call optimized driver implementation
-    gslc_DrvDrawFrameTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);
+    gslc_DrvDrawFrameTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);    
   #else
     // Draw triangle with three lines
     gslc_DrawLine(pGui,nX0,nY0,nX1,nY1,nCol);
@@ -1112,7 +1112,7 @@ void gslc_DrawFrameTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     gslc_DrawLine(pGui,nX2,nY2,nX0,nY0,nCol);
 
   #endif
-
+  
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1132,14 +1132,14 @@ void gslc_SwapCoords(int16_t* pnXa,int16_t* pnYa,int16_t* pnXb,int16_t* pnYb)
 void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     int16_t nX1,int16_t nY1,int16_t nX2,int16_t nY2,gslc_tsColor nCol)
 {
-
+  
   #if (DRV_HAS_DRAW_TRI_FILL)
     // Call optimized driver implementation
-    gslc_DrvDrawFillTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);
-
+    gslc_DrvDrawFillTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);    
+    
   #else
     // Emulate triangle fill
-
+    
     // Algorithm:
     // - An arbitrary triangle is cut into two portions:
     //   1) a flat bottom triangle
@@ -1152,7 +1152,7 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
     // - Walk each scan line and determine the intersection
     //   between triangle side A & B (flat bottom triangle)
     //   and then C and B (flat top triangle) using line slopes.
-
+        
     // Sort vertices
     // - Want nY0 >= nY1 >= nY2
     if (nY2>nY1) { gslc_SwapCoords(&nX2,&nY2,&nX1,&nY1); }
@@ -1161,13 +1161,13 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
 
     // TODO: It is more efficient to calculate row endpoints
     // using incremental additions instead of multiplies/divides
-
+    
     int16_t nXa,nXb,nXc,nYos;
     int16_t nX01,nX20,nY01,nY20,nX21,nY21;
     nX01 = nX0-nX1; nY01 = nY0-nY1;
     nX20 = nX2-nX0; nY20 = nY2-nY0;
     nX21 = nX2-nX1; nY21 = nY2-nY1;
-
+    
     // Flat bottom scenario
     // NOTE: Due to vertex sorting and loop range, it shouldn't
     // be possible to enter loop when nY0 == nY1 or nY2
@@ -1180,10 +1180,10 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
       nXa  = 2*(nYos)*nX01;
       nXa += (nXa>=0)?abs(nY01):-abs(nY01);
       nXa /= 2*nY01;
-
+      
       nXb = 2*(nYos-nY01)*nX20;
       nXb += (nXb>=0)?abs(nY20):-abs(nY20);
-      nXb /= 2*nY20;
+      nXb /= 2*nY20;      
 
       // Draw horizontal line between endpoints
       gslc_DrawLine(pGui,nX1+nXa,nY1+nYos,nX0+nXb,nY1+nYos,nCol);
@@ -1197,22 +1197,22 @@ void gslc_DrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
       // Determine row endpoints (no rounding)
       //nXc = (nYos          )*(nX2-nX1)/(nY2-nY1);
       //nXb = (nYos-(nY0-nY1))*(nX2-nX0)/(nY2-nY0);
-
+      
       // Determine row endpoints (using rounding)
       nXc  = 2*(nYos)*nX21;
       nXc += (nXc>=0)?abs(nY21):-abs(nY21);
       nXc /= 2*nY21;
-
-      nXb = 2*(nYos-nY01)*nX20;
+      
+      nXb = 2*(nYos-nY01)*nX20;      
       nXb += (nXb>=0)?abs(nY20):-abs(nY20);
-      nXb /= 2*nY20;
+      nXb /= 2*nY20;      
 
       // Draw horizontal line between endpoints
       gslc_DrawLine(pGui,nX1+nXc,nY1+nYos,nX0+nXb,nY1+nYos,nCol);
     }
-
+    
   #endif  // DRV_HAS_DRAW_TRI_FILL
-
+  
   gslc_PageFlipSet(pGui,true);
 }
 
@@ -1231,7 +1231,7 @@ void gslc_DrawFrameQuad(gslc_tsGui* pGui,gslc_tsPt* psPt,gslc_tsColor nCol)
 
   nX0 = psPt[3].x; nY0 = psPt[3].y; nX1 = psPt[0].x; nY1 = psPt[0].y;
   gslc_DrawLine(pGui,nX0,nY0,nX1,nY1,nCol);
-
+  
 }
 
 // Filling a quadrilateral is done by breaking it down into
@@ -1252,7 +1252,7 @@ void gslc_DrawFillQuad(gslc_tsGui* pGui,gslc_tsPt* psPt,gslc_tsColor nCol)
   nX1 = psPt[0].x; nY1 = psPt[0].y;
   nX2 = psPt[3].x; nY2 = psPt[3].y;
   gslc_DrawFillTriangle(pGui,nX0,nY0,nX1,nY1,nX2,nY2,nCol);
-
+  
 }
 
 
@@ -1266,7 +1266,7 @@ bool gslc_FontAdd(gslc_tsGui* pGui,int16_t nFontId,gslc_teFontRefType eFontRefTy
   if (pGui->nFontCnt+1 > (pGui->nFontMax)) {
     GSLC_DEBUG_PRINT("ERROR: FontAdd(%s) added too many fonts\n","");
     return false;
-  } else {
+  } else { 
     // Fetch a font resource from the driver
     const void* pvFont = gslc_DrvFontAdd(eFontRefType,pvFontRef,nFontSz);
 
@@ -1309,17 +1309,17 @@ bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent)
   //void*             pvData      = sEvent.pvData;
   gslc_tsPage*        pPage       = (gslc_tsPage*)(sEvent.pvScope);
   gslc_tsCollect*     pCollect    = NULL;
-
+    
   // Handle any page-level events first
   // ...
-
+  
   // A Page only contains one Element Collection, so propagate
-
+  
   // Handle the event types
   switch(sEvent.eType) {
     case GSLC_EVT_DRAW:
-    case GSLC_EVT_TICK:
-    case GSLC_EVT_TOUCH:
+    case GSLC_EVT_TICK:    
+    case GSLC_EVT_TOUCH:      
       pCollect  = &pPage->sCollect;
       // Update scope reference & propagate
       sEvent.pvScope = (void*)(pCollect);
@@ -1329,7 +1329,7 @@ bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent)
     default:
       break;
   } // sEvent.eType
-
+  
   return true;
 }
 
@@ -1340,29 +1340,29 @@ void gslc_PageAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* psElem,uint16_t 
   if (pGui->nPageCnt+1 > (pGui->nPageMax)) {
     GSLC_DEBUG_PRINT("ERROR: PageAdd(%s) added too many pages\n","");
     return;
-  }
+  }  
 
   gslc_tsPage*  pPage = &pGui->asPage[pGui->nPageCnt];
-
+  
   // TODO: Create proper PageReset()
   pPage->bPageNeedRedraw  = true;
   pPage->bPageNeedFlip    = false;
   pPage->pfuncXEvent      = NULL;
-
+  
   // Initialize pPage->sCollect
   gslc_CollectReset(&pPage->sCollect,psElem,nMaxElem,psElemRef,nMaxElemRef);
-
+  
   // Assign the requested Page ID
   pPage->nPageId = nPageId;
-
+  
   // Increment the page count
   pGui->nPageCnt++;
-
+  
   // Default the page pointer to the first page we create
   if (gslc_GetPageCur(pGui) == GSLC_PAGE_NONE) {
     gslc_SetPageCur(pGui,nPageId);
   }
-
+  
   // Force the page to redraw
   gslc_PageRedrawSet(pGui,true);
 
@@ -1383,20 +1383,20 @@ void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId)
   if (pGui->pCurPage != NULL) {
     nPageSaved = pGui->pCurPage->nPageId;
   }
-
+  
   // Find the page
   gslc_tsPage* pPage = gslc_PageFindById(pGui,nPageId);
   if (pPage == NULL) {
     GSLC_DEBUG_PRINT("ERROR: SetPageCur() can't find page (ID=%d)\n",nPageId);
     return;
   }
-
+  
   // Save a reference to the selected page
   pGui->pCurPage = pPage;
-
+  
   // Save a reference to the selected page's element collection
   pGui->pCurPageCollect = &pPage->sCollect;
-
+  
   // A change of page should always force a future redraw
   if (nPageSaved != nPageId) {
     gslc_PageRedrawSet(pGui,true);
@@ -1430,10 +1430,10 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
   int               nInd;
   gslc_tsElem*      pElem = NULL;
   gslc_tsCollect*   pCollect = NULL;
-
+  
   // Only work on current page
   pCollect = pGui->pCurPageCollect;
-
+  
   for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
     gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
     // Only elements in RAM need to be checked for changes
@@ -1443,10 +1443,10 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
     pElem = pCollect->asElemRef[nInd].pElem;
 
     if (pElem->eRedraw != GSLC_REDRAW_NONE) {
-
+      
       // Determine if entire page requires redraw
       bool  bRedrawFullPage = false;
-
+      
       // If partial redraw is supported, then we
       // look out for transparent elements which may
       // still warrant full page redraw.
@@ -1458,14 +1458,14 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
       } else {
         bRedrawFullPage = true;
       }
-
+      
       if (bRedrawFullPage) {
         // Mark the entire page as requiring redraw
         gslc_PageRedrawSet(pGui,true);
-        // No need to check any more elements
+        // No need to check any more elements 
         break;
       }
-
+      
     }
   }
 }
@@ -1477,7 +1477,7 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
 //   the elements that have been marked as needing redraw
 //   are rendered.
 void gslc_PageRedrawGo(gslc_tsGui* pGui)
-{
+{ 
   // Update any page redraw status that may be required
   // - Note that this routine handles cases where an element
   //   marked as requiring update is semi-transparent which can
@@ -1502,23 +1502,23 @@ void gslc_PageRedrawGo(gslc_tsGui* pGui)
     gslc_DrvDrawBkgnd(pGui);
     gslc_PageFlipSet(pGui,true);
   }
-
+    
   // Draw other elements (as needed, unless forced page redraw)
   // TODO: Handle GSLC_EVTSUB_DRAW_NEEDED
   uint32_t nSubType = (bPageRedraw)?GSLC_EVTSUB_DRAW_FORCE:GSLC_EVTSUB_DRAW_NEEDED;
   void* pvData = (void*)(pGui->pCurPage);
   gslc_tsEvent  sEvent = gslc_EventCreate(GSLC_EVT_DRAW,nSubType,pvData,NULL);
   gslc_PageEvent(pGui,sEvent);
-
-
+  
+ 
   // Clear the page redraw flag
   gslc_PageRedrawSet(pGui,false);
-
+  
   // Page flip the entire screen
   // - TODO: We could also call Update instead of Flip as that would
   //         limit the region to refresh.
   gslc_PageFlipGo(pGui);
-
+  
 }
 
 
@@ -1543,7 +1543,7 @@ void gslc_PageFlipGo(gslc_tsGui* pGui)
 {
   if (pGui->pCurPage->bPageNeedFlip) {
     gslc_DrvPageFlipNow(pGui);
-
+    
     // Indicate that page flip is no longer required
     gslc_PageFlipSet(pGui,false);
   }
@@ -1553,7 +1553,7 @@ void gslc_PageFlipGo(gslc_tsGui* pGui)
 gslc_tsPage* gslc_PageFindById(gslc_tsGui* pGui,int16_t nPageId)
 {
   int8_t nInd;
-
+  
   // Loop through list of pages
   // Return pointer to page
   gslc_tsPage*  pFoundPage = NULL;
@@ -1563,7 +1563,7 @@ gslc_tsPage* gslc_PageFindById(gslc_tsGui* pGui,int16_t nPageId)
       break;
     }
   }
-
+  
   // Error handling: if not found, make this a fatal error
   // as it shows a serious config error and continued operation
   // is not viable.
@@ -1571,7 +1571,7 @@ gslc_tsPage* gslc_PageFindById(gslc_tsGui* pGui,int16_t nPageId)
     GSLC_DEBUG_PRINT("ERROR: PageGet() can't find page (ID=%d)\n",nPageId);
     return NULL;
   }
-
+  
   return pFoundPage;
 }
 
@@ -1597,7 +1597,7 @@ void gslc_PageSetEventFunc(gslc_tsPage* pPage,GSLC_CB_EVENT funcCb)
   if ((pPage == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: PageSetEventFunc() called with NULL ptr\n",0);
     return;
-  }
+  }    
   pPage->pfuncXEvent       = funcCb;
 }
 
@@ -1636,7 +1636,7 @@ gslc_tsElem* gslc_ElemCreateTxt(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,g
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);
+    return &(pGui->sElemTmp);      
   }
 }
 
@@ -1645,7 +1645,7 @@ gslc_tsElem* gslc_ElemCreateBtnTxt(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
 {
   gslc_tsElem   sElem;
   gslc_tsElem*  pElem = NULL;
-
+  
   // Ensure the Font has been defined
   if (gslc_FontGet(pGui,nFontId) == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemCreateBtnTxt(ID=%d): Font(ID=%d) not loaded\n",nElemId,nFontId);
@@ -1670,7 +1670,7 @@ gslc_tsElem* gslc_ElemCreateBtnTxt(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);
+    return &(pGui->sElemTmp);       
   }
 }
 
@@ -1688,8 +1688,8 @@ gslc_tsElem* gslc_ElemCreateBtnImg(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
   sElem.bFrameEn          = false;
   sElem.bFillEn           = false;
   sElem.bClickEn          = true;
-  sElem.bGlowEn           = true;
-  sElem.pfuncXTouch       = cbTouch;
+  sElem.bGlowEn           = true;  
+  sElem.pfuncXTouch       = cbTouch;  
   gslc_ElemSetImage(pGui,&sElem,sImgRef,sImgRefSel);
   if (nPage != GSLC_PAGE_NONE) {
     pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);
@@ -1697,7 +1697,7 @@ gslc_tsElem* gslc_ElemCreateBtnImg(gslc_tsGui* pGui,int16_t nElemId,int16_t nPag
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);
+    return &(pGui->sElemTmp);     
   }
 }
 
@@ -1714,12 +1714,12 @@ gslc_tsElem* gslc_ElemCreateBox(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,g
   sElem.bFillEn           = true;
   sElem.bFrameEn          = true;
   if (nPage != GSLC_PAGE_NONE) {
-    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);
+    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);  
     return pElem;
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);
+    return &(pGui->sElemTmp);     
   }
 }
 
@@ -1739,12 +1739,12 @@ gslc_tsElem* gslc_ElemCreateLine(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
   sElem.bFillEn           = false;  // Disable boundary box fill
   sElem.bFrameEn          = false;  // Disable boundary box frame
   if (nPage != GSLC_PAGE_NONE) {
-    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);
+    pElem = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_SRC_RAM);  
     return pElem;
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);
+    return &(pGui->sElemTmp);     
   }
 }
 
@@ -1764,7 +1764,7 @@ gslc_tsElem* gslc_ElemCreateImg(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
   } else {
     // Save as temporary element
     pGui->sElemTmp = sElem;
-    return &(pGui->sElemTmp);
+    return &(pGui->sElemTmp);     
   }
 }
 
@@ -1782,19 +1782,19 @@ bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent)
   }
   gslc_tsGui*         pGui          = (gslc_tsGui*)(pvGui);
   void*               pvData        = sEvent.pvData;
-  void*               pvScope       = sEvent.pvScope;
+  void*               pvScope       = sEvent.pvScope;  
   gslc_tsElem*        pElem         = NULL;
   gslc_tsElem*        pElemTracked  = NULL;
   gslc_tsEventTouch*  pTouchRec     = NULL;
   int                 nRelX,nRelY;
   gslc_teTouch        eTouch;
   GSLC_CB_TOUCH       pfuncXTouch   = NULL;
-
+  
   switch(sEvent.eType) {
     case GSLC_EVT_DRAW:
-      // Fetch the parameters
+      // Fetch the parameters      
       pElem = (gslc_tsElem*)(pvScope);
-
+      
       // If redraw needed, call the function that invokes the callback
       if (sEvent.nSubType == GSLC_EVTSUB_DRAW_FORCE) {
         return gslc_ElemDrawByRef(pGui,pElem,GSLC_REDRAW_FULL);
@@ -1805,7 +1805,7 @@ bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent)
         return true;
       }
       break;
-
+      
     case GSLC_EVT_TOUCH:
       // Fetch the parameters
       pTouchRec = (gslc_tsEventTouch*)(pvData);
@@ -1815,26 +1815,32 @@ bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent)
       eTouch = pTouchRec->eTouch;
       pfuncXTouch = pElemTracked->pfuncXTouch;
 
+
       // Invoke the callback function
       if (pfuncXTouch != NULL) {
         // Pass in the relative position from corner of element region
+
         (*pfuncXTouch)(pvGui,(void*)(pElemTracked),eTouch,nRelX,nRelY);
+
       }
-
+      else
+      {
+}
+   
       break;
-
+      
     case GSLC_EVT_TICK:
       // Fetch the parameters
       pElem = (gslc_tsElem*)(pvScope);
-
-      // Invoke the callback function
+      
+      // Invoke the callback function      
       if (pElem->pfuncXTick != NULL) {
         // TODO: Confirm that tick functions want pvScope
         (*pElem->pfuncXTick)(pvGui,(void*)(pElem));
         return true;
       }
       break;
-
+      
     default:
       break;
   }
@@ -1856,7 +1862,11 @@ void gslc_ElemDraw(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId)
   gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_DRAW,GSLC_EVTSUB_DRAW_FORCE,(void*)pElem,NULL);
   gslc_ElemEvent(pGui,sEvent);
 }
-
+bool gslc_ElemForceDrawP(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eRedraw)
+{	gslc_tsElem sElemTmp;
+	(gslc_tsElem*)memcpy_P(&sElemTmp,pElem,sizeof(gslc_tsElem));
+	return gslc_ElemDrawByRef(pGui,&sElemTmp,GSLC_REDRAW_FULL);
+}
 // Draw an element to the active display
 // - Element is referenced by an element pointer
 // - TODO: Handle GSLC_TYPE_BKGND
@@ -1866,16 +1876,17 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
     // No redraw to do
     return true;
   }
-
+  
   if ((pGui == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemDrawByRef(%s) called with NULL ptr\n","");
-    return false;
-  }
 
+    return false;
+  }    
+  
   // --------------------------------------------------------------------------
   // Custom drawing
   // --------------------------------------------------------------------------
-
+  
   // Handle any extended element types
   // - If the pfuncXDraw callback is defined, then let the callback
   //   function supersede all default handling here
@@ -1884,16 +1895,16 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   if (pElem->pfuncXDraw != NULL) {
     (*pElem->pfuncXDraw)((void*)(pGui),(void*)(pElem),eRedraw);
     return true;
-  }
-
+  }  
+  
   // --------------------------------------------------------------------------
   // Init for default drawing
   // --------------------------------------------------------------------------
-
+  
   bool      bGlowEn,bGlowing,bGlowNow;
   int16_t   nElemX,nElemY;
   uint16_t  nElemW,nElemH;
-
+  
   nElemX    = pElem->rElem.x;
   nElemY    = pElem->rElem.y;
   nElemW    = pElem->rElem.w;
@@ -1901,12 +1912,12 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   bGlowEn   = pElem->bGlowEn;     // Does the element support glow state?
   bGlowing  = pElem->bGlowing;    // Element should be glowing (if enabled)
   bGlowNow  = bGlowEn & bGlowing; // Element is currently glowing
-
-
+  
+  
   // --------------------------------------------------------------------------
   // Background
   // --------------------------------------------------------------------------
-
+  
   // Fill in the background
   gslc_tsRect rElemInner = pElem->rElem;
   // - If both fill and frame are enabled then contract
@@ -1934,29 +1945,29 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   // Frame the region
   #ifdef DBG_FRAME
   // For debug purposes, draw a frame around every element
-  gslc_DrawFrameRect(pGui,sElem.rElem,GSLC_COL_GRAY_DK);
+  gslc_DrawFrameRect(pGui,pElem->rElem,GSLC_COL_GRAY_DK1);
   #else
   if (pElem->bFrameEn) {
     gslc_DrawFrameRect(pGui,pElem->rElem,pElem->colElemFrame);
   }
   #endif
 
-
+  
   // --------------------------------------------------------------------------
   // Handle special element types
   // --------------------------------------------------------------------------
   if (pElem->nType == GSLC_TYPE_LINE) {
     gslc_DrawLine(pGui,nElemX,nElemY,nElemX+nElemW-1,nElemY+nElemH-1,pElem->colElemFill);
   }
-
-
+  
+  
   // --------------------------------------------------------------------------
   // Image overlays
   // --------------------------------------------------------------------------
-
-  // Draw any images associated with element
+  
+  // Draw any images associated with element  
   if (pElem->sImgRefNorm.eImgFlags != GSLC_IMGREF_NONE) {
-    if ((bGlowEn && bGlowing) && (pElem->sImgRefGlow.eImgFlags != GSLC_IMGREF_NONE)) {
+    if ((bGlowEn && bGlowing) && (pElem->sImgRefGlow.eImgFlags != GSLC_IMGREF_NONE)) { 
       gslc_DrvDrawImage(pGui,nElemX,nElemY,pElem->sImgRefGlow);
     } else {
       gslc_DrvDrawImage(pGui,nElemX,nElemY,pElem->sImgRefNorm);
@@ -1966,17 +1977,17 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
   // --------------------------------------------------------------------------
   // Text overlays
   // --------------------------------------------------------------------------
-
+ 
   // Overlay the text
   bool bRenderTxt = true;
   // Skip text render if buffer pointer not allocated
   if ((bRenderTxt) && (pElem->pStrBuf == NULL)) { bRenderTxt = false; }
   // Skip text render if string is not set
   if ((bRenderTxt) && ((pElem->eTxtFlags & GSLC_TXT_ALLOC) == GSLC_TXT_ALLOC_NONE)) { bRenderTxt = false; }
-
+  
   // Do we still want to render?
   if (bRenderTxt) {
-#if (DRV_HAS_DRAW_TEXT)
+#if (DRV_HAS_DRAW_TEXT)    
     int16_t       nMargin   = pElem->nTxtMargin;
 
     // Determine the text color
@@ -2018,7 +2029,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
 
     // Calculate the text alignment
     int16_t       nTxtX,nTxtY;
-
+    
     // Check for ALIGNH_LEFT & ALIGNH_RIGHT. Default to ALIGNH_MID
     if      (pElem->eTxtAlign & GSLC_ALIGNH_LEFT)     { nTxtX = nElemX+nMargin; }
     else if (pElem->eTxtAlign & GSLC_ALIGNH_RIGHT)    { nTxtX = nElemX+nElemW-nMargin-nTxtSzW; }
@@ -2047,7 +2058,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
 
   // Mark the element as no longer requiring redraw
   gslc_ElemSetRedraw(pElem,GSLC_REDRAW_NONE);
-
+  
   return true;
 }
 
@@ -2062,8 +2073,8 @@ void gslc_ElemSetFillEn(gslc_tsElem* pElem,bool bFillEn)
     GSLC_DEBUG_PRINT("ERROR: ElemSetFillEn(%s) called with NULL ptr\n","");
     return;
   }
-  pElem->bFillEn          = bFillEn;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  pElem->bFillEn          = bFillEn;  
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
 }
 
 
@@ -2073,8 +2084,8 @@ void gslc_ElemSetFrameEn(gslc_tsElem* pElem,bool bFrameEn)
     GSLC_DEBUG_PRINT("ERROR: ElemSetFrameEn(%s) called with NULL ptr\n","");
     return;
   }
-  pElem->bFrameEn         = bFrameEn;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  pElem->bFrameEn         = bFrameEn;  
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
 }
 
 
@@ -2083,11 +2094,11 @@ void gslc_ElemSetCol(gslc_tsElem* pElem,gslc_tsColor colFrame,gslc_tsColor colFi
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetCol(%s) called with NULL ptr\n","");
     return;
-  }
+  }  
   pElem->colElemFrame     = colFrame;
   pElem->colElemFill      = colFill;
   pElem->colElemFillGlow      = colFillGlow;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
 }
 
 void gslc_ElemSetGlowCol(gslc_tsElem* pElem,gslc_tsColor colFrameGlow,gslc_tsColor colFillGlow,gslc_tsColor colTxtGlow)
@@ -2095,11 +2106,11 @@ void gslc_ElemSetGlowCol(gslc_tsElem* pElem,gslc_tsColor colFrameGlow,gslc_tsCol
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetColGlow(%s) called with NULL ptr\n","");
     return;
-  }
+  }  
   pElem->colElemFrameGlow   = colFrameGlow;
   pElem->colElemFillGlow    = colFillGlow;
   pElem->colElemTextGlow    = colTxtGlow;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL); 
 }
 
 void gslc_ElemSetGroup(gslc_tsElem* pElem,int nGroupId)
@@ -2107,7 +2118,7 @@ void gslc_ElemSetGroup(gslc_tsElem* pElem,int nGroupId)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetGroup(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pElem->nGroup           = nGroupId;
 }
 
@@ -2116,8 +2127,8 @@ int gslc_ElemGetGroup(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetGroup(%s) called with NULL ptr\n","");
     return GSLC_GROUP_ID_NONE;
-  }
-  return pElem->nGroup;
+  }    
+  return pElem->nGroup;  
 }
 
 
@@ -2126,9 +2137,9 @@ void gslc_ElemSetTxtAlign(gslc_tsElem* pElem,unsigned nAlign)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtAlign(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pElem->eTxtAlign        = nAlign;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);  
 }
 
 void gslc_ElemSetTxtMargin(gslc_tsElem* pElem,unsigned nMargin)
@@ -2136,9 +2147,9 @@ void gslc_ElemSetTxtMargin(gslc_tsElem* pElem,unsigned nMargin)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtMargin(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pElem->nTxtMargin        = nMargin;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);  
 }
 
 void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr)
@@ -2146,22 +2157,53 @@ void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTxtStr(%s) called with NULL ptr\n","");
     return;
-  }
-
+  }    
+  
   // Check for read-only status (in case the string was
   // defined in Flash/PROGMEM)
   if (pElem->nStrBufMax == 0) {
     // String was read-only, so abort now
     return;
   }
-
+  
   // To avoid unnecessary redraw / flicker, only a change in
   // the text content will drive a redraw
+
   if (strncmp(pElem->pStrBuf,pStr,pElem->nStrBufMax-1)) {
     strncpy(pElem->pStrBuf,pStr,pElem->nStrBufMax-1);
     pElem->pStrBuf[pElem->nStrBufMax-1] = '\0';  // Force termination
     gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
   }
+}
+void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr)
+{
+  if (pElem == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: ElemSetTxtStrP(%s) called with NULL ptr\n","");
+    return;
+  }
+  gslc_tsElem temp;
+   (gslc_tsElem*)memcpy_P(&temp,pElem,sizeof(gslc_tsElem));
+
+  // Check for read-only status (in case the string was
+  // defined in Flash/PROGMEM)
+  if (temp.nStrBufMax == 0) {
+    // String was read-only, so abort now
+    return;
+  }
+
+  // To avoid unnecessary redraw / flicker, only a change in
+  // the text content will drive a redraw
+
+  if (strncmp(temp.pStrBuf,pStr,temp.nStrBufMax-1)) {
+    strncpy(temp.pStrBuf,pStr,temp.nStrBufMax-1);
+    temp.pStrBuf[temp.nStrBufMax-1] = '\0';  // Force termination
+    //GSLC_DEBUG_PRINT("Update","");
+    gslc_ElemForceDrawP(pGui,pElem,GSLC_REDRAW_FULL);
+
+	// gslc_PageRedrawGo(pGui);
+
+  }
+
 }
 
 void gslc_ElemSetTxtCol(gslc_tsElem* pElem,gslc_tsColor colVal)
@@ -2189,12 +2231,12 @@ void gslc_ElemSetTxtMem(gslc_tsElem* pElem,gslc_teTxtFlags eFlags)
       // ERROR: Unsupported mode
       // - We don't support internal buffer mode with initialization
       //   from flash (PROGMEM)
-      GSLC_DEBUG_PRINT("ERROR: ElemSetTxtMem(%s) GSLC_LOCAL_STR can't be used with GSLC_TXT_MEM_PROG\n","");
+      GSLC_DEBUG_PRINT("ERROR: ElemSetTxtMem(%s) GSLC_LOCAL_STR can't be used with GSLC_TXT_MEM_PROG\n","");      
       return;
     }
   }
-  gslc_teTxtFlags eFlagsCur = pElem->eTxtFlags;
-  pElem->eTxtFlags = (eFlagsCur & ~GSLC_TXT_MEM) | (eFlags & GSLC_TXT_MEM);
+  gslc_teTxtFlags eFlagsCur = pElem->eTxtFlags;  
+  pElem->eTxtFlags = (eFlagsCur & ~GSLC_TXT_MEM) | (eFlags & GSLC_TXT_MEM); 
 }
 
 void gslc_ElemUpdateFont(gslc_tsGui* pGui,gslc_tsElem* pElem,int nFontId)
@@ -2212,7 +2254,7 @@ void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetRedraw(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
 
   // Handle request for update of redraw state
   // - We permit the new state to be assigned except in the
@@ -2225,10 +2267,10 @@ void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw)
     pElem->eRedraw = eRedraw;
   }
 
-
+  
   // Now propagate up the element hierarchy
   // (eg. in case of compound elements)
-
+  
   // TODO: Perhaps we need to qualify this with bRedraw=true?
   // - ie. we only want to invalidate the parent element
   //   containers, but we don't want to reset their status
@@ -2242,7 +2284,7 @@ gslc_teRedrawType gslc_ElemGetRedraw(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetRedraw(%s) called with NULL ptr\n","");
     return GSLC_REDRAW_NONE;
-  }
+  }    
   return pElem->eRedraw;
 }
 
@@ -2251,7 +2293,7 @@ void gslc_ElemSetGlow(gslc_tsElem* pElem,bool bGlowing)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetGlow(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   // TODO: Should also check for change in bGlowEn
   bool  bGlowingOld = pElem->bGlowing;
   pElem->bGlowing         = bGlowing;
@@ -2265,7 +2307,7 @@ bool gslc_ElemGetGlow(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetGlow(%s) called with NULL ptr\n","");
     return false;
-  }
+  }    
   return pElem->bGlowing;
 }
 
@@ -2274,7 +2316,7 @@ void gslc_ElemSetGlowEn(gslc_tsElem* pElem,bool bGlowEn)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetGlowEn(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pElem->bGlowEn         = bGlowEn;
   gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
 }
@@ -2284,7 +2326,7 @@ bool gslc_ElemGetGlowEn(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemGetGlowEn(%s) called with NULL ptr\n","");
     return false;
-  }
+  }    
   return pElem->bGlowEn;
 }
 
@@ -2304,11 +2346,11 @@ void gslc_ElemSetStyleFrom(gslc_tsElem* pElemSrc,gslc_tsElem* pElemDest)
   pElemDest->bGlowing         = pElemSrc->bGlowing;
   pElemDest->sImgRefNorm      = pElemSrc->sImgRefNorm;
   pElemDest->sImgRefGlow      = pElemSrc->sImgRefGlow;
-
+  
   pElemDest->bClickEn         = pElemSrc->bClickEn;
   pElemDest->bFrameEn         = pElemSrc->bFrameEn;
   pElemDest->bFillEn          = pElemSrc->bFillEn;
-
+  
   pElemDest->colElemFill      = pElemSrc->colElemFill;
   pElemDest->colElemFillGlow  = pElemSrc->colElemFillGlow;
   pElemDest->colElemFrame     = pElemSrc->colElemFrame;
@@ -2323,21 +2365,21 @@ void gslc_ElemSetStyleFrom(gslc_tsElem* pElemSrc,gslc_tsElem* pElemDest)
   //  pStr
   //  nStrMax
   //  eTxtFlags
-
+  
   pElemDest->colElemText      = pElemSrc->colElemText;
-  pElemDest->colElemTextGlow  = pElemSrc->colElemTextGlow;
+  pElemDest->colElemTextGlow  = pElemSrc->colElemTextGlow; 
   pElemDest->eTxtAlign        = pElemSrc->eTxtAlign;
   pElemDest->nTxtMargin       = pElemSrc->nTxtMargin;
   pElemDest->pTxtFont         = pElemSrc->pTxtFont;
 
   // pXData
-
+  
   pElemDest->pfuncXEvent      = pElemSrc->pfuncXEvent;
   pElemDest->pfuncXDraw       = pElemSrc->pfuncXDraw;
   pElemDest->pfuncXTouch      = pElemSrc->pfuncXTouch;
   pElemDest->pfuncXTick       = pElemSrc->pfuncXTick;
-
-  gslc_ElemSetRedraw(pElemDest,GSLC_REDRAW_FULL);
+   
+  gslc_ElemSetRedraw(pElemDest,GSLC_REDRAW_FULL); 
 }
 
 void gslc_ElemSetEventFunc(gslc_tsElem* pElem,GSLC_CB_EVENT funcCb)
@@ -2345,7 +2387,7 @@ void gslc_ElemSetEventFunc(gslc_tsElem* pElem,GSLC_CB_EVENT funcCb)
   if ((pElem == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetEventFunc(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pElem->pfuncXEvent       = funcCb;
 }
 
@@ -2355,9 +2397,9 @@ void gslc_ElemSetDrawFunc(gslc_tsElem* pElem,GSLC_CB_DRAW funcCb)
   if ((pElem == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetDrawFunc(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pElem->pfuncXDraw       = funcCb;
-  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);
+  gslc_ElemSetRedraw(pElem,GSLC_REDRAW_FULL);   
 }
 
 void gslc_ElemSetTickFunc(gslc_tsElem* pElem,GSLC_CB_TICK funcCb)
@@ -2365,8 +2407,8 @@ void gslc_ElemSetTickFunc(gslc_tsElem* pElem,GSLC_CB_TICK funcCb)
   if ((pElem == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetTickFunc(%s) called with NULL ptr\n","");
     return;
-  }
-  pElem->pfuncXTick       = funcCb;
+  }    
+  pElem->pfuncXTick       = funcCb; 
 }
 
 bool gslc_ElemOwnsCoord(gslc_tsElem* pElem,int16_t nX,int16_t nY,bool bOnlyClickEn)
@@ -2393,7 +2435,7 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
   int16_t       nX      = pEventTouch->nX;
   int16_t       nY      = pEventTouch->nY;
   gslc_teTouch  eTouch  = pEventTouch->eTouch;
-
+  
   gslc_tsElem*  pTrackedOld = NULL;
   gslc_tsElem*  pTrackedNew = NULL;
 
@@ -2402,25 +2444,26 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
 
   // Reset the in-tracked flag
   bool  bInTracked = false;
-
+  
   if (eTouch == GSLC_TOUCH_DOWN) {
     // ---------------------------------
     // Touch Down Event
     // ---------------------------------
-
+    
     // End glow on previously tracked element (if any)
     // - We shouldn't really enter a "Touch Down" event
     //   with an element still marked as being tracked
     if (pTrackedOld != NULL) {
       gslc_ElemSetGlow(pTrackedOld,false);
     }
-
+    
     // Determine the new element to start tracking
-    pTrackedNew = gslc_CollectFindElemFromCoord(pCollect,nX,nY);
+    pTrackedNew = gslc_CollectFindElemFromCoord(pGui,pCollect,nX,nY);
 
     if (pTrackedNew == NULL) {
-      // Didn't find an element, so clear the tracking reference
+      // Didn't find an element, so clear the tracking reference   
       gslc_CollectSetElemTracked(pCollect,NULL);
+
     } else {
       // Found an element, so mark it as being the tracked element
 
@@ -2429,15 +2472,16 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
 
       // Start glow on new element
       gslc_ElemSetGlow(pTrackedNew,true);
-
+      
       // Notify element for optional custom handling
       // - We do this after we have determined which element should
       //   receive the touch tracking
       eTouch = GSLC_TOUCH_DOWN_IN;
+
       gslc_ElemSendEventTouch(pGui,pTrackedNew,eTouch,nX,nY);
-
+ 
     }
-
+   
   } else if (eTouch == GSLC_TOUCH_UP) {
     // ---------------------------------
     // Touch Up Event
@@ -2446,7 +2490,7 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
     if (pTrackedOld != NULL) {
       // Are we still over tracked element?
       bInTracked = gslc_ElemOwnsCoord(pTrackedOld,nX,nY,true);
-
+  
       if (!bInTracked) {
         // Released not over tracked element
         eTouch = GSLC_TOUCH_UP_OUT;
@@ -2458,13 +2502,13 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
       }
 
       // Clear glow state
-      gslc_ElemSetGlow(pTrackedOld,false);
+      gslc_ElemSetGlow(pTrackedOld,false);      
 
     }
 
     // Clear the element tracking state
     gslc_CollectSetElemTracked(pCollect,NULL);
-
+    
   } else if (eTouch == GSLC_TOUCH_MOVE) {
     // ---------------------------------
     // Touch Move Event
@@ -2489,15 +2533,16 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
         // We are still over tracked element
         // - Notify tracked element
         eTouch = GSLC_TOUCH_MOVE_IN;
+
         gslc_ElemSendEventTouch(pGui,pTrackedOld,eTouch,nX,nY);
 
         // Ensure it is glowing
         gslc_ElemSetGlow(pTrackedOld,true);
-      }
+      }      
+      
+    }   
 
-    }
-
-  }
+  }  
 }
 
 
@@ -2508,7 +2553,7 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   if ((pGui == NULL) || (pPage == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: TrackTouch(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
 
   // Determine the transitions in the touch events based
   // on the previous touch pressure state
@@ -2519,25 +2564,25 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   gslc_teTouch  eTouch = GSLC_TOUCH_NONE;
   if ((pGui->nTouchLastPress == 0) && (nPress > 0)) {
     eTouch = GSLC_TOUCH_DOWN;
-    #ifdef DBG_TOUCH
+    #ifdef DBG_TOUCH    
     GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchDown\n",nX,nY,nPress);
     #endif
   } else if ((pGui->nTouchLastPress > 0) && (nPress == 0)) {
     eTouch = GSLC_TOUCH_UP;
-    #ifdef DBG_TOUCH
+    #ifdef DBG_TOUCH    
     GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchUp\n",nX,nY,nPress);
     #endif
-
+    
   } else if ((pGui->nTouchLastX != nX) || (pGui->nTouchLastY != nY)) {
     // We only track movement if touch is "down"
     if (nPress > 0) {
       eTouch = GSLC_TOUCH_MOVE;
-      #ifdef DBG_TOUCH
+      #ifdef DBG_TOUCH    
       GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchMove\n",nX,nY,nPress);
       #endif
     }
   }
-
+  
   gslc_tsEventTouch sEventTouch;
   sEventTouch.eTouch        = eTouch;
   sEventTouch.nX            = nX;
@@ -2545,7 +2590,7 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   void* pvData = (void*)(&sEventTouch);
   gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_TOUCH,0,(void*)pPage,pvData);
   gslc_PageEvent(pGui,sEvent);
-
+  
 
   // Save raw touch status so that we can detect transitions
   pGui->nTouchLastX      = nX;
@@ -2566,7 +2611,7 @@ bool gslc_InitTouch(gslc_tsGui* pGui,const char* acDev)
     GSLC_DEBUG_PRINT("ERROR: InitTouch(%s) called with NULL ptr\n","");
     return false;
   }
-
+  
   // Call driver-specific touchscreen init
   //
   // Determine if touch events are provided by the display driver
@@ -2574,7 +2619,7 @@ bool gslc_InitTouch(gslc_tsGui* pGui,const char* acDev)
 #if defined(DRV_TOUCH_NONE)
   // Touch handling disabled
   bOk = true;
-#elif defined(DRV_TOUCH_IN_DISP)
+#elif defined(DRV_TOUCH_IN_DISP)  
   // Touch handling by display driver
   bOk = gslc_DrvInitTouch(pGui,acDev);
 #else
@@ -2593,19 +2638,19 @@ bool gslc_GetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress)
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: GetTouch(%s) called with NULL ptr\n","");
     return false;
-  }
-
+  }    
+  
 #if defined(DRV_TOUCH_NONE)
   // Touch handling disabled
   return false;
 #elif defined(DRV_TOUCH_IN_DISP)
   // Use display driver for touch events
-  return gslc_DrvGetTouch(pGui,pnX,pnY,pnPress);
+  return gslc_DrvGetTouch(pGui,pnX,pnY,pnPress);  
 #else
   // Use external touch driver for touch events
   return gslc_TDrvGetTouch(pGui,pnX,pnY,pnPress);
 #endif
-
+    
   return false;
 }
 
@@ -2630,15 +2675,15 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
   gslc_tsElem sElem;
   // Assign defaults to the element record
   gslc_ResetElem(&sElem);
-
+  
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemCreate(%s) called with NULL ptr\n","");
     return sElem;
-  }
+  }  
 
   gslc_tsPage*    pPage = NULL;
   gslc_tsCollect* pCollect = NULL;
-
+  
   // If we are going to be adding the element to a page then we
   // perform some additional checks
   if (nPageId == GSLC_PAGE_NONE) {
@@ -2656,9 +2701,9 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
     if (pPage == NULL) {
       GSLC_DEBUG_PRINT("ERROR: ElemCreate() can't find page (ID=%d)\n",nPageId);
       return sElem;
-    }
+    }     
     pCollect  = &pPage->sCollect;
-
+  
     // Validate the user-supplied ID
     if (nElemId == GSLC_ID_AUTO) {
       // Get next auto-generated ID
@@ -2683,7 +2728,7 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
   sElem.rElem           = rElem;
   sElem.nType           = nType;
   gslc_ElemUpdateFont(pGui,&sElem,nFontId);
-
+ 
   // Initialize the local string buffer (if enabled via GSLC_LOCAL_STR)
   // otherwise just save a copy of the external string buffer pointer
   // and maximum buffer length from the parameters.
@@ -2704,7 +2749,7 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
     #if (GSLC_LOCAL_STR)
       // NOTE: Assume the string buffer pointer is located in RAM and not PROGMEM
       strncpy(sElem.pStrBuf,pStrBuf,GSLC_LOCAL_STR_LEN-1);
-      sElem.pStrBuf[GSLC_LOCAL_STR_LEN-1] = '\0';  // Force termination
+      sElem.pStrBuf[GSLC_LOCAL_STR_LEN-1] = '\0';  // Force termination    
       sElem.nStrBufMax = GSLC_LOCAL_STR_LEN;
       sElem.eTxtFlags  = (sElem.eTxtFlags & ~GSLC_TXT_ALLOC) | GSLC_TXT_ALLOC_INT;
     #else
@@ -2714,13 +2759,13 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,
       sElem.nStrBufMax = nStrBufMax;
       sElem.eTxtFlags  = (sElem.eTxtFlags & ~GSLC_TXT_ALLOC) | GSLC_TXT_ALLOC_EXT;
     #endif
-  }
-
+  }  
+  
   // TODO:
   // - Save pCollect in element?
   //   - This would facilitate any group operations (eg. checkbox)
   //   - Alternately, include pGui in parameters to gslc_ElemXCheckboxToggleState().
-
+  
   // If the element creation was successful, then set the valid flag
   sElem.bValid          = true;
 
@@ -2746,30 +2791,30 @@ bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent)
 
   unsigned        nInd;
   gslc_tsElem*    pElem = NULL;
-
+  
   // Handle any collection-based events first
   // ...
   if (sEvent.eType == GSLC_EVT_TOUCH) {
     // TOUCH is passed to CollectTouch which determines the element
     // in the collection that should receive the event
     gslc_tsEventTouch* pEventTouch = (gslc_tsEventTouch*)(pvData);
-    gslc_CollectTouch(pGui,pCollect,pEventTouch);
+    gslc_CollectTouch(pGui,pCollect,pEventTouch);    
     return true;
-
+  
   } else if ( (sEvent.eType == GSLC_EVT_DRAW) || (sEvent.eType == GSLC_EVT_TICK) ) {
     // DRAW and TICK are propagated down to all elements in collection
-
+    
     for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
       gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
       // Fetch the element pointer from the reference array
-      pElem = pCollect->asElemRef[nInd].pElem;
-
+      pElem = pCollect->asElemRef[nInd].pElem; 
+      
       // Copy event so we can modify it in the loop
       gslc_tsEvent sEventNew = sEvent;
-
+      
       // If it is an external reference (eg. flash), copy to temp element
       if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_PROG) {
-        #if (GSLC_USE_PROGMEM)
+        #if (GSLC_USE_PROGMEM)        
         // Copy from PROGMEM to RAM
         memcpy_P(&pGui->sElemTmp,pElem,sizeof(gslc_tsElem));
         // Update event data reference
@@ -2777,15 +2822,15 @@ bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent)
         #else
         // Ignore PROGMEM and update as if RAM
         // Update event data reference
-        sEventNew.pvScope = (void*)(pElem);
+        sEventNew.pvScope = (void*)(pElem);        
         #endif
       } else {
         // Update event data reference
-        sEventNew.pvScope = (void*)(pElem);
+        sEventNew.pvScope = (void*)(pElem);        
       }
       // Propagate the event to the element
-      gslc_ElemEvent(pvGui,sEventNew);
-
+      gslc_ElemEvent(pvGui,sEventNew);      
+        
     } // nInd
 
   } // eType
@@ -2806,52 +2851,52 @@ gslc_tsElem* gslc_CollectElemAdd(gslc_tsCollect* pCollect,const gslc_tsElem* pEl
   if ((pCollect == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: CollectElemAdd(%s) called with NULL ptr\n","");
     return NULL;
-  }
-
+  }    
+  
   if (pCollect->nElemRefCnt+1 > (pCollect->nElemRefMax)) {
     GSLC_DEBUG_PRINT("ERROR: CollectElemAdd() too many element references (max=%u)\n",pCollect->nElemRefMax);
     return NULL;
   }
-
+  
   // Is the element an external reference?
   // - If no, add to internal element array (asElem) and add a reference
   // - If yes, add a reference
   uint16_t nElemInd;
-  uint16_t nElemRefInd;
+  uint16_t nElemRefInd;  
   if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_RAM) {
-
+  
     // Ensure we have enough space in internal element array
     if (pCollect->nElemCnt+1 > (pCollect->nElemMax)) {
       GSLC_DEBUG_PRINT("ERROR: CollectElemAddExt() too many RAM elements (max=%u)\n",pCollect->nElemMax);
       return NULL;
     }
-
+    
     // Copy the element to the internal array
     // - This performs a copy so that we can discard the element
     //   pointer after the call is complete
-    nElemInd = pCollect->nElemCnt;
+    nElemInd = pCollect->nElemCnt;  
     pCollect->asElem[nElemInd] = *pElem;
     pCollect->nElemCnt++;
-
+    
     // Add a reference
     // - Pointer (pElem) links to an item of internal element array
     nElemRefInd = pCollect->nElemRefCnt;
     pCollect->asElemRef[nElemRefInd].eElemFlags = eFlags;
     pCollect->asElemRef[nElemRefInd].pElem = &(pCollect->asElem[nElemInd]);
     pCollect->nElemRefCnt++;
-    return pCollect->asElemRef[nElemRefInd].pElem;
+    return pCollect->asElemRef[nElemRefInd].pElem;     
   } else {
     // External reference
     // - Pointer (pElem) links to an external variable (must be declared statically)
     // - Provide option for either RAM or PROGMEM pointer
     // - TODO: Support other flags
-
+    
     // Add a reference
     nElemInd = pCollect->nElemRefCnt;
     pCollect->asElemRef[nElemInd].eElemFlags = eFlags;
     pCollect->asElemRef[nElemInd].pElem = (gslc_tsElem*)pElem;  // Typecast to drop const modifier
     pCollect->nElemRefCnt++;
-    // NULL is returned to ensure that we don't attempt to dereference
+    // NULL is returned to ensure that we don't attempt to dereference 
 
     return NULL;
   }
@@ -2871,13 +2916,13 @@ bool gslc_CollectGetRedraw(gslc_tsCollect* pCollect)
   uint16_t      nInd;
   gslc_tsElem*  pSubElem;
   bool          bCollectRedraw = false;
-
+  
   for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
     gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
     // Only elements in RAM can change, so no need to check others
     if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_RAM) {
       // Fetch the element pointer from the reference array
-      pSubElem = pCollect->asElemRef[nInd].pElem;
+      pSubElem = pCollect->asElemRef[nInd].pElem;   
       if (gslc_ElemGetRedraw(pSubElem) != GSLC_REDRAW_NONE) {
         bCollectRedraw = true;
         break;
@@ -2903,15 +2948,15 @@ gslc_tsElem* gslc_ElemAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* pElem,gs
   if ((pGui == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemAdd(%s) called with NULL ptr\n","");
     return NULL;
-  }
+  }    
 
   // Fetch the page containing the item
   gslc_tsPage* pPage = gslc_PageFindById(pGui,nPageId);
   if (pPage == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemAdd() page (ID=%d) was not found\n",nPageId);
     return NULL;
-  }
-
+  }   
+  
   gslc_tsCollect* pCollect = &pPage->sCollect;
   gslc_tsElem* pElemAdd = gslc_CollectElemAdd(pCollect,pElem,eFlags);
   return pElemAdd;
@@ -2925,7 +2970,7 @@ bool gslc_SetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
     // Set to full size of screen
     return gslc_DrvSetClipRect(pGui,NULL);
   } else {
-    // Set to user-specified region
+    // Set to user-specified region    
     return gslc_DrvSetClipRect(pGui,pRect);
   }
 }
@@ -2937,11 +2982,11 @@ void gslc_ElemSetImage(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef
   if ((pGui == NULL) || (pElem == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: ElemSetImage(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
 
   // Update the normal and glowing images
   gslc_DrvSetElemImageNorm(pGui,pElem,sImgRef);
-  gslc_DrvSetElemImageGlow(pGui,pElem,sImgRefSel);
+  gslc_DrvSetElemImageGlow(pGui,pElem,sImgRefSel);    
 }
 
 bool gslc_SetBkgndImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef)
@@ -2959,7 +3004,7 @@ bool gslc_SetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol)
     return false;
   }
   gslc_PageFlipSet(pGui,true);
-  return true;
+  return true;  
 }
 
 
@@ -2972,7 +3017,8 @@ bool gslc_ElemSendEventTouch(gslc_tsGui* pGui,gslc_tsElem* pElemTracked,
   sEventTouch.nX            = nX;
   sEventTouch.nY            = nY;
   gslc_tsEvent sEvent = gslc_EventCreate(GSLC_EVT_TOUCH,0,(void*)pElemTracked,&sEventTouch);
-  gslc_ElemEvent((void*)pGui,sEvent);
+
+  gslc_ElemEvent((void*)pGui,sEvent);  
   return true;
 }
 
@@ -2983,7 +3029,7 @@ void gslc_ResetElem(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ResetElem(%s) called with NULL ptr\n","");
     return;
-  }
+  }  
   pElem->bValid           = false;
   pElem->nId              = GSLC_ID_NONE;
   pElem->nType            = GSLC_TYPE_BOX;
@@ -2999,7 +3045,7 @@ void gslc_ResetElem(gslc_tsElem* pElem)
   pElem->eRedraw          = GSLC_REDRAW_FULL;
   pElem->colElemFrame     = GSLC_COL_WHITE;
   pElem->colElemFill      = GSLC_COL_WHITE;
-  pElem->colElemFrameGlow = GSLC_COL_WHITE;
+  pElem->colElemFrameGlow = GSLC_COL_WHITE;  
   pElem->colElemFillGlow  = GSLC_COL_WHITE;
   pElem->eTxtFlags        = GSLC_TXT_DEFAULT;
   #if (GSLC_LOCAL_STR)
@@ -3007,20 +3053,20 @@ void gslc_ResetElem(gslc_tsElem* pElem)
     pElem->nStrBufMax       = 0;
   #else
     pElem->pStrBuf          = NULL;
-    pElem->nStrBufMax       = 0;
+    pElem->nStrBufMax       = 0;  
   #endif
   pElem->colElemText      = GSLC_COL_WHITE;
-  pElem->colElemTextGlow  = GSLC_COL_WHITE;
+  pElem->colElemTextGlow  = GSLC_COL_WHITE;  
   pElem->eTxtAlign        = GSLC_ALIGN_MID_MID;
   pElem->nTxtMargin       = 0;
   pElem->pTxtFont         = NULL;
-
+  
   pElem->pXData           = NULL;
   pElem->pfuncXEvent      = NULL;
   pElem->pfuncXDraw       = NULL;
   pElem->pfuncXTouch      = NULL;
   pElem->pfuncXTick       = NULL;
-
+  
   pElem->pElemParent      = NULL;
 
 }
@@ -3031,7 +3077,7 @@ void gslc_ResetFont(gslc_tsFont* pFont)
   if (pFont == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ResetFont(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pFont->nId            = GSLC_FONT_NONE;
   pFont->eFontRefType   = GSLC_FONTREF_FNAME;
   pFont->pvFont         = NULL;
@@ -3045,20 +3091,20 @@ void gslc_ElemDestruct(gslc_tsElem* pElem)
   if (pElem == NULL) {
     GSLC_DEBUG_PRINT("ERROR: ElemDestruct(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   if (pElem->sImgRefNorm.pvImgRaw != NULL) {
     gslc_DrvImageDestruct(pElem->sImgRefNorm.pvImgRaw);
     pElem->sImgRefNorm = gslc_ResetImage();
   }
   if (pElem->sImgRefGlow.pvImgRaw != NULL) {
     gslc_DrvImageDestruct(pElem->sImgRefGlow.pvImgRaw);
-    pElem->sImgRefGlow = gslc_ResetImage();
+    pElem->sImgRefGlow = gslc_ResetImage();  
   }
-
+  
   // TODO: Add callback function so that
   // we can support additional closure actions
   // (eg. closing sub-elements of compound element).
-
+  
 }
 
 
@@ -3079,10 +3125,10 @@ void gslc_CollectDestruct(gslc_tsCollect* pCollect)
       continue;
     }
     // Fetch the element pointer from the reference array
-    pElem = pCollect->asElemRef[nInd].pElem;
+    pElem = pCollect->asElemRef[nInd].pElem;   
     gslc_ElemDestruct(pElem);
-  }
-
+  }  
+    
 }
 
 // Close down all in page
@@ -3091,7 +3137,7 @@ void gslc_PageDestruct(gslc_tsPage* pPage)
   if (pPage == NULL) {
     GSLC_DEBUG_PRINT("ERROR: PageDestruct(%s) called with NULL ptr\n","");
     return;
-  }
+  }      
   gslc_tsCollect* pCollect = &pPage->sCollect;
   gslc_CollectDestruct(pCollect);
 }
@@ -3102,7 +3148,7 @@ void gslc_GuiDestruct(gslc_tsGui* pGui)
   if (pGui == NULL) {
     GSLC_DEBUG_PRINT("ERROR: GuiDestruct(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   // Loop through all pages in GUI
   uint8_t nPageInd;
   gslc_tsPage*  pPage = NULL;
@@ -3110,18 +3156,18 @@ void gslc_GuiDestruct(gslc_tsGui* pGui)
     pPage = &pGui->asPage[nPageInd];
     gslc_PageDestruct(pPage);
   }
-
+  
   // TODO: Consider moving into main element array
   if (pGui->sImgRefBkgnd.eImgFlags != GSLC_IMGREF_NONE) {
     gslc_DrvImageDestruct(pGui->sImgRefBkgnd.pvImgRaw);
     pGui->sImgRefBkgnd = gslc_ResetImage();
   }
-
+  
   // Close all fonts
   gslc_DrvFontsDestruct(pGui);
-
+  
   // Close any driver-specific data
-  gslc_DrvDestruct(pGui);
+  gslc_DrvDestruct(pGui);  
 
 }
 
@@ -3135,24 +3181,24 @@ void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nEl
   if (pCollect == NULL) {
     GSLC_DEBUG_PRINT("ERROR: CollectReset(%s) called with NULL ptr\n","");
     return;
-  }
-
+  }  
+  
   pCollect->nElemMax          = nElemMax;
   pCollect->nElemCnt          = 0;
-
+  
   pCollect->nElemAutoIdNext   = GSLC_ID_AUTO_BASE;
-
+  
   pCollect->pElemTracked      = NULL;
   pCollect->pfuncXEvent       = NULL;
-
+  
   // Save the pointer to the element array
   pCollect->asElem = asElem;
-
+  
   uint16_t nInd;
   for (nInd=0;nInd<nElemMax;nInd++) {
     gslc_ResetElem(&(pCollect->asElem[nInd]));
   }
-
+  
   // Initialize element references
   pCollect->nElemRefMax = nElemRefMax;
   pCollect->nElemRefCnt = 0;
@@ -3170,24 +3216,36 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId)
   if (pCollect == NULL) {
     GSLC_DEBUG_PRINT("ERROR: CollectFindElemById(%s) called with NULL ptr\n","");
     return NULL;
-  }
+  }  
   gslc_tsElem*  pElem = NULL;
   gslc_tsElem*  pFoundElem = NULL;
   uint16_t      nInd;
   if (nElemId == GSLC_ID_TEMP) {
     // ERROR: Don't expect to do this
-    GSLC_DEBUG_PRINT("ERROR: CollectFindElemById(%s) searching for temp ID\n","");
+    GSLC_DEBUG_PRINT("ERROR: CollectFindElemById(%s) searching for temp ID\n","");    
     return NULL;
   }
-
+  gslc_tsElem tempFind;
   for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
     gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
     // Only elements in RAM are searched
-    if ((eFlags & GSLC_ELEMREF_SRC) != GSLC_ELEMREF_SRC_RAM) {
-      continue;
-    }
+//    if ((eFlags & GSLC_ELEMREF_SRC) != GSLC_ELEMREF_SRC_RAM) {
+//      continue;
+//    }
     // Fetch the element pointer from the reference array
     pElem = pCollect->asElemRef[nInd].pElem;
+
+    if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_PROG) {
+
+        (gslc_tsElem*)memcpy_P(&tempFind,pElem,sizeof(gslc_tsElem));
+        //GSLC_DEBUG_PRINT("FINDING S:%u D:%u at %u from %uOF %u\n",nElemId,tempFind.nId,(int)pElem,(int)pCollect,pCollect->nElemRefCnt);
+        if (tempFind.nId == nElemId) {
+              pFoundElem = pElem;
+              break;
+            }
+    }
+
+
     if (pElem->nId == nElemId) {
       pFoundElem = pElem;
       break;
@@ -3211,23 +3269,47 @@ gslc_tsElem* gslc_CollectGetElemTracked(gslc_tsCollect* pCollect)
 void gslc_CollectSetElemTracked(gslc_tsCollect* pCollect,gslc_tsElem* pElem)
 {
   pCollect->pElemTracked = pElem;
+
+
 }
 
 // Find an element index in a collection from a coordinate
-gslc_tsElem* gslc_CollectFindElemFromCoord(gslc_tsCollect* pCollect,int16_t nX, int16_t nY)
+gslc_tsElem* gslc_CollectFindElemFromCoord(void * pvGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY)
 {
   uint16_t      nInd;
   bool          bFound = false;
   gslc_tsElem*  pElem = NULL;
   gslc_tsElem*  pFoundElem = NULL;
+  gslc_tsElem  pElemTmp;
+  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
 
   for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
     gslc_teElemRefFlags eFlags = pCollect->asElemRef[nInd].eElemFlags;
     // Only elements in RAM are searched
-    if ((eFlags & GSLC_ELEMREF_SRC) != GSLC_ELEMREF_SRC_RAM) {
-      continue;
-    }
     pElem = pCollect->asElemRef[nInd].pElem;
+
+
+    if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_PROG) {
+    pElem = (gslc_tsElem*) memcpy_P(&pElemTmp,pElem,sizeof(gslc_tsElem));
+
+        //pElem=&pElemTmp;
+
+
+        bFound = gslc_ElemOwnsCoord(&pElemTmp,nX,nY,true);
+    if (bFound)
+    {
+
+     pGui->sElemTmpProg=pElemTmp;
+    pFoundElem=&pGui->sElemTmpProg;
+
+    break;
+    }
+    }
+    else if ((eFlags & GSLC_ELEMREF_SRC) != GSLC_ELEMREF_SRC_RAM) {
+      continue;
+
+    }
+
     bFound = gslc_ElemOwnsCoord(pElem,nX,nY,true);
     if (bFound) {
       pFoundElem = pElem;
@@ -3236,6 +3318,8 @@ gslc_tsElem* gslc_CollectFindElemFromCoord(gslc_tsCollect* pCollect,int16_t nX, 
     }
   }
    // Return pointer or NULL if none found
+
+
   return pFoundElem;
 }
 
@@ -3261,9 +3345,10 @@ void gslc_CollectSetEventFunc(gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb)
   if ((pCollect == NULL) || (funcCb == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: CollectSetEventFunc(%s) called with NULL ptr\n","");
     return;
-  }
+  }    
   pCollect->pfuncXEvent       = funcCb;
 }
+gslc_tsGui                  m_gui;
 
 uint16_t  m_nLUTSinF0X16[257] = {
   0x0000,0x0192,0x0324,0x04B6,0x0648,0x07DA,0x096C,0x0AFD,0x0C8F,0x0E21,0x0FB2,0x1143,0x12D5,0x1465,0x15F6,0x1787,

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -39,14 +39,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-  
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <inttypes.h>
 
-  
+
 // -----------------------------------------------------------------------
 // Configuration
 // -----------------------------------------------------------------------
@@ -70,7 +70,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
 // Constants
 // -----------------------------------------------------------------------
 #define GSLC_2PI  6.28318530718
-  
+
 // -----------------------------------------------------------------------
 // Enumerations
 // -----------------------------------------------------------------------
@@ -83,7 +83,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
   /// - Specifying GSLC_ID_AUTO to ElemCreate() requests that
   ///   GUIslice auto-assign an ID value for the Element. These
   ///   auto-assigned values will begin at GSLC_ID_AUTO_BASE.
-  /// - Negative Element ID values are reserved 
+  /// - Negative Element ID values are reserved
   typedef enum {
     // Public usage
     GSLC_ID_USER_BASE       = 0,      ///< Starting Element ID for user assignments
@@ -92,7 +92,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_ID_TEMP,                     ///< ID for Temporary Element
     // Internal usage
     GSLC_ID_AUTO_BASE       = 16384,  ///< Starting Element ID to start auto-assignment
-                                      ///< (when GSLC_ID_AUTO is specified)            
+                                      ///< (when GSLC_ID_AUTO is specified)
   } gslc_teElemId;
 
 
@@ -101,7 +101,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
   ///   reference a specific page of elements.
   /// - Application code can assign arbitrary Page ID values
   ///   in the range of 0...16383
-  /// - Negative Page ID values are reserved   
+  /// - Negative Page ID values are reserved
   typedef enum {
     // Public usage
     GSLC_PAGE_USER_BASE     = 0,      ///< Starting Page ID for user assignments
@@ -109,7 +109,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_PAGE_NONE          = -2999,  ///< No Page ID has been assigned
   } gslc_tePageId;
 
-  
+
   /// Group ID enumerations
   typedef enum {
     // Public usage
@@ -117,20 +117,20 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     // Internal usage
     GSLC_GROUP_ID_NONE      = -6999,  ///< No Group ID has been assigned
   } gslc_teGroupId;
-  
+
   /// Font ID enumerations
   /// - The Font ID is the primary means for user code to
   ///   reference a specific font.
   /// - Application code can assign arbitrary Font ID values
   ///   in the range of 0...16383
-  /// - Negative Font ID values are reserved    
+  /// - Negative Font ID values are reserved
   typedef enum {
     // Public usage
     GSLC_FONT_USER_BASE     = 0,      ///< Starting Font ID for user assignments
     GSLC_FONT_NONE          = -4999,  ///< No Font ID has been assigned
   } gslc_teFontId;
-  
-  
+
+
   /// Element Index enumerations
   /// - The Element Index is used for internal purposes as an offset
   //    into the GUI's array of elements
@@ -150,7 +150,7 @@ typedef enum {
     GSLC_TYPE_TXT,          ///< Text label element type
     GSLC_TYPE_BOX,          ///< Box / frame element type
     GSLC_TYPE_LINE,         ///< Line element type
-    
+
     /// Base value for extended type enumerations
     GSLC_TYPE_BASE_EXTEND = 0x1000
 } gslc_teTypeCore;
@@ -224,7 +224,7 @@ typedef enum {
 /// Touch event type for element touch tracking
 typedef enum {
   GSLC_TOUCH_NONE       = 0,                                ///< No touch event active
-          
+
   // Touch state
   GSLC_TOUCH_DOWN       = (1<<4),                           ///< Touch event (down)
   GSLC_TOUCH_MOVE       = (1<<5),                           ///< Touch event (move)
@@ -307,11 +307,11 @@ typedef enum {
   GSLC_IMGREF_SRC_RAM     = (3<<0),   ///< Image is stored in RAM
   GSLC_IMGREF_SRC_PROG    = (4<<0),   ///< Image is stored in program memory (PROGMEM)
   // Define image types
-          
+
   GSLC_IMGREF_FMT_BMP24   = (1<<4),   ///< Image format is BMP (24-bit)
   GSLC_IMGREF_FMT_BMP16   = (2<<4),   ///< Image format is BMP (16-bit RGB565)
   GSLC_IMGREF_FMT_RAW1    = (3<<4),   ///< Image format is raw monochrome (1-bit)
-          
+
   // Mask values for bitfield comparisons
   GSLC_IMGREF_SRC         = (7<<0),   ///< Mask for Source flags
   GSLC_IMGREF_FMT         = (7<<4),   ///< Mask for Format flags
@@ -356,7 +356,7 @@ typedef struct gslc_tsEvent gslc_tsEvent;
 
 /// Callback function for element drawing
 typedef bool (*GSLC_CB_EVENT)(void* pvGui,gslc_tsEvent sEvent);
-        
+
 /// Callback function for element drawing
 typedef bool (*GSLC_CB_DRAW)(void* pvGui,void* pvElem,gslc_teRedrawType eRedraw);
 
@@ -448,11 +448,11 @@ typedef struct gslc_tsElem {
   int16_t             nType;            ///< Element type enumeration
   gslc_tsRect         rElem;            ///< Rect region containing element
   int16_t             nGroup;           ///< Group ID that the element belongs to
-  
+
   // Behavior settings
   bool                bGlowEn;          ///< Enable glowing visual state
   bool                bClickEn;         ///< Element accepts touch events
- 
+
 
   // Style
   bool                bFrameEn;         ///< Element is drawn with frame
@@ -460,31 +460,31 @@ typedef struct gslc_tsElem {
                                         ///< This is also used during redraw to determine
                                         ///< if elements underneath are visible and must
                                         ///< be redrawn as well.
-  
+
   gslc_tsColor        colElemFrame;     ///< Color for frame
   gslc_tsColor        colElemFill;      ///< Color for background fill
-  gslc_tsColor        colElemFrameGlow; ///< Color to use for frame when glowing  
+  gslc_tsColor        colElemFrameGlow; ///< Color to use for frame when glowing
   gslc_tsColor        colElemFillGlow;  ///< Color to use for fill when glowing
 
   gslc_tsImgRef       sImgRefNorm;      ///< Image reference to draw (normal)
   gslc_tsImgRef       sImgRefGlow;      ///< Image reference to draw (glowing)
-  
+
   /// Parent element reference. Used during redraw
   /// to notify parent elements that they require
   /// redraw as well. Primary usage is in compound
   /// elements.
-  gslc_tsElem*        pElemParent;  
-  
+  gslc_tsElem*        pElemParent;
+
   // Text handling
 #if (GSLC_LOCAL_STR)
   char                pStrBuf[GSLC_LOCAL_STR_LEN];  ///< Text string to overlay
 #else
   char*               pStrBuf;          ///< Ptr to text string buffer to overlay
-#endif  
+#endif
   uint8_t             nStrBufMax;       ///< Size of string buffer
   gslc_teTxtFlags     eTxtFlags;        ///< Flags associated with text buffer
 
-  
+
   gslc_tsColor        colElemText;      ///< Color of overlay text
   gslc_tsColor        colElemTextGlow;  ///< Color of overlay text when glowing
   int8_t              eTxtAlign;        ///< Alignment of overlay text
@@ -493,14 +493,14 @@ typedef struct gslc_tsElem {
 
   // Extended data elements
   void*               pXData;           ///< Ptr to extended data structure
-  
+
   // Callback functions
   GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for event tree (draw,touch,tick)
-  
+
   GSLC_CB_DRAW        pfuncXDraw;       ///< Callback func ptr for custom drawing
   GSLC_CB_TOUCH       pfuncXTouch;      ///< Callback func ptr for touch
   GSLC_CB_TICK        pfuncXTick;       ///< Callback func ptr for timer/main loop tick
-  
+
   // Current status
   gslc_teRedrawType   eRedraw;          ///< Type of redraw requested for element
   bool                bGlowing;         ///< Element is currently glowing
@@ -523,16 +523,16 @@ typedef struct {
   uint16_t              nElemMax;         ///< Maximum number of elements to allocate (in RAM)
   uint16_t              nElemCnt;         ///< Number of elements allocated
   int16_t               nElemAutoIdNext;  ///< Next Element ID for auto-assignment
-  
+
   gslc_tsElemRef*       asElemRef;        ///< Array of element references
   uint16_t              nElemRefMax;      ///< Maximum number of element references to allocate
   uint16_t              nElemRefCnt;      ///< Number of element references allocated
-  
+
   gslc_tsElem*          pElemTracked;     ///< Element currently being touch-tracked (NULL for none)
-  
+
   // Callback functions
-  GSLC_CB_EVENT         pfuncXEvent;      ///< Callback func ptr for events  
-  
+  GSLC_CB_EVENT         pfuncXEvent;      ///< Callback func ptr for events
+
 } gslc_tsCollect;
 
 
@@ -545,16 +545,16 @@ typedef struct {
 typedef struct {
 
   gslc_tsCollect      sCollect;             ///< Collection of elements on page
-  
+
   int8_t              nPageId;              ///< Page identifier
-  
+
   // Redraw
   bool                bPageNeedRedraw;      ///< Page require a redraw
   bool                bPageNeedFlip;        ///< Screen requires a page flip
-  
+
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;          ///< Callback func ptr for events   
-  
+  GSLC_CB_EVENT       pfuncXEvent;          ///< Callback func ptr for events
+
 } gslc_tsPage;
 
 
@@ -573,7 +573,7 @@ typedef struct {
     uint8_t           nFlipX;          ///< Adafruit GFX Touch Flip x axis
     uint8_t           nFlipY;          ///< Adafruit GFX Touch Flip x axis
   #endif
-  
+
   gslc_tsFont*        asFont;           ///< Collection of loaded fonts
   uint8_t             nFontMax;         ///< Maximum number of fonts to allocate
   uint8_t             nFontCnt;         ///< Number of fonts allocated
@@ -591,25 +591,25 @@ typedef struct {
                                         ///< If false, entire page is redrawn when any
                                         ///< element has been updated prior to next
                                         ///< page redraw command.
-  
+
   // Primary surface definitions
   gslc_tsImgRef       sImgRefBkgnd;     ///< Image reference for background
-  
+
   uint8_t             nFrameRateCnt;    ///< Diagnostic frame rate count
   uint8_t             nFrameRateStart;  ///< Diagnostic frame rate timestamp
-  
-  
+
+
   // Pages
   gslc_tsPage*        asPage;           ///< Array of pages
   uint8_t             nPageMax;         ///< Maximum number of pages
   uint8_t             nPageCnt;         ///< Current page index
-  
+
   gslc_tsPage*        pCurPage;         ///< Currently active page
   gslc_tsCollect*     pCurPageCollect;  ///< Ptr to active page collection
-  
+
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events 
-  
+  GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events
+
 } gslc_tsGui;
 
 
@@ -664,7 +664,7 @@ void gslc_InitDebug(GSLC_CB_DEBUG_OUT pfunc);
 /// Optimized printf routine for GUIslice debug/error output
 /// - Only supports '%s','%d','%u' tokens
 /// - Calls on the output function configured in gslc_InitDebug()
-/// 
+///
 /// \param[in]  pFmt:      Format string to use for printing
 /// \param[in]  ...:       Variable parameter list
 ///
@@ -1173,7 +1173,7 @@ gslc_tsFont* gslc_FontGet(gslc_tsGui* pGui,int16_t nFontId);
 /// \param[in]  sEvent:      Event data structure
 ///
 /// \return true if success, false if fail
-/// 
+///
 bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent);
 
 ///
@@ -1612,7 +1612,7 @@ void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
 /// \param[in]  pElem:       Pointer to Element
 ///
 /// \return Redraw status
-/// 
+///
 gslc_teRedrawType gslc_ElemGetRedraw(gslc_tsElem* pElem);
 
 ///
@@ -1672,7 +1672,7 @@ bool gslc_ElemGetGlow(gslc_tsElem* pElem);
 /// \param[in]  funcCb:      Function pointer to event routine (or NULL for default))
 ///
 /// \return none
-/// 
+///
 void gslc_ElemSetEventFunc(gslc_tsElem* pElem,GSLC_CB_EVENT funcCb);
 
 
@@ -1705,7 +1705,7 @@ void gslc_ElemSetTickFunc(gslc_tsElem* pElem,GSLC_CB_TICK funcCb);
 /// Determine if a coordinate is inside of an element
 /// - This routine is useful in determining if a touch
 ///   coordinate is inside of a button.
-/// 
+///
 /// \param[in]  pElem:        Element used for boundary test
 /// \param[in]  nX:           X coordinate to test
 /// \param[in]  nY:           Y coordinate to test
@@ -1728,7 +1728,7 @@ bool gslc_ElemOwnsCoord(gslc_tsElem* pElem,int16_t nX,int16_t nY,bool bOnlyClick
 /// \param[in]  sEvent:      Event data structure
 ///
 /// \return true if success, false if fail
-/// 
+///
 bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent);
 
 
@@ -1773,7 +1773,7 @@ void gslc_ElemDraw(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId);
 ///                           it is stored in RAM or Flash (PROGMEM).
 ///
 /// \return none
-/// 
+///
 void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nElemMax,
         gslc_tsElemRef* asElemRef,uint16_t nElemRefMax);
 
@@ -1791,7 +1791,7 @@ void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nEl
 ///
 /// \return Pointer to the element in the collection that has been added
 ///         or NULL if there was an error
-/// 
+///
 gslc_tsElem* gslc_CollectElemAdd(gslc_tsCollect* pCollect,const gslc_tsElem* pElem,gslc_teElemRefFlags eFlags);
 
 
@@ -1812,7 +1812,7 @@ bool gslc_CollectGetRedraw(gslc_tsCollect* pCollect);
 ///
 /// \return Pointer to the element in the collection that was found
 ///         or NULL if no matches found
-/// 
+///
 gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 
 
@@ -1826,7 +1826,7 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 ///
 /// \return Pointer to the element in the collection that was found
 ///         or NULL if no matches found
-/// 
+///
 gslc_tsElem* gslc_CollectFindElemFromCoord(void * pvGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
 
 
@@ -1835,7 +1835,7 @@ gslc_tsElem* gslc_CollectFindElemFromCoord(void * pvGui,gslc_tsCollect* pCollect
 /// \param[in]  pCollect:     Pointer to the collection
 ///
 /// \return Element ID that is reserved for use
-/// 
+///
 int gslc_CollectGetNextId(gslc_tsCollect* pCollect);
 
 
@@ -1884,7 +1884,7 @@ void gslc_CollectSetParent(gslc_tsCollect* pCollect,gslc_tsElem* pElemParent);
 /// \param[in]  funcCb:      Function pointer to event routine (or NULL for default))
 ///
 /// \return none
-/// 
+///
 void gslc_CollectSetEventFunc(gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb);
 
 ///
@@ -1894,7 +1894,7 @@ void gslc_CollectSetEventFunc(gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb);
 /// \param[in]  sEvent:      Event data structure
 ///
 /// \return true if success, false if fail
-/// 
+///
 bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent);
 
 
@@ -2008,7 +2008,7 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,int
 ///                          or is located in Flash/PROGMEM).
 ///
 /// \return Pointer to Element or NULL if fail
-/// 
+///
 gslc_tsElem* gslc_ElemAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* pElem,gslc_teElemRefFlags eFlags);
 
 
@@ -2077,9 +2077,9 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
 /// pages, collections and elements. Also frees
 /// up any fonts.
 /// - Called by gslc_Quit()
-/// 
+///
 /// \param[in]  pGui:         Pointer to GUI
-/// 
+///
 /// \return none
 ///
 void gslc_GuiDestruct(gslc_tsGui* pGui);
@@ -2087,27 +2087,27 @@ void gslc_GuiDestruct(gslc_tsGui* pGui);
 
 ///
 /// Free up any members associated with a page
-/// 
+///
 /// \param[in]  pPage:        Pointer to Page
-/// 
+///
 /// \return none
 ///
 void gslc_PageDestruct(gslc_tsPage* pPage);
 
 ///
 /// Free up any members associated with an element collection
-/// 
+///
 /// \param[in]  pCollect:     Pointer to collection
-/// 
+///
 /// \return none
 ///
 void gslc_CollectDestruct(gslc_tsCollect* pCollect);
 
 ///
 /// Free up any members associated with an element
-/// 
+///
 /// \param[in]  pElem:        Pointer to element
-/// 
+///
 /// \return none
 ///
 void gslc_ElemDestruct(gslc_tsElem* pElem);
@@ -2176,7 +2176,7 @@ void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
             if (DEBUG_ERR) {                                    \
               gslc_DebugPrintf(PSTR(sFmt),__VA_ARGS__);         \
             }                                                   \
-          } while (0)  
+          } while (0)
 #else
   // Debug print macro for CPUs that don't support PROGMEM (Flash)
   #define GSLC_DEBUG_PRINT(sFmt, ...)                           \
@@ -2184,7 +2184,7 @@ void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
             if (DEBUG_ERR) {                                    \
               gslc_DebugPrintf(sFmt,__VA_ARGS__);               \
             }                                                   \
-          } while (0)  
+          } while (0)
 #endif
 
 

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -1584,7 +1584,7 @@ void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr);
 ///
 /// \return none
 ///
-void gslc_ElemSetTxtStrP1(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId,const char* pStr);
+void gslc_ElemSetTxtStr_P(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId,const char* pStr);
 
 ///
 /// Update the text string color associated with an Element ID

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -2306,27 +2306,29 @@ void gslc_ResetElem(gslc_tsElem* pElem);
 ///
 
 
-/// \def gslc_ElemCreateTxtBtn_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData)
+/// \def gslc_ElemCreateBtnTxt_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,colFrameGlow,colFillGlow,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData)
 ///
 /// Create a text button element
 ///
-/// \param[in]  pGui:       Pointer to GUI
-/// \param[in]  nElemId:    Unique element ID to assign
-/// \param[in]  nPage:      Page ID to attach element to
-/// \param[in]  nX:         X coordinate of element
-/// \param[in]  nY:         Y coordinate of element
-/// \param[in]  nW:         Width of element
-/// \param[in]  nH:         Height of element
-/// \param[in]  strTxt:     Text string to display
-/// \param[in]  pFont:      Pointer to font resource
-/// \param[in]  colTxt:     Color for the text
-/// \param[in]  colFrame:   Color for the frame
-/// \param[in]  colFill:    Color for the fill
-/// \param[in]  nAlignTxt:  Text alignment
-/// \param[in]  bFrameEn:   True if framed, false otherwise
-/// \param[in]  bFillEn:    True if filled, false otherwise
-/// \param[in]  callFunc:   Callback function for button press
-/// \param[in]  extraData:  Ptr to extended data structure
+/// \param[in]  pGui:         Pointer to GUI
+/// \param[in]  nElemId:      Unique element ID to assign
+/// \param[in]  nPage:        Page ID to attach element to
+/// \param[in]  nX:           X coordinate of element
+/// \param[in]  nY:           Y coordinate of element
+/// \param[in]  nW:           Width of element
+/// \param[in]  nH:           Height of element
+/// \param[in]  strTxt:       Text string to display
+/// \param[in]  pFont:        Pointer to font resource
+/// \param[in]  colTxt:       Color for the text
+/// \param[in]  colFrame:     Color for the frame
+/// \param[in]  colFill:      Color for the fill
+/// \param[in]  colFrameGlow: Color for the frame when glowing
+/// \param[in]  colFillGlow:  Color for the fill when glowing
+/// \param[in]  nAlignTxt:    Text alignment
+/// \param[in]  bFrameEn:     True if framed, false otherwise
+/// \param[in]  bFillEn:      True if filled, false otherwise
+/// \param[in]  callFunc:     Callback function for button press
+/// \param[in]  extraData:    Ptr to extended data structure
 ///
 
 
@@ -2422,15 +2424,15 @@ void gslc_ResetElem(gslc_tsElem* pElem);
   };                                                              \
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
 
-#define gslc_ElemCreateTxtBtn_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData) \
+#define gslc_ElemCreateBtnTxt_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,colFrameGlow,colFillGlow,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData) \
   static const char str##nElemId[] PROGMEM = strTxt;              \
   static const gslc_tsElem sElem##nElemId PROGMEM = {             \
       nElemId,                                                    \
       true,                                                       \
       GSLC_TYPE_BTN,                                              \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      GSLC_GROUP_ID_NONE,false,true,bFrameEn,bFillEn,            \
-      colFrame,colFill,GSLC_COL_BLACK,GSLC_COL_BLACK,             \
+      GSLC_GROUP_ID_NONE,false,true,bFrameEn,bFillEn,             \
+      colFrame,colFill,colFrameGlow,colFillGlow,                  \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
       NULL,                                                       \
@@ -2441,13 +2443,13 @@ void gslc_ResetElem(gslc_tsElem* pElem);
       colTxt,                                                     \
       nAlignTxt,                                                  \
       0,                                                          \
-      pFont,                                           \
-	  (void*)extraData,                                                       \
+      pFont,                                                      \
+      (void*)extraData,                                           \
       NULL,                                                       \
-	  NULL,                                                       \
-	  callFunc,                                                       \
       NULL,                                                       \
-      GSLC_REDRAW_NONE,                                                      \
+      callFunc,                                                   \
+      NULL,                                                       \
+      GSLC_REDRAW_NONE,                                           \
       false,                                                      \
   };                                                              \
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
@@ -2481,13 +2483,13 @@ void gslc_ResetElem(gslc_tsElem* pElem);
       NULL,                                                       \
       NULL,                                                       \
       NULL,                                                       \
-      GSLC_REDRAW_NONE,                                                      \
+      GSLC_REDRAW_NONE,                                           \
       false,                                                      \
   };                                                              \
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_RAM);
 
 
-#define gslc_ElemCreateBox_P(pGui,nElemId,nPage,nX,nY,nW,nH,colFrame,colFill,bFrameEn,bFillEn) \
+#define gslc_ElemCreateBox_P(pGui,nElemId,nPage,nX,nY,nW,nH,colFrame,colFill,bFrameEn,bFillEn,drawFunc) \
   static const gslc_tsElem sElem##nElemId = {                     \
       nElemId,                                                    \
       true,                                                       \
@@ -2508,10 +2510,10 @@ void gslc_ResetElem(gslc_tsElem* pElem);
       NULL,                                                       \
       NULL,                                                       \
       NULL,                                                       \
+      drawFunc,                                                   \
       NULL,                                                       \
       NULL,                                                       \
-      NULL,                                                       \
-      GSLC_REDRAW_NONE,                                                      \
+      GSLC_REDRAW_NONE,                                           \
       false,                                                      \
   };                                                              \
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_RAM);

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -39,14 +39,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-
+  
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <inttypes.h>
 
-
+  
 // -----------------------------------------------------------------------
 // Configuration
 // -----------------------------------------------------------------------
@@ -65,11 +65,12 @@ typedef int16_t (*GSLC_CB_DEBUG_OUT)(char ch);
 extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
 
 
+
 // -----------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------
 #define GSLC_2PI  6.28318530718
-
+  
 // -----------------------------------------------------------------------
 // Enumerations
 // -----------------------------------------------------------------------
@@ -82,7 +83,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
   /// - Specifying GSLC_ID_AUTO to ElemCreate() requests that
   ///   GUIslice auto-assign an ID value for the Element. These
   ///   auto-assigned values will begin at GSLC_ID_AUTO_BASE.
-  /// - Negative Element ID values are reserved
+  /// - Negative Element ID values are reserved 
   typedef enum {
     // Public usage
     GSLC_ID_USER_BASE       = 0,      ///< Starting Element ID for user assignments
@@ -91,7 +92,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_ID_TEMP,                     ///< ID for Temporary Element
     // Internal usage
     GSLC_ID_AUTO_BASE       = 16384,  ///< Starting Element ID to start auto-assignment
-                                      ///< (when GSLC_ID_AUTO is specified)
+                                      ///< (when GSLC_ID_AUTO is specified)            
   } gslc_teElemId;
 
 
@@ -100,7 +101,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
   ///   reference a specific page of elements.
   /// - Application code can assign arbitrary Page ID values
   ///   in the range of 0...16383
-  /// - Negative Page ID values are reserved
+  /// - Negative Page ID values are reserved   
   typedef enum {
     // Public usage
     GSLC_PAGE_USER_BASE     = 0,      ///< Starting Page ID for user assignments
@@ -108,7 +109,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_PAGE_NONE          = -2999,  ///< No Page ID has been assigned
   } gslc_tePageId;
 
-
+  
   /// Group ID enumerations
   typedef enum {
     // Public usage
@@ -116,20 +117,20 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     // Internal usage
     GSLC_GROUP_ID_NONE      = -6999,  ///< No Group ID has been assigned
   } gslc_teGroupId;
-
+  
   /// Font ID enumerations
   /// - The Font ID is the primary means for user code to
   ///   reference a specific font.
   /// - Application code can assign arbitrary Font ID values
   ///   in the range of 0...16383
-  /// - Negative Font ID values are reserved
+  /// - Negative Font ID values are reserved    
   typedef enum {
     // Public usage
     GSLC_FONT_USER_BASE     = 0,      ///< Starting Font ID for user assignments
     GSLC_FONT_NONE          = -4999,  ///< No Font ID has been assigned
   } gslc_teFontId;
-
-
+  
+  
   /// Element Index enumerations
   /// - The Element Index is used for internal purposes as an offset
   //    into the GUI's array of elements
@@ -149,7 +150,7 @@ typedef enum {
     GSLC_TYPE_TXT,          ///< Text label element type
     GSLC_TYPE_BOX,          ///< Box / frame element type
     GSLC_TYPE_LINE,         ///< Line element type
-
+    
     /// Base value for extended type enumerations
     GSLC_TYPE_BASE_EXTEND = 0x1000
 } gslc_teTypeCore;
@@ -223,7 +224,7 @@ typedef enum {
 /// Touch event type for element touch tracking
 typedef enum {
   GSLC_TOUCH_NONE       = 0,                                ///< No touch event active
-
+          
   // Touch state
   GSLC_TOUCH_DOWN       = (1<<4),                           ///< Touch event (down)
   GSLC_TOUCH_MOVE       = (1<<5),                           ///< Touch event (move)
@@ -288,8 +289,12 @@ typedef enum {
   GSLC_ELEMREF_SRC_RAM     = (1<<0),   ///< Element is stored in RAM (internal element array)
   GSLC_ELEMREF_SRC_PROG    = (2<<0),   ///< Element is stored in program memory
                                        ///< (PROGMEM, read-only, external to element array)
+  GSLC_ELEMREF_DRAW_PROG    = (1<<4),   ///< Element base is stored in PROGMEM but content is in RAM
+
   // Mask values for bitfield comparisons
   GSLC_ELEMREF_SRC         = (7<<0),   ///< Mask for Source flags
+  GSLC_ELEMREF_SRC_DRAW_MASK         = (7<<4),   ///< Mask for Source flags
+
 } gslc_teElemRefFlags;
 
 
@@ -302,11 +307,11 @@ typedef enum {
   GSLC_IMGREF_SRC_RAM     = (3<<0),   ///< Image is stored in RAM
   GSLC_IMGREF_SRC_PROG    = (4<<0),   ///< Image is stored in program memory (PROGMEM)
   // Define image types
-
+          
   GSLC_IMGREF_FMT_BMP24   = (1<<4),   ///< Image format is BMP (24-bit)
   GSLC_IMGREF_FMT_BMP16   = (2<<4),   ///< Image format is BMP (16-bit RGB565)
   GSLC_IMGREF_FMT_RAW1    = (3<<4),   ///< Image format is raw monochrome (1-bit)
-
+          
   // Mask values for bitfield comparisons
   GSLC_IMGREF_SRC         = (7<<0),   ///< Mask for Source flags
   GSLC_IMGREF_FMT         = (7<<4),   ///< Mask for Format flags
@@ -351,7 +356,7 @@ typedef struct gslc_tsEvent gslc_tsEvent;
 
 /// Callback function for element drawing
 typedef bool (*GSLC_CB_EVENT)(void* pvGui,gslc_tsEvent sEvent);
-
+        
 /// Callback function for element drawing
 typedef bool (*GSLC_CB_DRAW)(void* pvGui,void* pvElem,gslc_teRedrawType eRedraw);
 
@@ -443,11 +448,11 @@ typedef struct gslc_tsElem {
   int16_t             nType;            ///< Element type enumeration
   gslc_tsRect         rElem;            ///< Rect region containing element
   int16_t             nGroup;           ///< Group ID that the element belongs to
-
+  
   // Behavior settings
   bool                bGlowEn;          ///< Enable glowing visual state
   bool                bClickEn;         ///< Element accepts touch events
-
+ 
 
   // Style
   bool                bFrameEn;         ///< Element is drawn with frame
@@ -455,31 +460,31 @@ typedef struct gslc_tsElem {
                                         ///< This is also used during redraw to determine
                                         ///< if elements underneath are visible and must
                                         ///< be redrawn as well.
-
+  
   gslc_tsColor        colElemFrame;     ///< Color for frame
   gslc_tsColor        colElemFill;      ///< Color for background fill
-  gslc_tsColor        colElemFrameGlow; ///< Color to use for frame when glowing
+  gslc_tsColor        colElemFrameGlow; ///< Color to use for frame when glowing  
   gslc_tsColor        colElemFillGlow;  ///< Color to use for fill when glowing
 
   gslc_tsImgRef       sImgRefNorm;      ///< Image reference to draw (normal)
   gslc_tsImgRef       sImgRefGlow;      ///< Image reference to draw (glowing)
-
+  
   /// Parent element reference. Used during redraw
   /// to notify parent elements that they require
   /// redraw as well. Primary usage is in compound
   /// elements.
-  gslc_tsElem*        pElemParent;
-
+  gslc_tsElem*        pElemParent;  
+  
   // Text handling
 #if (GSLC_LOCAL_STR)
   char                pStrBuf[GSLC_LOCAL_STR_LEN];  ///< Text string to overlay
 #else
   char*               pStrBuf;          ///< Ptr to text string buffer to overlay
-#endif
+#endif  
   uint8_t             nStrBufMax;       ///< Size of string buffer
   gslc_teTxtFlags     eTxtFlags;        ///< Flags associated with text buffer
 
-
+  
   gslc_tsColor        colElemText;      ///< Color of overlay text
   gslc_tsColor        colElemTextGlow;  ///< Color of overlay text when glowing
   int8_t              eTxtAlign;        ///< Alignment of overlay text
@@ -488,14 +493,14 @@ typedef struct gslc_tsElem {
 
   // Extended data elements
   void*               pXData;           ///< Ptr to extended data structure
-
+  
   // Callback functions
   GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for event tree (draw,touch,tick)
-
+  
   GSLC_CB_DRAW        pfuncXDraw;       ///< Callback func ptr for custom drawing
   GSLC_CB_TOUCH       pfuncXTouch;      ///< Callback func ptr for touch
   GSLC_CB_TICK        pfuncXTick;       ///< Callback func ptr for timer/main loop tick
-
+  
   // Current status
   gslc_teRedrawType   eRedraw;          ///< Type of redraw requested for element
   bool                bGlowing;         ///< Element is currently glowing
@@ -518,16 +523,16 @@ typedef struct {
   uint16_t              nElemMax;         ///< Maximum number of elements to allocate (in RAM)
   uint16_t              nElemCnt;         ///< Number of elements allocated
   int16_t               nElemAutoIdNext;  ///< Next Element ID for auto-assignment
-
+  
   gslc_tsElemRef*       asElemRef;        ///< Array of element references
   uint16_t              nElemRefMax;      ///< Maximum number of element references to allocate
   uint16_t              nElemRefCnt;      ///< Number of element references allocated
-
+  
   gslc_tsElem*          pElemTracked;     ///< Element currently being touch-tracked (NULL for none)
-
+  
   // Callback functions
-  GSLC_CB_EVENT         pfuncXEvent;      ///< Callback func ptr for events
-
+  GSLC_CB_EVENT         pfuncXEvent;      ///< Callback func ptr for events  
+  
 } gslc_tsCollect;
 
 
@@ -540,16 +545,16 @@ typedef struct {
 typedef struct {
 
   gslc_tsCollect      sCollect;             ///< Collection of elements on page
-
+  
   int8_t              nPageId;              ///< Page identifier
-
+  
   // Redraw
   bool                bPageNeedRedraw;      ///< Page require a redraw
   bool                bPageNeedFlip;        ///< Screen requires a page flip
-
+  
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;          ///< Callback func ptr for events
-
+  GSLC_CB_EVENT       pfuncXEvent;          ///< Callback func ptr for events   
+  
 } gslc_tsPage;
 
 
@@ -568,13 +573,13 @@ typedef struct {
     uint8_t           nFlipX;          ///< Adafruit GFX Touch Flip x axis
     uint8_t           nFlipY;          ///< Adafruit GFX Touch Flip x axis
   #endif
-
+  
   gslc_tsFont*        asFont;           ///< Collection of loaded fonts
   uint8_t             nFontMax;         ///< Maximum number of fonts to allocate
   uint8_t             nFontCnt;         ///< Number of fonts allocated
 
   gslc_tsElem         sElemTmp;         ///< Temporary element
-
+  gslc_tsElem         sElemTmpProg;         ///< Temporary element
   int16_t             nTouchLastX;      ///< Last touch event X coord
   int16_t             nTouchLastY;      ///< Last touch event Y coord
   uint16_t            nTouchLastPress;  ///< Last touch event pressure (0=none))
@@ -586,25 +591,25 @@ typedef struct {
                                         ///< If false, entire page is redrawn when any
                                         ///< element has been updated prior to next
                                         ///< page redraw command.
-
+  
   // Primary surface definitions
   gslc_tsImgRef       sImgRefBkgnd;     ///< Image reference for background
-
+  
   uint8_t             nFrameRateCnt;    ///< Diagnostic frame rate count
   uint8_t             nFrameRateStart;  ///< Diagnostic frame rate timestamp
-
-
+  
+  
   // Pages
   gslc_tsPage*        asPage;           ///< Array of pages
   uint8_t             nPageMax;         ///< Maximum number of pages
   uint8_t             nPageCnt;         ///< Current page index
-
+  
   gslc_tsPage*        pCurPage;         ///< Currently active page
   gslc_tsCollect*     pCurPageCollect;  ///< Ptr to active page collection
-
+  
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events
-
+  GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events 
+  
 } gslc_tsGui;
 
 
@@ -659,7 +664,7 @@ void gslc_InitDebug(GSLC_CB_DEBUG_OUT pfunc);
 /// Optimized printf routine for GUIslice debug/error output
 /// - Only supports '%s','%d','%u' tokens
 /// - Calls on the output function configured in gslc_InitDebug()
-///
+/// 
 /// \param[in]  pFmt:      Format string to use for printing
 /// \param[in]  ...:       Variable parameter list
 ///
@@ -1168,7 +1173,7 @@ gslc_tsFont* gslc_FontGet(gslc_tsGui* pGui,int16_t nFontId);
 /// \param[in]  sEvent:      Event data structure
 ///
 /// \return true if success, false if fail
-///
+/// 
 bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent);
 
 ///
@@ -1578,7 +1583,7 @@ void gslc_ElemSetTxtCol(gslc_tsElem* pElem,gslc_tsColor colVal);
 /// \return none
 ///
 void gslc_ElemSetTxtMem(gslc_tsElem* pElem,gslc_teTxtFlags eFlags);
-
+void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr);
 
 ///
 /// Update the Font selected for an Element's text
@@ -1607,7 +1612,7 @@ void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
 /// \param[in]  pElem:       Pointer to Element
 ///
 /// \return Redraw status
-///
+/// 
 gslc_teRedrawType gslc_ElemGetRedraw(gslc_tsElem* pElem);
 
 ///
@@ -1667,7 +1672,7 @@ bool gslc_ElemGetGlow(gslc_tsElem* pElem);
 /// \param[in]  funcCb:      Function pointer to event routine (or NULL for default))
 ///
 /// \return none
-///
+/// 
 void gslc_ElemSetEventFunc(gslc_tsElem* pElem,GSLC_CB_EVENT funcCb);
 
 
@@ -1700,7 +1705,7 @@ void gslc_ElemSetTickFunc(gslc_tsElem* pElem,GSLC_CB_TICK funcCb);
 /// Determine if a coordinate is inside of an element
 /// - This routine is useful in determining if a touch
 ///   coordinate is inside of a button.
-///
+/// 
 /// \param[in]  pElem:        Element used for boundary test
 /// \param[in]  nX:           X coordinate to test
 /// \param[in]  nY:           Y coordinate to test
@@ -1723,7 +1728,7 @@ bool gslc_ElemOwnsCoord(gslc_tsElem* pElem,int16_t nX,int16_t nY,bool bOnlyClick
 /// \param[in]  sEvent:      Event data structure
 ///
 /// \return true if success, false if fail
-///
+/// 
 bool gslc_ElemEvent(void* pvGui,gslc_tsEvent sEvent);
 
 
@@ -1768,7 +1773,7 @@ void gslc_ElemDraw(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId);
 ///                           it is stored in RAM or Flash (PROGMEM).
 ///
 /// \return none
-///
+/// 
 void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nElemMax,
         gslc_tsElemRef* asElemRef,uint16_t nElemRefMax);
 
@@ -1786,7 +1791,7 @@ void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nEl
 ///
 /// \return Pointer to the element in the collection that has been added
 ///         or NULL if there was an error
-///
+/// 
 gslc_tsElem* gslc_CollectElemAdd(gslc_tsCollect* pCollect,const gslc_tsElem* pElem,gslc_teElemRefFlags eFlags);
 
 
@@ -1807,7 +1812,7 @@ bool gslc_CollectGetRedraw(gslc_tsCollect* pCollect);
 ///
 /// \return Pointer to the element in the collection that was found
 ///         or NULL if no matches found
-///
+/// 
 gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 
 
@@ -1821,8 +1826,8 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 ///
 /// \return Pointer to the element in the collection that was found
 ///         or NULL if no matches found
-///
-gslc_tsElem* gslc_CollectFindElemFromCoord(gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
+/// 
+gslc_tsElem* gslc_CollectFindElemFromCoord(void * pvGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
 
 
 /// Allocate the next available Element ID in a collection
@@ -1830,7 +1835,7 @@ gslc_tsElem* gslc_CollectFindElemFromCoord(gslc_tsCollect* pCollect,int16_t nX, 
 /// \param[in]  pCollect:     Pointer to the collection
 ///
 /// \return Element ID that is reserved for use
-///
+/// 
 int gslc_CollectGetNextId(gslc_tsCollect* pCollect);
 
 
@@ -1879,7 +1884,7 @@ void gslc_CollectSetParent(gslc_tsCollect* pCollect,gslc_tsElem* pElemParent);
 /// \param[in]  funcCb:      Function pointer to event routine (or NULL for default))
 ///
 /// \return none
-///
+/// 
 void gslc_CollectSetEventFunc(gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb);
 
 ///
@@ -1889,7 +1894,7 @@ void gslc_CollectSetEventFunc(gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb);
 /// \param[in]  sEvent:      Event data structure
 ///
 /// \return true if success, false if fail
-///
+/// 
 bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent);
 
 
@@ -2003,7 +2008,7 @@ gslc_tsElem gslc_ElemCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPageId,int
 ///                          or is located in Flash/PROGMEM).
 ///
 /// \return Pointer to Element or NULL if fail
-///
+/// 
 gslc_tsElem* gslc_ElemAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* pElem,gslc_teElemRefFlags eFlags);
 
 
@@ -2072,9 +2077,9 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eR
 /// pages, collections and elements. Also frees
 /// up any fonts.
 /// - Called by gslc_Quit()
-///
+/// 
 /// \param[in]  pGui:         Pointer to GUI
-///
+/// 
 /// \return none
 ///
 void gslc_GuiDestruct(gslc_tsGui* pGui);
@@ -2082,27 +2087,27 @@ void gslc_GuiDestruct(gslc_tsGui* pGui);
 
 ///
 /// Free up any members associated with a page
-///
+/// 
 /// \param[in]  pPage:        Pointer to Page
-///
+/// 
 /// \return none
 ///
 void gslc_PageDestruct(gslc_tsPage* pPage);
 
 ///
 /// Free up any members associated with an element collection
-///
+/// 
 /// \param[in]  pCollect:     Pointer to collection
-///
+/// 
 /// \return none
 ///
 void gslc_CollectDestruct(gslc_tsCollect* pCollect);
 
 ///
 /// Free up any members associated with an element
-///
+/// 
 /// \param[in]  pElem:        Pointer to element
-///
+/// 
 /// \return none
 ///
 void gslc_ElemDestruct(gslc_tsElem* pElem);
@@ -2142,8 +2147,8 @@ void gslc_ResetFont(gslc_tsFont* pFont);
 ///
 void gslc_ResetElem(gslc_tsElem* pElem);
 
-
-
+bool gslc_ElemForceDrawP(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
+void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
 // ------------------------------------------------------------------------
 // General purpose macros
 // ------------------------------------------------------------------------
@@ -2171,7 +2176,7 @@ void gslc_ResetElem(gslc_tsElem* pElem);
             if (DEBUG_ERR) {                                    \
               gslc_DebugPrintf(PSTR(sFmt),__VA_ARGS__);         \
             }                                                   \
-          } while (0)
+          } while (0)  
 #else
   // Debug print macro for CPUs that don't support PROGMEM (Flash)
   #define GSLC_DEBUG_PRINT(sFmt, ...)                           \
@@ -2179,7 +2184,7 @@ void gslc_ResetElem(gslc_tsElem* pElem);
             if (DEBUG_ERR) {                                    \
               gslc_DebugPrintf(sFmt,__VA_ARGS__);               \
             }                                                   \
-          } while (0)
+          } while (0)  
 #endif
 
 
@@ -2246,6 +2251,37 @@ void gslc_ResetElem(gslc_tsElem* pElem);
 ///
 
 #if (GSLC_USE_PROGMEM)
+#define gslc_ElemCreateTxtBtn_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData) \
+  static const char str##nElemId[] PROGMEM = strTxt;              \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      true,                                                       \
+      GSLC_TYPE_BTN,                                              \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,false,true,bFrameEn,bFillEn,            \
+      colFrame,colFill,GSLC_COL_BLACK,GSLC_COL_BLACK,             \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      (char*)str##nElemId,                                        \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_MEM_PROG | GSLC_TXT_ALLOC_EXT),  \
+      colTxt,                                                     \
+      colTxt,                                                     \
+      nAlignTxt,                                                  \
+      0,                                                          \
+      pFont,                                           \
+	  (void*)extraData,                                                       \
+      NULL,                                                       \
+	  NULL,                                                       \
+	  callFunc,                                                       \
+      NULL,                                                       \
+      GSLC_REDRAW_NONE,                                                      \
+      false,                                                      \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
+
+
 
 #define gslc_ElemCreateTxt_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn) \
   static const char str##nElemId[] PROGMEM = strTxt;              \
@@ -2278,7 +2314,37 @@ void gslc_ResetElem(gslc_tsElem* pElem);
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
 
 
-#define gslc_ElemCreateBox_P(pGui,nElemId,nPage,nX,nY,nW,nH,colFrame,colFill,bFrameEn,bFillEn) \
+
+#define gslc_ElemCreateTxt_P_R(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,strLength,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn) \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      true,                                                       \
+      GSLC_TYPE_TXT,                                              \
+	  (gslc_tsRect){nX,nY,nW,nH},                                  \
+      GSLC_GROUP_ID_NONE,false,false,bFrameEn,bFillEn,            \
+      colFrame,colFill,GSLC_COL_BLACK,GSLC_COL_BLACK,             \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      (char*)strTxt,                                        \
+      strLength,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_MEM_RAM | GSLC_TXT_ALLOC_EXT),  \
+      colTxt,                                                     \
+      colTxt,                                                     \
+      nAlignTxt,                                                  \
+      0,                                                          \
+      pFont,                                           \
+      NULL,                                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+      GSLC_REDRAW_NONE,                                                      \
+      false,                                                      \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
+
+#define gslc_ElemCreateBox_P(pGui,nElemId,nPage,nX,nY,nW,nH,colFrame,colFill,bFrameEn,bFillEn,drawFunc) \
   static const gslc_tsElem sElem##nElemId PROGMEM = {             \
       nElemId,                                                    \
       true,                                                       \
@@ -2299,7 +2365,7 @@ void gslc_ResetElem(gslc_tsElem* pElem);
       NULL,                                                       \
       NULL,                                                       \
       NULL,                                                       \
-      NULL,                                                       \
+      drawFunc,                                                       \
       NULL,                                                       \
       NULL,                                                       \
       GSLC_REDRAW_NONE,                                                      \
@@ -2370,7 +2436,6 @@ void gslc_ResetElem(gslc_tsElem* pElem);
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_RAM);
 
 #endif // GSLC_USE_PROGMEM
-
 
 #ifdef __cplusplus
 }

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -6,7 +6,7 @@
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
 //
-// - Version 0.9.3    (2018/01/08)
+// - Version 0.9.3    (2018/01/11)
 // =======================================================================
 //
 // The MIT License
@@ -1563,7 +1563,7 @@ void gslc_ElemSetTxtMargin(gslc_tsElem* pElem,unsigned nMargin);
 void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr);
 
 ///
-/// Update the text string associated with an flash-based Element ID
+/// Update the text string associated with a flash-based Element by ptr
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElem:       Pointer to Element
@@ -1572,6 +1572,19 @@ void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr);
 /// \return none
 ///
 void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr);
+
+///
+/// Update the text string associated with a flash-based Element by its
+/// Page ID and Element ID
+///
+/// \param[in]  pGui:         Pointer to GUI
+/// \param[in]  nPageId:      Page ID to search
+/// \param[in]  nElemId:      Element ID to search
+/// \param[in]  pStr:        String to copy into element
+///
+/// \return none
+///
+void gslc_ElemSetTxtStrP1(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId,const char* pStr);
 
 ///
 /// Update the text string color associated with an Element ID
@@ -2446,7 +2459,7 @@ void gslc_ResetElem(gslc_tsElem* pElem);
       true,                                                       \
       GSLC_TYPE_BTN,                                              \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      GSLC_GROUP_ID_NONE,true,true,bFrameEn,bFillEn,             \
+      GSLC_GROUP_ID_NONE,true,true,bFrameEn,bFillEn,              \
       colFrame,colFill,colFrameGlow,colFillGlow,                  \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -1840,7 +1840,7 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 /// - A match is found if the element is "clickable" (bClickEn=true)
 ///   and the coordinate falls within the element's bounds (rElem).
 ///
-/// \param[in]  pvGui:        Void pointer to GUI
+/// \param[in]  pGui:         Pointer to GUI
 /// \param[in]  pCollect:     Pointer to the collection
 /// \param[in]  nX:           Absolute X coordinate to use for search
 /// \param[in]  nY:           Absolute Y coordinate to use for search
@@ -1848,7 +1848,22 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 /// \return Pointer to the element in the collection that was found
 ///         or NULL if no matches found
 ///
-gslc_tsElem* gslc_CollectFindElemFromCoord(void* pvGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
+gslc_tsElem* gslc_CollectFindElemFromCoord(gslc_tsGui* pGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
+
+
+///
+/// UNUSED
+/// Find an element reference from an element pointer
+/// - This could potentially be used when handling an element
+///   handler needs to access state that is stored in the
+///   element reference array.
+///
+/// \param[in]  pCollect:     Pointer to the collection
+/// \param[in]  pElem:        Ptr to the element to find
+///
+/// \return Pointer to the element reference
+///
+gslc_tsElemRef* gslc_CollectFindRefFromElem(gslc_tsCollect* pCollect,gslc_tsElem* pElem);
 
 
 /// Allocate the next available Element ID in a collection
@@ -2431,7 +2446,7 @@ void gslc_ResetElem(gslc_tsElem* pElem);
       true,                                                       \
       GSLC_TYPE_BTN,                                              \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      GSLC_GROUP_ID_NONE,false,true,bFrameEn,bFillEn,             \
+      GSLC_GROUP_ID_NONE,true,true,bFrameEn,bFillEn,             \
       colFrame,colFill,colFrameGlow,colFillGlow,                  \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -6,7 +6,7 @@
 // - Calvin Hass
 // - http://www.impulseadventure.com/elec/guislice-gui.html
 //
-// - Version 0.9.2    (2018/01/01)
+// - Version 0.9.3    (2018/01/08)
 // =======================================================================
 //
 // The MIT License
@@ -63,7 +63,6 @@ typedef int16_t (*GSLC_CB_DEBUG_OUT)(char ch);
 /// Global debug output function
 /// - The user assigns this function via gslc_InitDebug()
 extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
-
 
 
 // -----------------------------------------------------------------------
@@ -289,11 +288,11 @@ typedef enum {
   GSLC_ELEMREF_SRC_RAM     = (1<<0),   ///< Element is stored in RAM (internal element array)
   GSLC_ELEMREF_SRC_PROG    = (2<<0),   ///< Element is stored in program memory
                                        ///< (PROGMEM, read-only, external to element array)
-  GSLC_ELEMREF_DRAW_PROG    = (1<<4),   ///< Element base is stored in PROGMEM but content is in RAM
+  GSLC_ELEMREF_DRAW_PROG   = (1<<4),   ///< Element base is stored in PROGMEM but content is in RAM
 
   // Mask values for bitfield comparisons
-  GSLC_ELEMREF_SRC         = (7<<0),   ///< Mask for Source flags
-  GSLC_ELEMREF_SRC_DRAW_MASK         = (7<<4),   ///< Mask for Source flags
+  GSLC_ELEMREF_SRC            = (7<<0),   ///< Mask for Source flags
+  GSLC_ELEMREF_SRC_DRAW_MASK  = (7<<4),   ///< Mask for Source flags
 
 } gslc_teElemRefFlags;
 
@@ -579,7 +578,7 @@ typedef struct {
   uint8_t             nFontCnt;         ///< Number of fonts allocated
 
   gslc_tsElem         sElemTmp;         ///< Temporary element
-  gslc_tsElem         sElemTmpProg;         ///< Temporary element
+  gslc_tsElem         sElemTmpProg;     ///< Temporary element
   int16_t             nTouchLastX;      ///< Last touch event X coord
   int16_t             nTouchLastY;      ///< Last touch event Y coord
   uint16_t            nTouchLastPress;  ///< Last touch event pressure (0=none))
@@ -1564,6 +1563,17 @@ void gslc_ElemSetTxtMargin(gslc_tsElem* pElem,unsigned nMargin);
 void gslc_ElemSetTxtStr(gslc_tsElem* pElem,const char* pStr);
 
 ///
+/// Update the text string associated with an flash-based Element ID
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElem:       Pointer to Element
+/// \param[in]  pStr:        String to copy into element
+///
+/// \return none
+///
+void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr);
+
+///
 /// Update the text string color associated with an Element ID
 ///
 /// \param[in]  pElem:       Pointer to Element
@@ -1583,7 +1593,7 @@ void gslc_ElemSetTxtCol(gslc_tsElem* pElem,gslc_tsColor colVal);
 /// \return none
 ///
 void gslc_ElemSetTxtMem(gslc_tsElem* pElem,gslc_teTxtFlags eFlags);
-void gslc_ElemSetTxtStrP(gslc_tsGui* pGui,gslc_tsElem* pElem,const char* pStr);
+
 
 ///
 /// Update the Font selected for an Element's text
@@ -1605,6 +1615,16 @@ void gslc_ElemUpdateFont(gslc_tsGui* pGui,gslc_tsElem* pElem,int nFontId);
 /// \return none
 ///
 void gslc_ElemSetRedraw(gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
+
+///
+/// Update the need-redraw status for a flash-based element
+///
+/// \param[in]  pElem:       Pointer to Element
+/// \param[in]  eRedraw:     Redraw state to set
+///
+/// \return none
+///
+void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
 
 ///
 /// Get the need-redraw status for an element
@@ -1820,6 +1840,7 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 /// - A match is found if the element is "clickable" (bClickEn=true)
 ///   and the coordinate falls within the element's bounds (rElem).
 ///
+/// \param[in]  pvGui:        Void pointer to GUI
 /// \param[in]  pCollect:     Pointer to the collection
 /// \param[in]  nX:           Absolute X coordinate to use for search
 /// \param[in]  nY:           Absolute Y coordinate to use for search
@@ -1827,7 +1848,7 @@ gslc_tsElem* gslc_CollectFindElemById(gslc_tsCollect* pCollect,int16_t nElemId);
 /// \return Pointer to the element in the collection that was found
 ///         or NULL if no matches found
 ///
-gslc_tsElem* gslc_CollectFindElemFromCoord(void * pvGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
+gslc_tsElem* gslc_CollectFindElemFromCoord(void* pvGui,gslc_tsCollect* pCollect,int16_t nX, int16_t nY);
 
 
 /// Allocate the next available Element ID in a collection
@@ -2072,6 +2093,17 @@ bool gslc_SetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol);
 bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
 
 
+/// Draw a flash-based element to the active display
+/// - Element is referenced by an element pointer
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElem:       Ptr to Element to draw
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemForceDrawP(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
+
 ///
 /// Free up any surfaces associated with the GUI,
 /// pages, collections and elements. Also frees
@@ -2147,8 +2179,8 @@ void gslc_ResetFont(gslc_tsFont* pFont);
 ///
 void gslc_ResetElem(gslc_tsElem* pElem);
 
-bool gslc_ElemForceDrawP(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_teRedrawType eRedraw);
-void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
+
+
 // ------------------------------------------------------------------------
 // General purpose macros
 // ------------------------------------------------------------------------
@@ -2232,8 +2264,30 @@ void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
 /// \param[in]  bFillEn:    True if filled, false otherwise
 ///
 
+/// \def gslc_ElemCreateTxt_P_R(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,strLength,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn)
+///
+/// Create a read-write text element (element in Flash, string in RAM)
+///
+/// \param[in]  pGui:       Pointer to GUI
+/// \param[in]  nElemId:    Unique element ID to assign
+/// \param[in]  nPage:      Page ID to attach element to
+/// \param[in]  nX:         X coordinate of element
+/// \param[in]  nY:         Y coordinate of element
+/// \param[in]  nW:         Width of element
+/// \param[in]  nH:         Height of element
+/// \param[in]  strTxt:     Text string to display
+/// \param[in]  strLength:  Length of text string
+/// \param[in]  pFont:      Pointer to font resource
+/// \param[in]  colTxt:     Color for the text
+/// \param[in]  colFrame:   Color for the frame
+/// \param[in]  colFill:    Color for the fill
+/// \param[in]  nAlignTxt:  Text alignment
+/// \param[in]  bFrameEn:   True if framed, false otherwise
+/// \param[in]  bFillEn:    True if filled, false otherwise
+///
 
-/// \def gslc_ElemCreateBox_P(pGui,nElemId,nPage,nX,nY,nW,nH,colFrame,colFill,bFrameEn,bFillEn)
+
+/// \def gslc_ElemCreateBox_P(pGui,nElemId,nPage,nX,nY,nW,nH,colFrame,colFill,bFrameEn,bFillEn,drawFunc)
 ///
 /// Create a read-only box element
 ///
@@ -2248,40 +2302,35 @@ void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
 /// \param[in]  colFill:    Color for the fill
 /// \param[in]  bFrameEn:   True if framed, false otherwise
 /// \param[in]  bFillEn:    True if filled, false otherwise
+/// \param[in]  drawFunc:   Pointer to custom draw callback (or NULL if default)
 ///
 
+
+/// \def gslc_ElemCreateTxtBtn_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData)
+///
+/// Create a text button element
+///
+/// \param[in]  pGui:       Pointer to GUI
+/// \param[in]  nElemId:    Unique element ID to assign
+/// \param[in]  nPage:      Page ID to attach element to
+/// \param[in]  nX:         X coordinate of element
+/// \param[in]  nY:         Y coordinate of element
+/// \param[in]  nW:         Width of element
+/// \param[in]  nH:         Height of element
+/// \param[in]  strTxt:     Text string to display
+/// \param[in]  pFont:      Pointer to font resource
+/// \param[in]  colTxt:     Color for the text
+/// \param[in]  colFrame:   Color for the frame
+/// \param[in]  colFill:    Color for the fill
+/// \param[in]  nAlignTxt:  Text alignment
+/// \param[in]  bFrameEn:   True if framed, false otherwise
+/// \param[in]  bFillEn:    True if filled, false otherwise
+/// \param[in]  callFunc:   Callback function for button press
+/// \param[in]  extraData:  Ptr to extended data structure
+///
+
+
 #if (GSLC_USE_PROGMEM)
-#define gslc_ElemCreateTxtBtn_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData) \
-  static const char str##nElemId[] PROGMEM = strTxt;              \
-  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
-      nElemId,                                                    \
-      true,                                                       \
-      GSLC_TYPE_BTN,                                              \
-      (gslc_tsRect){nX,nY,nW,nH},                                 \
-      GSLC_GROUP_ID_NONE,false,true,bFrameEn,bFillEn,            \
-      colFrame,colFill,GSLC_COL_BLACK,GSLC_COL_BLACK,             \
-      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
-      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
-      NULL,                                                       \
-      (char*)str##nElemId,                                        \
-      0,                                                          \
-      (gslc_teTxtFlags)(GSLC_TXT_MEM_PROG | GSLC_TXT_ALLOC_EXT),  \
-      colTxt,                                                     \
-      colTxt,                                                     \
-      nAlignTxt,                                                  \
-      0,                                                          \
-      pFont,                                           \
-	  (void*)extraData,                                                       \
-      NULL,                                                       \
-	  NULL,                                                       \
-	  callFunc,                                                       \
-      NULL,                                                       \
-      GSLC_REDRAW_NONE,                                                      \
-      false,                                                      \
-  };                                                              \
-  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
-
-
 
 #define gslc_ElemCreateTxt_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn) \
   static const char str##nElemId[] PROGMEM = strTxt;              \
@@ -2372,6 +2421,38 @@ void gslc_ElemSetRedrawP(gslc_tsElem* pElem, bool eRedraw);
       false,                                                      \
   };                                                              \
   gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
+
+#define gslc_ElemCreateTxtBtn_P(pGui,nElemId,nPage,nX,nY,nW,nH,strTxt,pFont,colTxt,colFrame,colFill,nAlignTxt,bFrameEn,bFillEn,callFunc,extraData) \
+  static const char str##nElemId[] PROGMEM = strTxt;              \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      true,                                                       \
+      GSLC_TYPE_BTN,                                              \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,false,true,bFrameEn,bFillEn,            \
+      colFrame,colFill,GSLC_COL_BLACK,GSLC_COL_BLACK,             \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      (char*)str##nElemId,                                        \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_MEM_PROG | GSLC_TXT_ALLOC_EXT),  \
+      colTxt,                                                     \
+      colTxt,                                                     \
+      nAlignTxt,                                                  \
+      0,                                                          \
+      pFont,                                           \
+	  (void*)extraData,                                                       \
+      NULL,                                                       \
+	  NULL,                                                       \
+	  callFunc,                                                       \
+      NULL,                                                       \
+      GSLC_REDRAW_NONE,                                                      \
+      false,                                                      \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
+
+
 
 #else
 

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -47,15 +47,15 @@ extern "C" {
 #endif // __cplusplus
 
 // -----------------------------------------------------------------------------------------
-  
+
 // Specify the graphics driver library
 // - Uncomment one of the following graphics drivers
 //#define DRV_DISP_SDL1                // LINUX: SDL 1.2 library
 //#define DRV_DISP_SDL2              // LINUX: SDL 2.0 library
 #define DRV_DISP_ADAGFX            // Arduino: Adafruit-GFX library
 //#define DRV_DISP_TFT_ESPI          // Arduino: Bodmer/TFT_eSPI library
-  
-  
+
+
 // Specify the touchscreen driver
 // - Uncomment one of the following touchscreen drivers
 //#define DRV_TOUCH_NONE          // No touchscreen support
@@ -69,9 +69,9 @@ extern "C" {
 
 // -----------------------------------------------------------------------------------------
 
-// Graphics display driver-specific additional configuration  
+// Graphics display driver-specific additional configuration
 #if defined(DRV_DISP_SDL1)
-  // Define default device paths for framebuffer & touchscreen  
+  // Define default device paths for framebuffer & touchscreen
   #define GSLC_DEV_FB       "/dev/fb1"
   #define GSLC_DEV_TOUCH    "/dev/input/touchscreen"
   #define GSLC_DEV_VID_DRV  "fbcon"
@@ -81,11 +81,11 @@ extern "C" {
 
   // Show SDL mouse (1 to show, 0 to hide)
   #define DRV_SDL_MOUSE_SHOW 0
-  
+
   #define GSLC_LOCAL_STR      1
   #define GSLC_USE_FLOAT      1
 
-    
+
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
 
@@ -97,14 +97,14 @@ extern "C" {
   // - To use SDL2.0 with hardware acceleration with such displays,
   //   use fb0 as the target and then run fbcp to mirror fb0 to fb1
   #define GSLC_DEV_FB       "/dev/fb0"
-  #define GSLC_DEV_TOUCH    ""  
+  #define GSLC_DEV_TOUCH    ""
   #define GSLC_DEV_VID_DRV  "x11"
 
   // Show SDL mouse (1 to show, 0 to hide)
   #define DRV_SDL_MOUSE_SHOW 0
   // Enable hardware acceleration
   #define DRV_SDL_RENDER_ACCEL 1
-  
+
   #define GSLC_LOCAL_STR      1
   #define GSLC_USE_FLOAT      1
 
@@ -113,7 +113,7 @@ extern "C" {
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
 
 
-#elif defined(DRV_DISP_ADAGFX)  
+#elif defined(DRV_DISP_ADAGFX)
 
   #define GSLC_DEV_TOUCH ""   // No device path used
 
@@ -122,7 +122,7 @@ extern "C" {
 
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
-  
+
   // The Adafruit-GFX library supports a number of displays
   // - Select a display sub-type by uncommenting one of the
   //   following DRV_DISP_ADAGFX_* lines
@@ -132,7 +132,7 @@ extern "C" {
  // #define DRV_DISP_ADAGFX_SSD1306
   //#define DRV_DISP_ADAGFX_HX8357
 
-  
+
   // For Adafruit-GFX drivers, define pin connections
   // - Define general pins (modify these example pin assignments to match your board)
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
@@ -154,7 +154,7 @@ extern "C" {
   #define ADAGFX_PIN_MOSI
   #define ADAGFX_PIN_MISO
   #define ADAGFX_PIN_CLK
-  
+
 
   // Enable support for SD card
   // - Set to 1 to enable, 0 to disable
@@ -162,7 +162,7 @@ extern "C" {
   //   RAM and flash memory which could be problematic for Arduino models
   //   with limited resources.
   #define ADAGFX_SD_EN    0
-  
+
   // Define buffer size for loading images from SD
   // - A larger buffer will be faster but at the cost of RAM
   #define ADAGFX_SD_BUFFPIXEL   50
@@ -176,8 +176,8 @@ extern "C" {
   //   as well to ensure that the touch screen orientation matches the display rotation
   #define ADAGFX_ROTATE     1
 
-  
-#elif defined(DRV_DISP_TFT_ESPI)  
+
+#elif defined(DRV_DISP_TFT_ESPI)
 
   // NOTE: When using the TFT_eSPI library, there are additional
   //       library-specific configuration files that may need
@@ -189,7 +189,7 @@ extern "C" {
 
   // NOTE: To avoid potential SPI conflicts, it is recommended
   //       that SUPPORT_TRANSACTIONS is defined in TFT_eSPI's "User Setup"
-  
+
   #define GSLC_DEV_TOUCH ""   // No device path used
 
   #define GSLC_LOCAL_STR      0
@@ -197,7 +197,7 @@ extern "C" {
 
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
-  
+
 
   // Enable support for SD card
   // - Set to 1 to enable, 0 to disable
@@ -210,7 +210,7 @@ extern "C" {
   // Enable support for clipping (DrvSetClipRect)
   // - Note that this will impact performance of drawing graphics primitives
   #define ADAGFX_CLIP 1
-  
+
   // Set Default rotation
   // - Note that if you change this you will likely have to change ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y
   //   as well to ensure that the touch screen orientation matches the display rotation
@@ -221,10 +221,10 @@ extern "C" {
 
 // -----------------------------------------------------------------------------------------
 
-// Touch Driver-specific additional configuration  
+// Touch Driver-specific additional configuration
 #if defined(DRV_TOUCH_SDL)
   #define DRV_TOUCH_IN_DISP   // Use the display driver (SDL) for touch events
-  
+
 #elif defined(DRV_TOUCH_ADA_STMPE610)
 
   // Select wiring method by setting one of the following to 1
@@ -249,7 +249,7 @@ extern "C" {
   #define ADATOUCH_X_MAX 3800
   #define ADATOUCH_Y_MAX 3700
 
- 
+
 
 #elif defined(DRV_TOUCH_ADA_FT6206)
   // Define sensitivity coefficient (capacitive touch)
@@ -259,7 +259,7 @@ extern "C" {
 #define ADATOUCH_Y_MIN 150
 #define ADATOUCH_X_MAX 900
 #define ADATOUCH_Y_MAX 900
-  
+
 
 #elif defined(DRV_TOUCH_TFT_ESPI)
   // The TFT_eSPI display library also includes support for XPT2046 touch controller
@@ -281,7 +281,7 @@ extern "C" {
 #define ADATOUCH_SWAP_XY  1
 #define ADATOUCH_FLIP_X   0
 #define ADATOUCH_FLIP_Y   1
-  
+
 // Define the maximum number of touch events that are handled
 // per gslc_Update() call. Normally this can be set to 1 but certain
 // displays may require a greater value (eg. 30) in order to increase

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -47,31 +47,31 @@ extern "C" {
 #endif // __cplusplus
 
 // -----------------------------------------------------------------------------------------
-
+  
 // Specify the graphics driver library
 // - Uncomment one of the following graphics drivers
-#define DRV_DISP_SDL1                // LINUX: SDL 1.2 library
+//#define DRV_DISP_SDL1                // LINUX: SDL 1.2 library
 //#define DRV_DISP_SDL2              // LINUX: SDL 2.0 library
-//#define DRV_DISP_ADAGFX            // Arduino: Adafruit-GFX library
+#define DRV_DISP_ADAGFX            // Arduino: Adafruit-GFX library
 //#define DRV_DISP_TFT_ESPI          // Arduino: Bodmer/TFT_eSPI library
-
-
+  
+  
 // Specify the touchscreen driver
 // - Uncomment one of the following touchscreen drivers
 //#define DRV_TOUCH_NONE          // No touchscreen support
 //#define DRV_TOUCH_SDL           // LINUX: Use SDL touch driver
-#define DRV_TOUCH_TSLIB           // LINUX: Use tslib touch driver
+//#define DRV_TOUCH_SDL           // LINUX: Use SDL touch driver
+//#define DRV_TOUCH_TSLIB           // LINUX: Use tslib touch driver
 //#define DRV_TOUCH_ADA_STMPE610  // Arduino: Use Adafruit STMPE610 touch driver
 //#define DRV_TOUCH_ADA_FT6206    // Arduino: Use Adafruit FT6206 touch driver
-//#define DRV_TOUCH_TFT_ESPI      // Arduino: Use TFT_eSPI XPT2046 touch driver
-
+#define DRV_TOUCH_ADA_SIMPLE    // Arduino: Use Adafruit Touchscreen
 
 
 // -----------------------------------------------------------------------------------------
 
-// Graphics display driver-specific additional configuration
+// Graphics display driver-specific additional configuration  
 #if defined(DRV_DISP_SDL1)
-  // Define default device paths for framebuffer & touchscreen
+  // Define default device paths for framebuffer & touchscreen  
   #define GSLC_DEV_FB       "/dev/fb1"
   #define GSLC_DEV_TOUCH    "/dev/input/touchscreen"
   #define GSLC_DEV_VID_DRV  "fbcon"
@@ -81,11 +81,11 @@ extern "C" {
 
   // Show SDL mouse (1 to show, 0 to hide)
   #define DRV_SDL_MOUSE_SHOW 0
-
+  
   #define GSLC_LOCAL_STR      1
   #define GSLC_USE_FLOAT      1
 
-
+    
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
 
@@ -97,14 +97,14 @@ extern "C" {
   // - To use SDL2.0 with hardware acceleration with such displays,
   //   use fb0 as the target and then run fbcp to mirror fb0 to fb1
   #define GSLC_DEV_FB       "/dev/fb0"
-  #define GSLC_DEV_TOUCH    ""
+  #define GSLC_DEV_TOUCH    ""  
   #define GSLC_DEV_VID_DRV  "x11"
 
   // Show SDL mouse (1 to show, 0 to hide)
   #define DRV_SDL_MOUSE_SHOW 0
   // Enable hardware acceleration
   #define DRV_SDL_RENDER_ACCEL 1
-
+  
   #define GSLC_LOCAL_STR      1
   #define GSLC_USE_FLOAT      1
 
@@ -113,33 +113,35 @@ extern "C" {
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
 
 
-#elif defined(DRV_DISP_ADAGFX)
+#elif defined(DRV_DISP_ADAGFX)  
 
   #define GSLC_DEV_TOUCH ""   // No device path used
 
   #define GSLC_LOCAL_STR      0
-  #define GSLC_USE_FLOAT      0 // Use fixed-point lookup tables instead
+  #define GSLC_USE_FLOAT      1 // Use fixed-point lookup tables instead
 
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
-
+  
   // The Adafruit-GFX library supports a number of displays
   // - Select a display sub-type by uncommenting one of the
   //   following DRV_DISP_ADAGFX_* lines
-  #define DRV_DISP_ADAGFX_ILI9341
+#define DRV_DISP_ADAGFX_ILI9341
+//#define DRV_DISP_ADAGFX_ILI9341_8BIT
   //#define DRV_DISP_ADAGFX_ST7735
-  //#define DRV_DISP_ADAGFX_SSD1306
+ // #define DRV_DISP_ADAGFX_SSD1306
   //#define DRV_DISP_ADAGFX_HX8357
 
-
+  
   // For Adafruit-GFX drivers, define pin connections
   // - Define general pins (modify these example pin assignments to match your board)
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
-  #define ADAGFX_PIN_CS    10   // Display chip select
-  #define ADAGFX_PIN_DC     9   // Display SPI data/command
-  #define ADAGFX_PIN_RST   11   // Display Reset
-  #define ADAGFX_PIN_SDCS   4   // SD card chip select
-
+  #define ADAGFX_PIN_CS    53   // Display chip select
+  #define ADAGFX_PIN_DC     49   // Display SPI data/command
+  #define ADAGFX_PIN_RST   -1   // Display Reset
+  #define ADAGFX_PIN_SDCS   31   // SD card chip select
+  #define ADAGFX_PIN_WR     A1
+  #define ADAGFX_PIN_RD     A0
   // Use hardware SPI interface?
   // - Set to 1 to enable hardware SPI interface, 0 to use software SPI
   // - Software SPI may support the use of custom pin selection (via ADAGFX_PIN_MOSI,
@@ -152,7 +154,7 @@ extern "C" {
   #define ADAGFX_PIN_MOSI
   #define ADAGFX_PIN_MISO
   #define ADAGFX_PIN_CLK
-
+  
 
   // Enable support for SD card
   // - Set to 1 to enable, 0 to disable
@@ -160,10 +162,10 @@ extern "C" {
   //   RAM and flash memory which could be problematic for Arduino models
   //   with limited resources.
   #define ADAGFX_SD_EN    0
-
+  
   // Define buffer size for loading images from SD
   // - A larger buffer will be faster but at the cost of RAM
-  #define ADAGFX_SD_BUFFPIXEL   20
+  #define ADAGFX_SD_BUFFPIXEL   50
 
   // Enable support for clipping (DrvSetClipRect)
   // - Note that this will impact performance of drawing graphics primitives
@@ -174,8 +176,8 @@ extern "C" {
   //   as well to ensure that the touch screen orientation matches the display rotation
   #define ADAGFX_ROTATE     1
 
-
-#elif defined(DRV_DISP_TFT_ESPI)
+  
+#elif defined(DRV_DISP_TFT_ESPI)  
 
   // NOTE: When using the TFT_eSPI library, there are additional
   //       library-specific configuration files that may need
@@ -187,7 +189,7 @@ extern "C" {
 
   // NOTE: To avoid potential SPI conflicts, it is recommended
   //       that SUPPORT_TRANSACTIONS is defined in TFT_eSPI's "User Setup"
-
+  
   #define GSLC_DEV_TOUCH ""   // No device path used
 
   #define GSLC_LOCAL_STR      0
@@ -195,7 +197,7 @@ extern "C" {
 
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
-
+  
 
   // Enable support for SD card
   // - Set to 1 to enable, 0 to disable
@@ -208,7 +210,7 @@ extern "C" {
   // Enable support for clipping (DrvSetClipRect)
   // - Note that this will impact performance of drawing graphics primitives
   #define ADAGFX_CLIP 1
-
+  
   // Set Default rotation
   // - Note that if you change this you will likely have to change ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y
   //   as well to ensure that the touch screen orientation matches the display rotation
@@ -219,10 +221,10 @@ extern "C" {
 
 // -----------------------------------------------------------------------------------------
 
-// Touch Driver-specific additional configuration
+// Touch Driver-specific additional configuration  
 #if defined(DRV_TOUCH_SDL)
   #define DRV_TOUCH_IN_DISP   // Use the display driver (SDL) for touch events
-
+  
 #elif defined(DRV_TOUCH_ADA_STMPE610)
 
   // Select wiring method by setting one of the following to 1
@@ -235,7 +237,6 @@ extern "C" {
 
   // For ADATOUCH_SPI_HW=1
   #define ADATOUCH_PIN_CS     8 // From Adafruit 2.8" TFT touch shield
-  //#define ADATOUCH_PIN_CS     PIN_D0 // From Adafruit 2.8" TFT touch shield (for ESP8266)
 
   // Calibration values for touch display
   // - These values may need to be updated to match your display
@@ -248,11 +249,17 @@ extern "C" {
   #define ADATOUCH_X_MAX 3800
   #define ADATOUCH_Y_MAX 3700
 
-
+ 
 
 #elif defined(DRV_TOUCH_ADA_FT6206)
   // Define sensitivity coefficient (capacitive touch)
   #define ADATOUCH_SENSITIVITY  40
+#elif defined(DRV_TOUCH_ADA_SIMPLE)
+#define ADATOUCH_X_MIN 100
+#define ADATOUCH_Y_MIN 150
+#define ADATOUCH_X_MAX 900
+#define ADATOUCH_Y_MAX 900
+  
 
 #elif defined(DRV_TOUCH_TFT_ESPI)
   // The TFT_eSPI display library also includes support for XPT2046 touch controller
@@ -274,7 +281,7 @@ extern "C" {
 #define ADATOUCH_SWAP_XY  1
 #define ADATOUCH_FLIP_X   0
 #define ADATOUCH_FLIP_Y   1
-
+  
 // Define the maximum number of touch events that are handled
 // per gslc_Update() call. Normally this can be set to 1 but certain
 // displays may require a greater value (eg. 30) in order to increase
@@ -316,3 +323,5 @@ extern "C" {
 }
 #endif // __cplusplus
 #endif // _GUISLICE_CONFIG_H_
+
+

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -31,9 +31,6 @@
 //
 // =======================================================================
 
-// Other contributions:
-// - 2017/08/29: Added Adafruit HX8357 support. [by ALittleSlow]
-
 // =======================================================================
 // User Configuration
 // - This file can be modified by the user to match the
@@ -50,9 +47,9 @@ extern "C" {
 
 // Specify the graphics driver library
 // - Uncomment one of the following graphics drivers
-//#define DRV_DISP_SDL1                // LINUX: SDL 1.2 library
+#define DRV_DISP_SDL1                // LINUX: SDL 1.2 library
 //#define DRV_DISP_SDL2              // LINUX: SDL 2.0 library
-#define DRV_DISP_ADAGFX            // Arduino: Adafruit-GFX library
+//#define DRV_DISP_ADAGFX            // Arduino: Adafruit-GFX library
 //#define DRV_DISP_TFT_ESPI          // Arduino: Bodmer/TFT_eSPI library
 
 
@@ -60,11 +57,11 @@ extern "C" {
 // - Uncomment one of the following touchscreen drivers
 //#define DRV_TOUCH_NONE          // No touchscreen support
 //#define DRV_TOUCH_SDL           // LINUX: Use SDL touch driver
-//#define DRV_TOUCH_SDL           // LINUX: Use SDL touch driver
-//#define DRV_TOUCH_TSLIB           // LINUX: Use tslib touch driver
+#define DRV_TOUCH_TSLIB           // LINUX: Use tslib touch driver
 //#define DRV_TOUCH_ADA_STMPE610  // Arduino: Use Adafruit STMPE610 touch driver
 //#define DRV_TOUCH_ADA_FT6206    // Arduino: Use Adafruit FT6206 touch driver
-#define DRV_TOUCH_ADA_SIMPLE    // Arduino: Use Adafruit Touchscreen
+//#define DRV_TOUCH_TFT_ESPI      // Arduino: Use TFT_eSPI XPT2046 touch driver
+//#define DRV_TOUCH_ADA_SIMPLE    // Arduino: Use Adafruit Touchscreen
 
 
 // -----------------------------------------------------------------------------------------
@@ -118,7 +115,7 @@ extern "C" {
   #define GSLC_DEV_TOUCH ""   // No device path used
 
   #define GSLC_LOCAL_STR      0
-  #define GSLC_USE_FLOAT      1 // Use fixed-point lookup tables instead
+  #define GSLC_USE_FLOAT      0 // Use fixed-point lookup tables instead
 
   // Error reporting
   #define DEBUG_ERR   1       // Enable error message reporting (requires more memory)
@@ -126,22 +123,23 @@ extern "C" {
   // The Adafruit-GFX library supports a number of displays
   // - Select a display sub-type by uncommenting one of the
   //   following DRV_DISP_ADAGFX_* lines
-#define DRV_DISP_ADAGFX_ILI9341
-//#define DRV_DISP_ADAGFX_ILI9341_8BIT
+  #define DRV_DISP_ADAGFX_ILI9341
+  //#define DRV_DISP_ADAGFX_ILI9341_8BIT
   //#define DRV_DISP_ADAGFX_ST7735
- // #define DRV_DISP_ADAGFX_SSD1306
+  //#define DRV_DISP_ADAGFX_SSD1306
   //#define DRV_DISP_ADAGFX_HX8357
 
 
   // For Adafruit-GFX drivers, define pin connections
   // - Define general pins (modify these example pin assignments to match your board)
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
-  #define ADAGFX_PIN_CS    53   // Display chip select
-  #define ADAGFX_PIN_DC     49   // Display SPI data/command
-  #define ADAGFX_PIN_RST   -1   // Display Reset
-  #define ADAGFX_PIN_SDCS   31   // SD card chip select
-  #define ADAGFX_PIN_WR     A1
-  #define ADAGFX_PIN_RD     A0
+  #define ADAGFX_PIN_CS    10   // Display chip select
+  #define ADAGFX_PIN_DC     9   // Display SPI data/command
+  #define ADAGFX_PIN_RST   11   // Display Reset
+  #define ADAGFX_PIN_SDCS   4   // SD card chip select
+  #define ADAGFX_PIN_WR    A1  // Display write pin (for parallel displays)
+  #define ADAGFX_PIN_RD    A0  // Display read pin (for parallel displays)
+
   // Use hardware SPI interface?
   // - Set to 1 to enable hardware SPI interface, 0 to use software SPI
   // - Software SPI may support the use of custom pin selection (via ADAGFX_PIN_MOSI,
@@ -237,6 +235,7 @@ extern "C" {
 
   // For ADATOUCH_SPI_HW=1
   #define ADATOUCH_PIN_CS     8 // From Adafruit 2.8" TFT touch shield
+  //#define ADATOUCH_PIN_CS     PIN_D0 // From Adafruit 2.8" TFT touch shield (for ESP8266)
 
   // Calibration values for touch display
   // - These values may need to be updated to match your display
@@ -254,11 +253,16 @@ extern "C" {
 #elif defined(DRV_TOUCH_ADA_FT6206)
   // Define sensitivity coefficient (capacitive touch)
   #define ADATOUCH_SENSITIVITY  40
+
+
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
-#define ADATOUCH_X_MIN 100
-#define ADATOUCH_Y_MIN 150
-#define ADATOUCH_X_MAX 900
-#define ADATOUCH_Y_MAX 900
+  // Calibration values for touch display
+  // - These values may need to be updated to match your display
+  // - Typically used in resistive displays
+  #define ADATOUCH_X_MIN 100
+  #define ADATOUCH_Y_MIN 150
+  #define ADATOUCH_X_MAX 900
+  #define ADATOUCH_Y_MAX 900
 
 
 #elif defined(DRV_TOUCH_TFT_ESPI)
@@ -323,5 +327,3 @@ extern "C" {
 }
 #endif // __cplusplus
 #endif // _GUISLICE_CONFIG_H_
-
-

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -100,7 +100,7 @@ extern "C" {
 
 
 // ------------------------------------------------------------------------
-#if defined(DRV_DISP_ADAGFX_ILI9341) 
+#if defined(DRV_DISP_ADAGFX_ILI9341)
   #if (ADAGFX_SPI_HW) // Use hardware SPI or software SPI (with custom pins)
     Adafruit_ILI9341 m_disp = Adafruit_ILI9341(ADAGFX_PIN_CS, ADAGFX_PIN_DC);
   #else
@@ -135,23 +135,23 @@ Adafruit_SSD1306 m_disp(OLED_RESET);
   #else
     Adafruit_HX8357 m_disp(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_MOSI, ADAGFX_PIN_CLK, ADAGFX_PIN_RESET);
   #endif
-    
+
 // ------------------------------------------------------------------------
 #endif // DRV_DISP_ADAGFX_*
 
 
 
 // ------------------------------------------------------------------------
-#if defined(DRV_TOUCH_ADA_STMPE610) 
+#if defined(DRV_TOUCH_ADA_STMPE610)
   #if (ADATOUCH_I2C_HW) // Use I2C
     Adafruit_STMPE610 m_touch = Adafruit_STMPE610();
   #elif (ADATOUCH_SPI_HW) // Use hardware SPI
     Adafruit_STMPE610 m_touch = Adafruit_STMPE610(ADATOUCH_PIN_CS);
   #elif (ADATOUCH_SPI_SW) // Use software SPI
-    Adafruit_STMPE610 m_touch = Adafruit_STMPE610(ADATOUCH_PIN_CS, ADATOUCH_PIN_SDI, ADATOUCH_PIN_SDO, ADATOUCH_PIN_SCK);   
+    Adafruit_STMPE610 m_touch = Adafruit_STMPE610(ADATOUCH_PIN_CS, ADATOUCH_PIN_SDI, ADATOUCH_PIN_SDO, ADATOUCH_PIN_SCK);
   #endif
 // ------------------------------------------------------------------------
-#elif defined(DRV_TOUCH_ADA_FT6206) 
+#elif defined(DRV_TOUCH_ADA_FT6206)
     // Always use I2C
     Adafruit_FT6206 m_touch = Adafruit_FT6206();
 // ------------------------------------------------------------------------
@@ -179,7 +179,7 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
   // Report any debug info if enabled
   #if defined(DBG_DRIVER)
   // TODO
-  #endif  
+  #endif
 
   // Initialize any library-specific members
   if (pGui->pvDriver) {
@@ -192,7 +192,7 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
     pGui->bRedrawPartialEn = true;
 
     #if defined(DRV_DISP_ADAGFX_ILI9341)
-      m_disp.begin();      
+      m_disp.begin();
 
       uint8_t x = m_disp.readcommand8(ILI9341_RDMODE);
       x = m_disp.readcommand8(ILI9341_RDMADCTL);
@@ -220,26 +220,26 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
       m_disp.begin(SSD1306_SWITCHCAPVCC);
       pGui->nDispW = SSD1306_LCDWIDTH;
       pGui->nDispH = SSD1306_LCDHEIGHT;
-      
+
     #elif defined(DRV_DISP_ADAGFX_ST7735)
       m_disp.initR(INITR_144GREENTAB);  // 1.44"
       //m_disp.initR(INITR_BLACKTAB);     // 1.8" [TODO]
       pGui->nDispW = m_disp.width();
       pGui->nDispH = m_disp.height();
     #elif defined(DRV_DISP_ADAGFX_HX8357)
-      m_disp.begin(HX8357D);      
+      m_disp.begin(HX8357D);
       // Rotate display from native portrait orientation to landscape
       // NOTE: The touch events in gslc_TDrvGetTouch() will also need rotation
       m_disp.setRotation(1);
       pGui->nDispW = HX8357_TFTHEIGHT;
       pGui->nDispH = HX8357_TFTWIDTH;
-      
+
     #endif
 
     // Defaults for clipping region
     gslc_tsRect rClipRect = {0,0,pGui->nDispW,pGui->nDispH};
     gslc_DrvSetClipRect(pGui,&rClipRect);
-      
+
     // Initialize SD card usage
     #if (ADAGFX_SD_EN)
     if (!SD.begin(ADAGFX_PIN_SDCS)) {
@@ -247,8 +247,8 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
       return false;
     }
     #endif
-    
-  }  
+
+  }
   return true;
 }
 
@@ -270,7 +270,7 @@ void* gslc_DrvLoadImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef)
   if (sImgRef.eImgFlags == GSLC_IMGREF_NONE) {
     return NULL;
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_FILE) {
-    return NULL;  // No image preload done  
+    return NULL;  // No image preload done
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_SD) {
     return NULL;  // No image preload done
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_RAM) {
@@ -293,8 +293,8 @@ bool gslc_DrvSetBkgndImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef)
   if (pGui->sImgRefBkgnd.pvImgRaw == NULL) {
     GSLC_DEBUG_PRINT("ERROR: DrvSetBkgndImage(%s) failed\n","");
     return false;
-  }      
-  
+  }
+
   return true;
 }
 
@@ -322,7 +322,7 @@ bool gslc_DrvSetElemImageGlow(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef 
 {
   // This driver doesn't preload the image to memory,
   // so we just save the reference for loading upon render
-  pElem->sImgRefGlow = sImgRef;  
+  pElem->sImgRefGlow = sImgRef;
   return true; // TODO
 }
 
@@ -373,7 +373,7 @@ void gslc_DrvFontsDestruct(gslc_tsGui* pGui)
 bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,
         int16_t* pnTxtX,int16_t* pnTxtY,uint16_t* pnTxtSzW,uint16_t* pnTxtSzH)
 {
-  uint16_t  nTxtLen   = 0;  
+  uint16_t  nTxtLen   = 0;
   uint16_t  nTxtScale = pFont->nSize;
   m_disp.setFont((const GFXfont *)pFont->pvFont);
   m_disp.setTextSize(nTxtScale);
@@ -381,7 +381,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
   //m_disp.getTextBounds((char*)pStr,0,0,&nDummyX,&nDummyY,pnTxtSzW,pnTxtSzH);
   // TODO: FIXME: getTextBounds seems to return bad value.
   //       Would also need to handle pStr in PROGMEM
-  
+
   // Workaround uses the dimensions of default default font in Adafruit-GFX library
   if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_RAM) {
 
@@ -403,7 +403,7 @@ m_disp.setFont();
 
 bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
 {
-  uint16_t nTxtScale = pFont->nSize;  
+  uint16_t nTxtScale = pFont->nSize;
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
   m_disp.setFont((const GFXfont *)pFont->pvFont);
   m_disp.setTextColor(nColRaw);
@@ -419,7 +419,7 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
       m_disp.print(ch);
     }
     m_disp.println();
- 
+
   }
  m_disp.setFont();
   return true;
@@ -441,24 +441,24 @@ void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
     m_disp.display();
 
     // TODO: Might need to call m_disp.clearDisplay() now?
-    
+
   #endif
 }
 
 
 // -----------------------------------------------------------------------
 // Graphics Primitives Functions
-// -----------------------------------------------------------------------  
+// -----------------------------------------------------------------------
 
 
 bool gslc_DrvDrawPoint(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol)
 {
 #if (ADAGFX_CLIP)
   // Perform clipping
-  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);  
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
   if (!gslc_ClipPt(&pDriver->rClipRect,nX,nY)) { return true; }
 #endif
-  
+
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.drawPixel(nX,nY,nColRaw);
   return true;
@@ -474,11 +474,11 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 {
 #if (ADAGFX_CLIP)
   // Perform clipping
-  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);  
-  if (!gslc_ClipRect(&pDriver->rClipRect,&rRect)) { return true; }  
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (!gslc_ClipRect(&pDriver->rClipRect,&rRect)) { return true; }
 #endif
-  
-  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);  
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.fillRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
   return true;
 }
@@ -487,11 +487,11 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 {
 #if (ADAGFX_CLIP)
   // Perform clipping
-  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);  
-  if (!gslc_ClipRect(&pDriver->rClipRect,&rRect)) { return true; }    
-#endif  
-  
-  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);  
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (!gslc_ClipRect(&pDriver->rClipRect,&rRect)) { return true; }
+#endif
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.drawRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
   return true;
 }
@@ -500,10 +500,10 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 bool gslc_DrvDrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)
 {
 #if (ADAGFX_CLIP)
-  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);  
-  if (!gslc_ClipLine(&pDriver->rClipRect,&nX0,&nY0,&nX1,&nY1)) { return true; }      
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (!gslc_ClipLine(&pDriver->rClipRect,&nX0,&nY0,&nX1,&nY1)) { return true; }
 #endif
-  
+
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.drawLine(nX0,nY0,nX1,nY1,nColRaw);
   return true;
@@ -514,8 +514,8 @@ bool gslc_DrvDrawFrameCircle(gslc_tsGui*,int16_t nMidX,int16_t nMidY,uint16_t nR
 #if (ADAGFX_CLIP)
   // TODO
 #endif
-  
-  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);  
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.drawCircle(nMidX,nMidY,nRadius,nColRaw);
   return true;
 }
@@ -525,7 +525,7 @@ bool gslc_DrvDrawFillCircle(gslc_tsGui*,int16_t nMidX,int16_t nMidY,uint16_t nRa
 #if (ADAGFX_CLIP)
   // TODO
 #endif
-  
+
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.fillCircle(nMidX,nMidY,nRadius,nColRaw);
   return true;
@@ -538,7 +538,7 @@ bool gslc_DrvDrawFrameTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
 #if (ADAGFX_CLIP)
   // TODO
 #endif
-  
+
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.drawTriangle(nX0,nY0,nX1,nY1,nX2,nY2,nColRaw);
   return true;
@@ -550,10 +550,10 @@ bool gslc_DrvDrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
 #if (ADAGFX_CLIP)
   // TODO
 #endif
-  
+
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
   m_disp.fillTriangle(nX0,nY0,nX1,nY1,nX2,nY2,nColRaw);
-  return true;   
+  return true;
 }
 
 
@@ -584,7 +584,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t x, int16_t y,
   const unsigned char*  bmap_base = bitmap;
   int16_t         w,h;
   gslc_tsColor    nCol;
-  
+
   // Read header
   w       = ( (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++) ) << 8;
   w      |= ( (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++) ) << 0;
@@ -594,7 +594,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t x, int16_t y,
   nCol.g  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.b  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   bmap_base++;
-  
+
   int16_t i, j, byteWidth = (w + 7) / 8;
   uint8_t nByte;
 
@@ -612,7 +612,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t x, int16_t y,
         gslc_DrvDrawPoint(pGui,x+i,y+j,nCol);
       }
     }
-  }   
+  }
 }
 // ----- REFERENCE CODE end
 
@@ -661,7 +661,7 @@ void gslc_DrvDrawBmp24FromSD(gslc_tsGui* pGui,const char *filename, uint16_t x, 
   uint32_t pos = 0, startTime = millis();
 
   if((x >= pGui->nDispW) || (y >= pGui->nDispH)) return;
- 
+
   //Serial.println();
   //Serial.print("Loading image '");
   //Serial.print(filename);
@@ -753,7 +753,7 @@ void gslc_DrvDrawBmp24FromSD(gslc_tsGui* pGui,const char *filename, uint16_t x, 
             if (bDrawBit) {
               gslc_DrvDrawPoint(pGui,x+col,y+row,nCol);
             }
-            
+
           } // end pixel
         } // end scanline
         //Serial.print("Loaded in ");
@@ -772,16 +772,16 @@ void gslc_DrvDrawBmp24FromSD(gslc_tsGui* pGui,const char *filename, uint16_t x, 
 
 
 bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRef sImgRef)
-{ 
+{
   // GUIslice adapter library for Adafruit-GFX does not pre-load
   // image data into memory before calling DrvDrawImage(), so
   // we to handle the loading now (when rendering).
   if (sImgRef.eImgFlags == GSLC_IMGREF_NONE) {
     return true;  // Nothing to do
-    
+
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_FILE) {
     return false; // Not supported
-    
+
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_RAM) {
     if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_RAW1) {
       // Draw a monochrome bitmap from SRAM
@@ -790,8 +790,8 @@ bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRe
       return true;
     } else {
       return false; // TODO: not yet supported
-    }    
-    
+    }
+
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_PROG) {
     // TODO: Probably need to fix this to work with PROGMEM,
     //       but check (GSLC_USE_PROGMEM) first
@@ -801,18 +801,18 @@ bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRe
       // Draw a monochrome bitmap from program memory
       // - Dimensions and output color are defined in arrray header
       gslc_DrvDrawMonoFromMem(pGui,nDstX,nDstY,sImgRef.pImgBuf,true);
-      return true;      
+      return true;
     } else {
       return false; // TODO: not yet supported
     }
-    
+
   } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_SD) {
     // Load image from SD media
     #if (ADAGFX_SD_EN)
       if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_BMP24) {
         // 24-bit Bitmap
-        gslc_DrvDrawBmp24FromSD(pGui,sImgRef.pFname,nDstX,nDstY);   
-        return true; 
+        gslc_DrvDrawBmp24FromSD(pGui,sImgRef.pFname,nDstX,nDstY);
+        return true;
       } else {
         // Unsupported format
         return false;
@@ -821,7 +821,7 @@ bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRe
       // SD card access not enabled
       return false;
     #endif
-    
+
   } else {
     // Unsupported source
     return false;
@@ -836,7 +836,7 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui)
 {
   if (pGui->pvDriver) {
     gslc_tsDriver*  pDriver = (gslc_tsDriver*)(pGui->pvDriver);
-    
+
     // Check to see if an image has been assigned to the background
     if (pGui->sImgRefBkgnd.eImgFlags == GSLC_IMGREF_NONE) {
 	  // No image assigned, so assume flat color background
@@ -859,7 +859,7 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui)
 
 // -----------------------------------------------------------------------
 // Touch Functions (via display driver)
-// -----------------------------------------------------------------------  
+// -----------------------------------------------------------------------
 
 
 bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
@@ -927,12 +927,12 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
   static int16_t  m_nLastRawY     = 0;
   static uint16_t m_nLastRawPress = 0;
   static bool     m_bLastTouched  = false;
-  
+
   bool bValid = false;  // Indicate a touch event to GUIslice core?
-  
+
   // ----------------------------------------------------------------
-  #if defined(DRV_TOUCH_ADA_STMPE610)    
-  
+  #if defined(DRV_TOUCH_ADA_STMPE610)
+
   if (m_touch.touched()) {
 
     if (m_touch.bufferEmpty()) {
@@ -949,11 +949,11 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
         m_bLastTouched = true;
         bValid = true;
       }
-   
+
     }
     // Clear interrupts
     m_touch.writeRegister8(STMPE_INT_STA, 0xFF);
-    
+
   } else {
     if (!m_bLastTouched) {
       // Wasn't touched before; do nothing
@@ -962,17 +962,17 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
       // Indicate old coordinate but with pressure=0
       m_nLastRawPress = 0;
       m_bLastTouched = false;
-      bValid = true;      
+      bValid = true;
     }
     // Flush the FIFO
     while (!m_touch.bufferEmpty()) {
       m_touch.readData(&nRawX,&nRawY,&nRawPress);
     }
   }
-  
+
   // ----------------------------------------------------------------
   #elif defined(DRV_TOUCH_ADA_FT6206)
-  
+
   if (m_touch.touched()) {
     TS_Point ptTouch = m_touch.getPoint();
     m_nLastRawX = ptTouch.x;
@@ -980,7 +980,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
     m_nLastRawPress = 255;  // Select arbitrary non-zero value
     m_bLastTouched = true;
     bValid = true;
-    
+
   } else {
     if (!m_bLastTouched) {
       // Wasn't touched before; do nothing
@@ -989,13 +989,13 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
       // Indicate old coordinate but with pressure=0
       m_nLastRawPress = 0;
       m_bLastTouched = false;
-      bValid = true;      
+      bValid = true;
     }
   }
 
   // ----------------------------------------------------------------
 #elif  defined(DRV_TOUCH_ADA_SIMPLE)
- 
+
   TSPoint p = m_touch.getPoint();
 
   pinMode(XM, OUTPUT);
@@ -1026,7 +1026,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
 
   #endif // DRV_TOUCH_*
 
-  
+
   // If an event was detected, signal it back to GUIslice
   if (bValid) {
 
@@ -1060,7 +1060,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
       nInputY = constrain(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX);
       // Perform scaling from input to output
       nOutputX = map(nInputX,ADATOUCH_X_MIN,ADATOUCH_X_MAX,0,nDispOutMaxX);
-      nOutputY = map(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX,0,nDispOutMaxY);    
+      nOutputY = map(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX,0,nDispOutMaxY);
     #else
       // No scaling from input to output
       nOutputX = nInputX;
@@ -1078,19 +1078,19 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
     // Final assignment
     *pnX      = nOutputX;
     *pnY      = nOutputY;
-    *pnPress  = m_nLastRawPress;    
+    *pnPress  = m_nLastRawPress;
 
     // Print output for debug
     #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT("DBG: Touch Press=%u Raw[%d,%d] Out[%d,%d]\n",
         m_nLastRawPress,m_nLastRawX,m_nLastRawY,nOutputX,nOutputY);
-    #endif  
-  
-       
+    #endif
+
+
     // Return with indication of new value
     return true;
   }
-    
+
   // No new value
   return false;
 }
@@ -1143,22 +1143,22 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
 uint16_t gslc_DrvAdaptColorToRaw(gslc_tsColor nCol)
 {
   uint16_t nColRaw = 0;
-  
+
   #if defined(DRV_DISP_ADAGFX_ILI) ||defined(DRV_DISP_ADAGFX_ILI9341)||defined(DRV_DISP_ADAGFX_ILI9341_8BIT)|| defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
     // RGB565
     nColRaw |= (((nCol.r & 0xF8) >> 3) << 11); // Mask: 1111 1000 0000 0000
     nColRaw |= (((nCol.g & 0xFC) >> 2) <<  5); // Mask: 0000 0111 1110 0000
     nColRaw |= (((nCol.b & 0xF8) >> 3) <<  0); // Mask: 0000 0000 0001 1111
-  
+
   #elif defined(DRV_DISP_ADAGFX_SSD1306)
     if ((nCol.r == 0) && (nCol.g == 0) && (nCol.b == 0)) { // GSLC_COL_BLACK
       nColRaw = 0;  // BLACK
     } else {
       nColRaw = 1;  // WHITE
     }
-    
+
   #endif // DRV_DISP_ADAGFX_*
-  
+
   return nColRaw;
 }
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -43,10 +43,10 @@ extern "C" {
 #include "GUIslice.h"
 
 #include <stdio.h>
+  
 
-
-
-
+  
+  
 // =======================================================================
 // API support definitions
 // - These defines indicate whether the driver includes optimized
@@ -55,9 +55,9 @@ extern "C" {
 // - At the very minimum, the point draw routine must be available:
 //   gslc_DrvDrawPoint()
 // =======================================================================
-
+  
 #define DRV_HAS_DRAW_POINT          1 ///< Support gslc_DrvDrawPoint()
-
+  
 #define DRV_HAS_DRAW_POINTS         0 ///< Support gslc_DrvDrawPoints()
 #define DRV_HAS_DRAW_LINE           1 ///< Support gslc_DrvDrawLine()
 #define DRV_HAS_DRAW_RECT_FRAME     1 ///< Support gslc_DrvDrawFrameRect()
@@ -69,19 +69,19 @@ extern "C" {
 #define DRV_HAS_DRAW_TEXT           1 ///< Support gslc_DrvDrawTxt()
 
 #define DRV_OVERRIDE_TXT_ALIGN      0 ///< Driver provides text alignment
-
+  
 // =======================================================================
 // Driver-specific members
 // =======================================================================
 typedef struct {
   uint16_t      nColRawBkgnd;   ///< Background color (if not image-based)
-
+  
   gslc_tsRect   rClipRect;      ///< Clipping rectangle
-
+  
 } gslc_tsDriver;
+  
 
-
-
+  
 // =======================================================================
 // Public APIs to GUIslice core library
 // - These functions define the renderer / driver-dependent
@@ -128,9 +128,9 @@ bool gslc_DrvInitTs(gslc_tsGui* pGui,const char* acDev);
 ///
 /// Free up any members associated with the driver
 /// - Eg. renderers, windows, background surfaces, etc.
-///
+/// 
 /// \param[in]  pGui:         Pointer to GUI
-///
+/// 
 /// \return none
 ///
 void gslc_DrvDestruct(gslc_tsGui* pGui);
@@ -153,7 +153,7 @@ void gslc_DrvDestruct(gslc_tsGui* pGui);
 ///
 void* gslc_DrvLoadImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef);
 
-
+void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t x, int16_t y, const unsigned char *bitmap,bool bProgMem);
 ///
 /// Configure the background to use a bitmap image
 /// - The background is used when redrawing the entire page
@@ -195,26 +195,26 @@ bool gslc_DrvSetElemImageNorm(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef 
 /// \param[in]  sImgRef:     Image reference
 ///
 /// \return true if success, false if error
-///
+///  
 bool gslc_DrvSetElemImageGlow(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef);
 
 
-///
+/// 
 /// Release an image surface
-///
+/// 
 /// \param[in]  pvImg:          Void ptr to image
-///
+/// 
 /// \return none
 ///
-void gslc_DrvImageDestruct(void* pvImg);
+void gslc_DrvImageDestruct(void* pvImg);  
 
 
-///
+/// 
 /// Set the clipping rectangle for future drawing updates
-///
-/// \param[in]  pGui:          Pointer to GUI
+/// 
+/// \param[in]  pGui:          Pointer to GUI  
 /// \param[in]  pRect:         Rectangular region to constrain edits
-///
+/// 
 /// \return none
 ///
 bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect);
@@ -235,11 +235,11 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect);
 ///
 const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType,const void* pvFontRef,uint16_t nFontSz);
 
-///
+/// 
 /// Release all fonts defined in the GUI
-///
-/// \param[in]  pGui:          Pointer to GUI
-///
+/// 
+/// \param[in]  pGui:          Pointer to GUI  
+/// 
 /// \return none
 ///
 void gslc_DrvFontsDestruct(gslc_tsGui* pGui);
@@ -252,13 +252,11 @@ void gslc_DrvFontsDestruct(gslc_tsGui* pGui);
 /// \param[in]  pFont:       Ptr to Font structure
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
-/// \param[out] pnTxtX:      Ptr to offset X of text
-/// \param[out] pnTxtY:      Ptr to offset Y of text
 /// \param[out] pnTxtSzW:    Ptr to width of text
 /// \param[out] pnTxtSzH:    Ptr to height of text
 ///
 /// \return true if success, false if failure
-///
+///  
 bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,
         int16_t* pnTxtX,int16_t* pnTxtY,uint16_t* pnTxtSzW,uint16_t* pnTxtSzH);
 
@@ -275,7 +273,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 /// \param[in]  colTxt:      Color to draw text
 ///
 /// \return true if success, false if failure
-///
+///  
 bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
 
 
@@ -290,13 +288,13 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 /// \param[in]  pGui:        Pointer to GUI
 ///
 /// \return none
-///
+/// 
 void gslc_DrvPageFlipNow(gslc_tsGui* pGui);
 
 
 // -----------------------------------------------------------------------
 // Graphics Primitives Functions
-// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------  
 
 ///
 /// Draw a point
@@ -444,12 +442,12 @@ bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRe
 ///
 /// \return true if success, false if fail
 ///
-void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
+void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);  
 
 
 // -----------------------------------------------------------------------
 // Touch Functions (if using display driver library)
-// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------  
 
 ///
 /// Perform any touchscreen-specific initialization
@@ -461,7 +459,7 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
 /// \return true if successful
 ///
 bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev);
-
+void gslc_SleepOn();
 
 ///
 /// Get the last touch event from the SDL_Event handler
@@ -478,7 +476,7 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pnP
 
 // -----------------------------------------------------------------------
 // Touch Functions (if using external touch driver library)
-// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------  
 
 #if defined(DRV_TOUCH_ADA_STMPE610) || defined(DRV_TOUCH_ADA_FT6206)
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -153,7 +153,7 @@ void gslc_DrvDestruct(gslc_tsGui* pGui);
 ///
 void* gslc_DrvLoadImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef);
 
-void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t x, int16_t y, const unsigned char *bitmap,bool bProgMem);
+
 ///
 /// Configure the background to use a bitmap image
 /// - The background is used when redrawing the entire page
@@ -252,6 +252,8 @@ void gslc_DrvFontsDestruct(gslc_tsGui* pGui);
 /// \param[in]  pFont:       Ptr to Font structure
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
+/// \param[out] pnTxtX:      Ptr to offset X of text
+/// \param[out] pnTxtY:      Ptr to offset Y of text
 /// \param[out] pnTxtSzW:    Ptr to width of text
 /// \param[out] pnTxtSzH:    Ptr to height of text
 ///
@@ -435,6 +437,23 @@ bool gslc_DrvDrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
 ///
 bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRef sImgRef);
 
+
+///
+/// Draw a monochrome bitmap from a memory array
+/// - Draw from the bitmap buffer using the foreground color
+///   defined in the header (unset bits are transparent)
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nDstX:       Destination X coord for copy
+/// \param[in]  nDstY:       Destination Y coord for copy
+/// \param[in]  bitmap:      Pointer to bitmap buffer
+/// \param[in]  bProgMem:    Bitmap is stored in Flash if true, RAM otherwise
+///
+/// \return none
+///
+void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t x, int16_t y, const unsigned char *bitmap,bool bProgMem);
+
+
 ///
 /// Copy the background image to destination screen
 ///
@@ -459,7 +478,7 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
 /// \return true if successful
 ///
 bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev);
-void gslc_SleepOn();
+
 
 ///
 /// Get the last touch event from the SDL_Event handler

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -43,10 +43,10 @@ extern "C" {
 #include "GUIslice.h"
 
 #include <stdio.h>
-  
 
-  
-  
+
+
+
 // =======================================================================
 // API support definitions
 // - These defines indicate whether the driver includes optimized
@@ -55,9 +55,9 @@ extern "C" {
 // - At the very minimum, the point draw routine must be available:
 //   gslc_DrvDrawPoint()
 // =======================================================================
-  
+
 #define DRV_HAS_DRAW_POINT          1 ///< Support gslc_DrvDrawPoint()
-  
+
 #define DRV_HAS_DRAW_POINTS         0 ///< Support gslc_DrvDrawPoints()
 #define DRV_HAS_DRAW_LINE           1 ///< Support gslc_DrvDrawLine()
 #define DRV_HAS_DRAW_RECT_FRAME     1 ///< Support gslc_DrvDrawFrameRect()
@@ -69,19 +69,19 @@ extern "C" {
 #define DRV_HAS_DRAW_TEXT           1 ///< Support gslc_DrvDrawTxt()
 
 #define DRV_OVERRIDE_TXT_ALIGN      0 ///< Driver provides text alignment
-  
+
 // =======================================================================
 // Driver-specific members
 // =======================================================================
 typedef struct {
   uint16_t      nColRawBkgnd;   ///< Background color (if not image-based)
-  
-  gslc_tsRect   rClipRect;      ///< Clipping rectangle
-  
-} gslc_tsDriver;
-  
 
-  
+  gslc_tsRect   rClipRect;      ///< Clipping rectangle
+
+} gslc_tsDriver;
+
+
+
 // =======================================================================
 // Public APIs to GUIslice core library
 // - These functions define the renderer / driver-dependent
@@ -128,9 +128,9 @@ bool gslc_DrvInitTs(gslc_tsGui* pGui,const char* acDev);
 ///
 /// Free up any members associated with the driver
 /// - Eg. renderers, windows, background surfaces, etc.
-/// 
+///
 /// \param[in]  pGui:         Pointer to GUI
-/// 
+///
 /// \return none
 ///
 void gslc_DrvDestruct(gslc_tsGui* pGui);
@@ -195,26 +195,26 @@ bool gslc_DrvSetElemImageNorm(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef 
 /// \param[in]  sImgRef:     Image reference
 ///
 /// \return true if success, false if error
-///  
+///
 bool gslc_DrvSetElemImageGlow(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef);
 
 
-/// 
+///
 /// Release an image surface
-/// 
+///
 /// \param[in]  pvImg:          Void ptr to image
-/// 
+///
 /// \return none
 ///
-void gslc_DrvImageDestruct(void* pvImg);  
+void gslc_DrvImageDestruct(void* pvImg);
 
 
-/// 
+///
 /// Set the clipping rectangle for future drawing updates
-/// 
-/// \param[in]  pGui:          Pointer to GUI  
+///
+/// \param[in]  pGui:          Pointer to GUI
 /// \param[in]  pRect:         Rectangular region to constrain edits
-/// 
+///
 /// \return none
 ///
 bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect);
@@ -235,11 +235,11 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect);
 ///
 const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType,const void* pvFontRef,uint16_t nFontSz);
 
-/// 
+///
 /// Release all fonts defined in the GUI
-/// 
-/// \param[in]  pGui:          Pointer to GUI  
-/// 
+///
+/// \param[in]  pGui:          Pointer to GUI
+///
 /// \return none
 ///
 void gslc_DrvFontsDestruct(gslc_tsGui* pGui);
@@ -256,7 +256,7 @@ void gslc_DrvFontsDestruct(gslc_tsGui* pGui);
 /// \param[out] pnTxtSzH:    Ptr to height of text
 ///
 /// \return true if success, false if failure
-///  
+///
 bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,
         int16_t* pnTxtX,int16_t* pnTxtY,uint16_t* pnTxtSzW,uint16_t* pnTxtSzH);
 
@@ -273,7 +273,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 /// \param[in]  colTxt:      Color to draw text
 ///
 /// \return true if success, false if failure
-///  
+///
 bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
 
 
@@ -288,13 +288,13 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 /// \param[in]  pGui:        Pointer to GUI
 ///
 /// \return none
-/// 
+///
 void gslc_DrvPageFlipNow(gslc_tsGui* pGui);
 
 
 // -----------------------------------------------------------------------
 // Graphics Primitives Functions
-// -----------------------------------------------------------------------  
+// -----------------------------------------------------------------------
 
 ///
 /// Draw a point
@@ -442,12 +442,12 @@ bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRe
 ///
 /// \return true if success, false if fail
 ///
-void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);  
+void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
 
 
 // -----------------------------------------------------------------------
 // Touch Functions (if using display driver library)
-// -----------------------------------------------------------------------  
+// -----------------------------------------------------------------------
 
 ///
 /// Perform any touchscreen-specific initialization
@@ -476,7 +476,7 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pnP
 
 // -----------------------------------------------------------------------
 // Touch Functions (if using external touch driver library)
-// -----------------------------------------------------------------------  
+// -----------------------------------------------------------------------
 
 #if defined(DRV_TOUCH_ADA_STMPE610) || defined(DRV_TOUCH_ADA_FT6206)
 

--- a/src/GUIslice_ex.h
+++ b/src/GUIslice_ex.h
@@ -847,6 +847,71 @@ void gslc_ElemXGraphScrollSet(gslc_tsElem* pElem,uint8_t nScrollPos,uint8_t nScr
 
 // ============================================================================
 
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+/// \def gslc_ElemXCheckboxCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,bRadio,nStyle,colCheck,bChecked)
+///
+/// Create a Checkbox Element in Flash
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Unique element ID to assign
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  nX:          X coordinate of element
+/// \param[in]  nY:          Y coordinate of element
+/// \param[in]  nW:          Width of element
+/// \param[in]  nH:          Height of element
+/// \param[in]  bRadio:      Radio-button functionality if true
+/// \param[in]  nStyle:      Drawing style for checkbox / radio button
+/// \param[in]  colCheck:    Color for inner fill when checked
+/// \param[in]  bChecked:    Default state
+///
+/// \return none
+///
+
+#ifdef GSLC_USE_PROGMEM
+
+#define gslc_ElemXCheckboxCreate_P(pGui_,nElemId,nPage,nX,nY,nW,nH,bRadio_,nStyle_,colCheck_,bChecked_) \
+  static gslc_tsXCheckbox sCheckbox##nElemId;                     \
+  sCheckbox##nElemId.pGui = pGui_;                                \
+  sCheckbox##nElemId.bRadio = bRadio_;                            \
+  sCheckbox##nElemId.bChecked = bChecked_;                        \
+  sCheckbox##nElemId.colCheck = colCheck_;                        \
+  sCheckbox##nElemId.nStyle = nStyle_;                            \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      true,                                                       \
+      GSLC_TYPEX_CHECKBOX,                                        \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,true,true,false,true,                    \
+      GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sCheckbox##nElemId),                               \
+      NULL,                                                       \
+      &gslc_ElemXCheckboxDraw,                                    \
+      &gslc_ElemXCheckboxTouch,                                   \
+      NULL,                                                       \
+      GSLC_REDRAW_NONE,                                           \
+      false,                                                      \
+  };                                                              \
+  gslc_ElemAdd(pGui_,nPage,(gslc_tsElem*)&sElem##nElemId,GSLC_ELEMREF_SRC_PROG);
+
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a continuation of #25 but merged against the latest codebase
- A number of additional features have been added for Flash-based elements including button glow and checkboxes
- `arduino_min` examples have been revised to take advantage of the significant RAM savings

Internal breaking changes:
- `FindElemByCoord()` has added the `pGui` parameter
