### PR TITLE
Remove padding byte from gslc_tsColor

### DIFF
--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -400,7 +400,6 @@ typedef struct gslc_tsColor {
   uint8_t r;      ///< RGB red value
   uint8_t g;      ///< RGB green value
   uint8_t b;      ///< RGB blue value
-  uint8_t unused; ///< Unused value to pad structure
 } gslc_tsColor;
 
 /// Event structure


### PR DESCRIPTION
The padding byte leads to tons of compiler warnings because the color
defines don't include them. In addition I cannot conceive of there being
any benefit to adding the padding byte. If the compiler thinks it helps
then it is free to add the padding itself.

I'm happy to learn something new here, but this is my reasoning:

The only case where padding might be beneficial is in arrays of
gslc_tsColor, where you can quickly read an entire pixel value in a
single, aligned, 32-bit read. 32-bit cores typically have caches,
though, and the decrease in cache hits (25% of the data is wasted)
almost certainly offsets this benefit.

16-bit cores could have a similar benefit, but they typically have so
little RAM that it's preferable to pack the data as dense as possible.

8-bit cores don't benefit at all, but still suffer the RAM penalty.