### PR TITLE
Added back common config.h file

### DIFF
--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -52,16 +52,8 @@ extern "C" {
 // Configuration
 // -----------------------------------------------------------------------
 
-// Import user configuration depending on device type
-#if defined(__linux__)
-  #include "GUIslice_config_linux.h"
-#elif defined(__AVR__) || defined(ARDUINO_SAMD_ZERO)
-  #include "GUIslice_config_ard.h"
-#elif defined(ESP8266) || defined(ESP32)
-  #include "GUIslice_config_esp.h"
-#else
-  #error "Unknown device platform"
-#endif
+// Import configuration ( which will import a sub-config depending on device type)
+#include "GUIslice_config.h"
 
 // Provide an alias for PROGMEM so that we can disable
 // it on devices that don't use it when defining constant

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -1,0 +1,64 @@
+#ifndef _GUISLICE_CONFIG_H_
+#define _GUISLICE_CONFIG_H_
+
+// =======================================================================
+// GUIslice library (user configuration) for Arduino / Cortex-M0
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2018 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+
+// =======================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
+//   specific to board and display combinations
+// =======================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// -----------------------------------------------------------------------------------------
+
+// Import user configuration depending on device type
+#if defined(__linux__)
+  #include "GUIslice_config_linux.h"
+#elif defined(__AVR__) || defined(ARDUINO_SAMD_ZERO)
+  #include "GUIslice_config_ard.h"
+#elif defined(ESP8266) || defined(ESP32)
+  #include "GUIslice_config_esp.h"
+#else
+  #error "Unknown device platform"
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_H_

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -1,5 +1,5 @@
-#ifndef _GUISLICE_CONFIG_H_
-#define _GUISLICE_CONFIG_H_
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
 
 // =======================================================================
 // GUIslice library (user configuration) for Arduino / Cortex-M0
@@ -245,4 +245,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-#endif // _GUISLICE_CONFIG_H_
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/src/GUIslice_config_esp.h
+++ b/src/GUIslice_config_esp.h
@@ -1,5 +1,5 @@
-#ifndef _GUISLICE_CONFIG_H_
-#define _GUISLICE_CONFIG_H_
+#ifndef _GUISLICE_CONFIG_ESP_H_
+#define _GUISLICE_CONFIG_ESP_H_
 
 // =======================================================================
 // GUIslice library (user configuration) for ESP8266 / ESP32
@@ -224,4 +224,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-#endif // _GUISLICE_CONFIG_H_
+#endif // _GUISLICE_CONFIG_ESP_H_

--- a/src/GUIslice_config_linux.h
+++ b/src/GUIslice_config_linux.h
@@ -1,5 +1,5 @@
-#ifndef _GUISLICE_CONFIG_H_
-#define _GUISLICE_CONFIG_H_
+#ifndef _GUISLICE_CONFIG_LINUX_H_
+#define _GUISLICE_CONFIG_LINUX_H_
 
 // =======================================================================
 // GUIslice library (user configuration) for LINUX / Raspberry Pi / Beaglebone
@@ -170,4 +170,4 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-#endif // _GUISLICE_CONFIG_H_
+#endif // _GUISLICE_CONFIG_LINUX_H_


### PR DESCRIPTION
Added back common config.h file that in turn delegates to specific hardware config files.

This will make it easier for users that prefer to create their own customized GUIslice_config,h file, without requiring a change to the core GUIslice.h file.

