### PR TITLE
Fixed to include higher level GUIslice_config.h

### DIFF
--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -32,7 +32,7 @@
 
 // Compiler guard for requested driver
 #if defined (__AVR__) || defined(ARDUINO_SAMD_ZERO) || defined(ESP8266) || defined(ESP32)
-#include "GUIslice_config_ard.h" // Sets DRV_DISP_*
+#include "GUIslice_config.h" // Sets DRV_DISP_*
 #if defined(DRV_DISP_ADAGFX)
 
 // =======================================================================

--- a/src/GUIslice_drv_sdl.c
+++ b/src/GUIslice_drv_sdl.c
@@ -31,7 +31,7 @@
 
 // Compiler guard for requested driver
 #if defined(__linux__)
-#include "GUIslice_config_linux.h" // Sets DRV_DISP_*
+#include "GUIslice_config.h" // Sets DRV_DISP_*
 #if defined(DRV_DISP_SDL1) || defined(DRV_DISP_SDL2)
 
 // =======================================================================
@@ -1381,4 +1381,3 @@ int gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPre
 
 #endif // Compiler guard for requested driver
 #endif // __linux__
-

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -31,7 +31,7 @@
 
 // Compiler guard for requested driver
 #if defined(ESP8266) || defined(ESP32)
-#include "GUIslice_config_ard.h" // Sets DRV_DISP_*
+#include "GUIslice_config.h" // Sets DRV_DISP_*
 #if defined(DRV_DISP_TFT_ESPI)
 
 // =======================================================================


### PR DESCRIPTION
The driver source files were fixed so that they include the higher level GUIslice_config.h instead of the platform specific includes.  The main config.h file will select which specific platform config .h needs to be included.

This makes it easier to have a single master GUIslice_config.h if a user does not want to use or maintain the provided platform specific files.