### PR TITLE
Add support for STM32 with Adafruit_GFX_AS

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -101,7 +101,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   pGui->nDispH          = 0;
   pGui->nDispDepth      = 0;
 
-  #if defined( DRV_DISP_ADAGFX ) || defined( DRV_DISP_TFT_ESPI ) || defined( DRV_DISP_M5STACK )
+  #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS) || defined(DRV_DISP_TFT_ESPI) || defined(DRV_DISP_M5STACK)
     pGui->nRotation		= GSLC_ROTATE;
     pGui->nSwapXY		= ADATOUCH_SWAP_XY;
     pGui->nFlipX		= ADATOUCH_FLIP_X;

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -7,7 +7,7 @@
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 //
-// - Version 0.10.0   (2018/02/03)
+// - Version 0.10.0   (2018/02/12)
 // =======================================================================
 //
 // The MIT License
@@ -591,7 +591,7 @@ typedef struct {
   uint16_t            nDispH;           ///< Height of the display (pixels)
   uint8_t             nDispDepth;       ///< Bit depth of display (bits per pixel)
 
-  #if defined( DRV_DISP_ADAGFX ) || defined( DRV_DISP_TFT_ESPI ) || defined( DRV_DISP_M5STACK )
+  #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS) || defined(DRV_DISP_TFT_ESPI) || defined(DRV_DISP_M5STACK)
     uint8_t           nRotation;       ///< Adafruit GFX Rotation of display
     uint8_t           nSwapXY;         ///< Adafruit GFX Touch Swap x and y axes
     uint8_t           nFlipX;          ///< Adafruit GFX Touch Flip x axis

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -48,7 +48,7 @@ extern "C" {
   #include "GUIslice_config_ard.h"
 #elif defined(NRF52)
   #include "GUIslice_config_ard.h"
-#elif defined(ARDUINO_STM32_FEATHER)
+#elif defined(ARDUINO_STM32_FEATHER) || defined(__STM32F1__)
   #include "GUIslice_config_ard.h"
 #else
   #error "Unknown device platform"

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -70,6 +70,7 @@ extern "C" {
   // --------------------------------------------------------------
   // STM32:
   //  #define DRV_DISP_ADAGFX           // Adafruit-GFX library
+  //  #define DRV_DISP_ADAGFX_AS        // Adafruit-GFX-AS library
   // --------------------------------------------------------------
 
 
@@ -106,7 +107,16 @@ extern "C" {
   //#define DRV_DISP_ADAGFX_HX8357        // Adafruit HX8357
   //#define DRV_DISP_ADAGFX_PCD8544       // Adafruit PCD8544
 
+#elif defined(DRV_DISP_ADAGFX_AS)
 
+  // The Adafruit-GFX-AS library supports a number of displays
+  // - Select a display sub-type by uncommenting one of the
+  //   following DRV_DISP_ADAGFX_* lines
+  #define DRV_DISP_ADAGFX_ILI9341_STM     // Adafruit ILI9341 (STM32 version)
+
+#endif
+
+#if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
   // For Adafruit-GFX drivers, define pin connections
   // - Define general pins (modify these example pin assignments to match your board)
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples

--- a/src/GUIslice_drv.h
+++ b/src/GUIslice_drv.h
@@ -45,7 +45,7 @@ extern "C" {
   #include "GUIslice_drv_sdl.h"
 #elif defined(DRV_DISP_SDL2)
   #include "GUIslice_drv_sdl.h"
-#elif defined(DRV_DISP_ADAGFX)
+#elif defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
   #include "GUIslice_drv_adagfx.h"
 #elif defined(DRV_DISP_TFT_ESPI)
   #include "GUIslice_drv_tft_espi.h"

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -481,7 +481,7 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 
 void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 {
-  #if defined(DRV_DISP_ADAGFX_ILI9341)|| defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
+  #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ILI9341_STM) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
     // Nothing to do as we're not double-buffered
 
   #elif defined(DRV_DISP_ADAGFX_SSD1306)
@@ -1187,7 +1187,7 @@ uint16_t gslc_DrvAdaptColorToRaw(gslc_tsColor nCol)
 {
   uint16_t nColRaw = 0;
 
-  #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
+  #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ILI9341_STM) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
     // RGB565
     nColRaw |= (((nCol.r & 0xF8) >> 3) << 11); // Mask: 1111 1000 0000 0000
     nColRaw |= (((nCol.g & 0xFC) >> 2) <<  5); // Mask: 0000 0111 1110 0000

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -32,7 +32,7 @@
 
 // Compiler guard for requested driver
 #include "GUIslice_config.h" // Sets DRV_DISP_*
-#if defined(DRV_DISP_ADAGFX)
+#if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
 
 // =======================================================================
 // Driver Layer for Adafruit-GFX
@@ -43,8 +43,12 @@
 
 #include <stdio.h>
 
-#include <Adafruit_GFX.h>
-#include <gfxfont.h>
+#if defined(DRV_DISP_ADAGFX)
+  #include <Adafruit_GFX.h>
+  #include <gfxfont.h>
+#elif defined(DRV_DISP_ADAGFX_AS)
+  #include <Adafruit_GFX_AS.h>
+#endif
 
 #if defined(DRV_DISP_ADAGFX_ILI9341)
   #include <Adafruit_ILI9341.h>
@@ -54,6 +58,12 @@
   #include <SPI.h>
 #elif defined(DRV_DISP_ADAGFX_ILI9341_8BIT)
   #include <Adafruit_TFTLCD.h>
+  #if (GSLC_SD_EN)
+    #include <SD.h>   // Include support for SD card access
+  #endif
+  #include <SPI.h>
+#elif defined(DRV_DISP_ADAGFX_ILI9341_STM)
+  #include <Adafruit_ILI9341_STM.h>
   #if (GSLC_SD_EN)
     #include <SD.h>   // Include support for SD card access
   #endif
@@ -110,6 +120,14 @@ extern "C" {
   Adafruit_TFTLCD m_disp = Adafruit_TFTLCD (ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_WR, ADAGFX_PIN_RD, ADAGFX_PIN_RST);
 
 // ------------------------------------------------------------------------
+#elif defined(DRV_DISP_ADAGFX_ILI9341_STM)
+  #if (ADAGFX_SPI_HW) // Use hardware SPI or software SPI (with custom pins)
+    Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_RST);
+  #else
+    Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_MOSI, ADAGFX_PIN_CLK, ADAGFX_PIN_RST, ADAGFX_PIN_MISO);
+  #endif
+
+    // ------------------------------------------------------------------------
 #elif defined(DRV_DISP_ADAGFX_SSD1306)
   #if (ADAGFX_SPI_HW) // Use hardware SPI or software SPI (with custom pins)
     Adafruit_SSD1306 m_disp(ADAGFX_PIN_DC, ADAGFX_PIN_RST, ADAGFX_PIN_CS);
@@ -384,18 +402,22 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 {
   uint16_t  nTxtLen   = 0;
   uint16_t  nTxtScale = pFont->nSize;
+  char*     pTmpStr   = NULL;
+
+#if defined(DRV_DISP_ADAGFX)
   m_disp.setFont((const GFXfont *)pFont->pvFont);
+#endif
   m_disp.setTextSize(nTxtScale);
 
   if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_RAM) {
-    m_disp.getTextBounds((char*)pStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+    pTmpStr = (char*)pStr;
   } else if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_PROG) {
 #if (GSLC_USE_PROGMEM)
     nTxtLen = strlen_P(pStr);
     char tempStr[nTxtLen+1];
     strncpy_P(tempStr,pStr,nTxtLen);
     tempStr[nTxtLen] = '\0';  // Force termination
-    m_disp.getTextBounds(tempStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+    pTmpStr = tempStr;
 #else
     // NOTE: Should not get here
     // - The text string has been marked as being stored in
@@ -403,10 +425,23 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
     //   the current device does not support the PROGMEM
     //   methodology.
     // - Degrade back to using SRAM directly
-    m_disp.getTextBounds((char*)pStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+    pTmpStr = (char*)pStr;
 #endif
   }
+
+  // Fetch the text bounds
+#if defined(DRV_DISP_ADAGFX)
+  m_disp.getTextBounds(pTmpStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+#elif defined(DRV_DISP_ADAGFX_AS)
+  // NOTE: Adafruit-GFX-AS is based on an older version of Adafruit-GFX
+  //       and doesn't provide the getTextBounds() API
+  *pnTxtSzW = m_disp.getTextWidth(pTmpStr,nTxtScale);
+  *pnTxtSzH = m_disp.getTextHeight(nTxtScale);
+#endif
+
+#if defined(DRV_DISP_ADAGFX)
   m_disp.setFont();
+#endif
   return true;
 }
 
@@ -414,7 +449,9 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 {
   uint16_t nTxtScale = pFont->nSize;
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
+#if defined(DRV_DISP_ADAGFX)
   m_disp.setFont((const GFXfont *)pFont->pvFont);
+#endif
   m_disp.setTextColor(nColRaw);
   m_disp.setCursor(nTxtX,nTxtY);
   m_disp.setTextSize(nTxtScale);
@@ -430,7 +467,9 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
     }
     m_disp.println();
   }
+#if defined(DRV_DISP_ADAGFX)
    m_disp.setFont();
+#endif
   return true;
 }
 

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -437,11 +437,14 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 #elif defined(DRV_DISP_ADAGFX_AS)
   // NOTE: Adafruit-GFX-AS is based on an older version of Adafruit-GFX
   //       and doesn't provide the getTextBounds() API.
-  //       A nFontId of 1 is passed to indicate that the default
+  //       A nFontId of 0 is passed to indicate that the default
   //       Adafruit font (5x7) will be used.
   // TODO: Support custom fonts in Adafruit-GFX-AS
-  *pnTxtSzW = m_disp.getTextWidth(pTmpStr,1);
-  *pnTxtSzH = m_disp.getTextHeight(1);
+  *pnTxtSzW = m_disp.getTextWidth(pTmpStr,0);
+  *pnTxtSzH = m_disp.getTextHeight(pTmpStr,0);
+  // No baseline offset supported
+  *pnTxtX = 0;
+  *pnTxtY = 0;
 #endif
 
 #if defined(DRV_DISP_ADAGFX)

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -436,9 +436,12 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
   m_disp.getTextBounds(pTmpStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
 #elif defined(DRV_DISP_ADAGFX_AS)
   // NOTE: Adafruit-GFX-AS is based on an older version of Adafruit-GFX
-  //       and doesn't provide the getTextBounds() API
-  *pnTxtSzW = m_disp.getTextWidth(pTmpStr,nTxtScale);
-  *pnTxtSzH = m_disp.getTextHeight(nTxtScale);
+  //       and doesn't provide the getTextBounds() API.
+  //       A nFontId of 1 is passed to indicate that the default
+  //       Adafruit font (5x7) will be used.
+  // TODO: Support custom fonts in Adafruit-GFX-AS
+  *pnTxtSzW = m_disp.getTextWidth(pTmpStr,1);
+  *pnTxtSzH = m_disp.getTextHeight(1);
 #endif
 
 #if defined(DRV_DISP_ADAGFX)

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -122,7 +122,9 @@ extern "C" {
 // ------------------------------------------------------------------------
 #elif defined(DRV_DISP_ADAGFX_ILI9341_STM)
   #if (ADAGFX_SPI_HW) // Use hardware SPI or software SPI (with custom pins)
-    Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_RST);
+    //Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_RST);
+    // TODO: Resolve why PIN_RST=-1 doesn't give same behavior as 2-param function variant
+    Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC);
   #else
     Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_MOSI, ADAGFX_PIN_CLK, ADAGFX_PIN_RST, ADAGFX_PIN_MISO);
   #endif
@@ -215,7 +217,7 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
     // image in the controller graphics RAM
     pGui->bRedrawPartialEn = true;
 
-    #if defined(DRV_DISP_ADAGFX_ILI9341)
+#if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_STM)
       m_disp.begin();
 
       m_disp.readcommand8(ILI9341_RDMODE);


### PR DESCRIPTION
- Preliminary support for **STM32** (F1) with *Adafruit_GFX_AS* and *Adafruit_ILI9341_STM*
- Mode can be selected via `DRV_DISP_ADAGFX_AS` and `DRV_DISP_ADAGFX_ILI9341_STM` in `GUIslice_config_ard.h`
- The [Arduino_STM32](https://github.com/rogerclarkmelbourne/Arduino_STM32) library provides an Arduino core for the **STM32** class of devices (including generic **STM32F103**). Hardware-optimized versions of *Adafruit_GFX* and *Adafruit_ILI9341* were bundled with the `Arduino_STM32` library (named *Adafruit_GFX_AS* and *Adafruit_ILI9341_STM*)
- This release supports the original *Adafruit_GFX* font. The extra fonts available in *Adafruit_GFX_AS* (eg. via its `LOAD_FONT*` definitions) will be supported in a future update.


Important Note:
- Support for *Adafruit_GFX_AS* is dependent upon a pending addition to the *Arduino_STM32* library (awaiting [pull request](https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/443) merge) to add two text dimension functions since the *Arduino_STM32* bundled version of *GFX* is a couple years old. The branch containing the pending update is currently available in the [ImpulseAdventure getText branch](https://github.com/ImpulseAdventure/Arduino_STM32/tree/getText).
- In the case of genuine **Adafruit Feather STM32** devices, support in *GUIslice* should already be available using the official *Adafruit_GFX* library (selected via `DRV_DISP_ADAGFX`)
