### PR TITLE
Add Arduino_STM32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - *Widgets*: text, images, buttons, checkboxes, radio buttons, sliders,
   radial controls, scrolling textbox / terminal, graphs, etc. plus extensions and multiple pages.
 - *Platform-independent GUI core currently supports*: SDL1.2, SDL2.0, Adafruit-GFX, TFT_eSPI
-- *Devices*: Raspberry Pi, Arduino, ESP8266 / NodeMCU, ESP32, Feather M0 (Cortex-M0), nRF52 (Cortex-M4F), LINUX, Beaglebone Black, M5Stack, (soon STM32)
+- *Devices*: Raspberry Pi, Arduino, ESP8266 / NodeMCU, ESP32, Feather M0 (Cortex-M0), nRF52 (Cortex-M4F), LINUX, Beaglebone Black, M5Stack, STM32
 - *Typical displays*: PiTFT, Waveshare, Adafruit TFT 3.5" / 2.8" / 2.4" / 2.2" / 1.44", OLED 0.96", 4D Cape
 - *Display drivers include*: ILI9341, ST7735, SSD1306, HX8357
 - *Touchscreen control including*: STMPE610, FT6206, XPT2046, tslib

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -44,7 +44,7 @@
 #include <stdio.h>
 
 #ifdef DBG_FRAME_RATE
-	#include <time.h> // for FrameRate reporting
+  #include <time.h> // for FrameRate reporting
 #endif
 
 #if (GSLC_USE_FLOAT)
@@ -101,7 +101,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   pGui->nDispH          = 0;
   pGui->nDispDepth      = 0;
 
-  #if defined( DRV_DISP_ADAGFX ) || defined( DRV_DISP_TFT_ESPI ) || defined( DRV_DISP_M5STACK )
+  #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS) || defined(DRV_DISP_TFT_ESPI) || defined(DRV_DISP_M5STACK)
     pGui->nRotation		= GSLC_ROTATE;
     pGui->nSwapXY		= ADATOUCH_SWAP_XY;
     pGui->nFlipX		= ADATOUCH_FLIP_X;

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -591,7 +591,7 @@ typedef struct {
   uint16_t            nDispH;           ///< Height of the display (pixels)
   uint8_t             nDispDepth;       ///< Bit depth of display (bits per pixel)
 
-  #if defined( DRV_DISP_ADAGFX ) || defined( DRV_DISP_TFT_ESPI ) || defined( DRV_DISP_M5STACK )
+  #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS) || defined(DRV_DISP_TFT_ESPI) || defined(DRV_DISP_M5STACK)
     uint8_t           nRotation;       ///< Adafruit GFX Rotation of display
     uint8_t           nSwapXY;         ///< Adafruit GFX Touch Swap x and y axes
     uint8_t           nFlipX;          ///< Adafruit GFX Touch Flip x axis

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -48,7 +48,7 @@ extern "C" {
   #include "GUIslice_config_ard.h"
 #elif defined(NRF52)
   #include "GUIslice_config_ard.h"
-#elif defined(ARDUINO_STM32_FEATHER)
+#elif defined(ARDUINO_STM32_FEATHER) || defined(__STM32F1__)
   #include "GUIslice_config_ard.h"
 #else
   #error "Unknown device platform"

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -70,6 +70,7 @@ extern "C" {
   // --------------------------------------------------------------
   // STM32:
   //  #define DRV_DISP_ADAGFX           // Adafruit-GFX library
+  //  #define DRV_DISP_ADAGFX_AS        // Adafruit-GFX-AS library
   // --------------------------------------------------------------
 
 
@@ -106,7 +107,16 @@ extern "C" {
   //#define DRV_DISP_ADAGFX_HX8357        // Adafruit HX8357
   //#define DRV_DISP_ADAGFX_PCD8544       // Adafruit PCD8544
 
+#elif defined(DRV_DISP_ADAGFX_AS)
 
+  // The Adafruit-GFX-AS library supports a number of displays
+  // - Select a display sub-type by uncommenting one of the
+  //   following DRV_DISP_ADAGFX_* lines
+  #define DRV_DISP_ADAGFX_ILI9341_STM     // Adafruit ILI9341 (STM32 version)
+
+#endif
+
+#if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
   // For Adafruit-GFX drivers, define pin connections
   // - Define general pins (modify these example pin assignments to match your board)
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples

--- a/src/GUIslice_drv.h
+++ b/src/GUIslice_drv.h
@@ -45,7 +45,7 @@ extern "C" {
   #include "GUIslice_drv_sdl.h"
 #elif defined(DRV_DISP_SDL2)
   #include "GUIslice_drv_sdl.h"
-#elif defined(DRV_DISP_ADAGFX)
+#elif defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
   #include "GUIslice_drv_adagfx.h"
 #elif defined(DRV_DISP_TFT_ESPI)
   #include "GUIslice_drv_tft_espi.h"

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -32,7 +32,7 @@
 
 // Compiler guard for requested driver
 #include "GUIslice_config.h" // Sets DRV_DISP_*
-#if defined(DRV_DISP_ADAGFX)
+#if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
 
 // =======================================================================
 // Driver Layer for Adafruit-GFX
@@ -43,8 +43,12 @@
 
 #include <stdio.h>
 
-#include <Adafruit_GFX.h>
-#include <gfxfont.h>
+#if defined(DRV_DISP_ADAGFX)
+  #include <Adafruit_GFX.h>
+  #include <gfxfont.h>
+#elif defined(DRV_DISP_ADAGFX_AS)
+  #include <Adafruit_GFX_AS.h>
+#endif
 
 #if defined(DRV_DISP_ADAGFX_ILI9341)
   #include <Adafruit_ILI9341.h>
@@ -54,6 +58,12 @@
   #include <SPI.h>
 #elif defined(DRV_DISP_ADAGFX_ILI9341_8BIT)
   #include <Adafruit_TFTLCD.h>
+  #if (GSLC_SD_EN)
+    #include <SD.h>   // Include support for SD card access
+  #endif
+  #include <SPI.h>
+#elif defined(DRV_DISP_ADAGFX_ILI9341_STM)
+  #include <Adafruit_ILI9341_STM.h>
   #if (GSLC_SD_EN)
     #include <SD.h>   // Include support for SD card access
   #endif
@@ -108,6 +118,16 @@ extern "C" {
 // ------------------------------------------------------------------------
 #elif defined(DRV_DISP_ADAGFX_ILI9341_8BIT)
   Adafruit_TFTLCD m_disp = Adafruit_TFTLCD (ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_WR, ADAGFX_PIN_RD, ADAGFX_PIN_RST);
+
+// ------------------------------------------------------------------------
+#elif defined(DRV_DISP_ADAGFX_ILI9341_STM)
+  #if (ADAGFX_SPI_HW) // Use hardware SPI or software SPI (with custom pins)
+    //Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_RST);
+    // TODO: Resolve why PIN_RST=-1 doesn't give same behavior as 2-param function variant
+    Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC);
+  #else
+    Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_MOSI, ADAGFX_PIN_CLK, ADAGFX_PIN_RST, ADAGFX_PIN_MISO);
+  #endif
 
 // ------------------------------------------------------------------------
 #elif defined(DRV_DISP_ADAGFX_SSD1306)
@@ -197,7 +217,7 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
     // image in the controller graphics RAM
     pGui->bRedrawPartialEn = true;
 
-    #if defined(DRV_DISP_ADAGFX_ILI9341)
+    #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_STM)
       m_disp.begin();
 
       m_disp.readcommand8(ILI9341_RDMODE);
@@ -384,18 +404,20 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 {
   uint16_t  nTxtLen   = 0;
   uint16_t  nTxtScale = pFont->nSize;
+  char*     pTmpStr   = NULL;
+
   m_disp.setFont((const GFXfont *)pFont->pvFont);
   m_disp.setTextSize(nTxtScale);
 
   if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_RAM) {
-    m_disp.getTextBounds((char*)pStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+    pTmpStr = (char*)pStr;
   } else if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_PROG) {
 #if (GSLC_USE_PROGMEM)
     nTxtLen = strlen_P(pStr);
     char tempStr[nTxtLen+1];
     strncpy_P(tempStr,pStr,nTxtLen);
     tempStr[nTxtLen] = '\0';  // Force termination
-    m_disp.getTextBounds(tempStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+    pTmpStr = tempStr;
 #else
     // NOTE: Should not get here
     // - The text string has been marked as being stored in
@@ -403,9 +425,12 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
     //   the current device does not support the PROGMEM
     //   methodology.
     // - Degrade back to using SRAM directly
-    m_disp.getTextBounds((char*)pStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+    pTmpStr = (char*)pStr;
 #endif
   }
+  // Fetch the text bounds
+  m_disp.getTextBounds(pTmpStr,0,0,pnTxtX,pnTxtY,pnTxtSzW,pnTxtSzH);
+
   m_disp.setFont();
   return true;
 }
@@ -469,7 +494,7 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 
 void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 {
-  #if defined(DRV_DISP_ADAGFX_ILI9341)|| defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
+  #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ILI9341_STM) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
     // Nothing to do as we're not double-buffered
 
   #elif defined(DRV_DISP_ADAGFX_SSD1306)
@@ -1175,7 +1200,7 @@ uint16_t gslc_DrvAdaptColorToRaw(gslc_tsColor nCol)
 {
   uint16_t nColRaw = 0;
 
-  #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
+  #if defined(DRV_DISP_ADAGFX_ILI9341) || defined(DRV_DISP_ADAGFX_ILI9341_8BIT) || defined(DRV_DISP_ADAGFX_ILI9341_STM) || defined(DRV_DISP_ADAGFX_ST7735) || defined(DRV_DISP_ADAGFX_HX8357)
     // RGB565
     nColRaw |= (((nCol.r & 0xF8) >> 3) << 11); // Mask: 1111 1000 0000 0000
     nColRaw |= (((nCol.g & 0xFC) >> 2) <<  5); // Mask: 0000 0111 1110 0000


### PR DESCRIPTION
- Preliminary support for **STM32** (F1) with *Adafruit_GFX_AS* and *Adafruit_ILI9341_STM*
- Mode can be selected via `DRV_DISP_ADAGFX_AS` and `DRV_DISP_ADAGFX_ILI9341_STM` in `GUIslice_config_ard.h`
- The [Arduino_STM32](https://github.com/rogerclarkmelbourne/Arduino_STM32) library provides an Arduino core for the **STM32** class of devices (including generic **STM32F103**). Hardware-optimized versions of *Adafruit_GFX* and *Adafruit_ILI9341* were bundled with the `Arduino_STM32` library (named *Adafruit_GFX_AS* and *Adafruit_ILI9341_STM*)
- This is a revised PR (replacing #39) as The upstream Arduino_STM32 library now incorporates better support for the latest GFX routines.

Important Note:
- Support for *Adafruit_GFX_AS* requires a recent version of the *Arduino_STM32* library (after April 8, 2018, which integrated [pull request 461](https://github.com/rogerclarkmelbourne/Arduino_STM32/pull/461).
- In the case of genuine **Adafruit Feather STM32** devices, support in *GUIslice* should already be available using the official *Adafruit_GFX* library (selected via `DRV_DISP_ADAGFX`)