### PR TITLE
Adds antialiasing support and font file loadingsupport to TFT_eSPI

### DIFF
--- a/arduino/gslc_ex11_ard/gslc_ex11_ard.ino
+++ b/arduino/gslc_ex11_ard/gslc_ex11_ard.ino
@@ -1,0 +1,123 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 11 (ESP32):
+//   - Accept touch input, text button, text box
+//   - Antialiased Fonts
+//   - NOTE: This is Example demonstrates text antialiasing with the TFT_eSPI library.
+//     The font which can be found in the TFT_eSPI source in the libraries
+//     examples/Smooth Fonts/Print_Smooth_Font/data folder has to be uploaded to SPIFFS first
+
+// Font file is stored in SPIFFS
+#define FS_NO_GLOBALS
+#include <SPIFFS.h>
+
+#include <stdint.h>
+#include <TouchScreen.h>
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN};
+enum {E_ELEM_BOX,E_ELEM_BTN_QUIT, E_ELEM_TEXT};
+enum {E_FONT_BTN};
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_FONT            1
+#define MAX_ELEM_PG_MAIN    3
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui,void *pvElem,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+void setup()
+{
+
+  bool            bOk = true;
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  analogReadResolution(10);
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+
+  // Init SPIFFS for Font Loading
+  if (!SPIFFS.begin()) {
+    Serial.println("SPIFFS initialisation failed!");
+    while (1) yield(); // Stay here twiddling thumbs waiting
+  }
+
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_FNAME,"Final-Frontier-28",28)) { return; }
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,20,300,200});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
+    (gslc_tsRect){120,40,80,40},(char*)"Quit",0,E_FONT_BTN,&CbBtnQuit);
+
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_ELEM_TEXT,E_PG_MAIN,
+    (gslc_tsRect){30,80,260,120},(char*)"Antialias Demo Text",0,E_FONT_BTN);
+
+
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+}
+
+void loop()
+{
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) { }
+  }
+}
+

--- a/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
+++ b/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
@@ -3,7 +3,7 @@
 // - Calvin Hass
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
-// - Example 11 (ESP32):
+// - Example 17 (ESP32):
 //   - Accept touch input, text button, text box
 //   - Antialiased Fonts
 //   - NOTE: This is Example demonstrates text antialiasing with the TFT_eSPI library.

--- a/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
+++ b/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
@@ -11,11 +11,16 @@
 //     examples/Smooth Fonts/Print_Smooth_Font/data folder has to be uploaded to SPIFFS first
 
 // Font file is stored in SPIFFS
+
+#if !defined(ESP8266) && !defined(ESP32)
+  #error "This example only works on ESP8266 / ESP32"
+#endif
+
+
 #define FS_NO_GLOBALS
 #include <SPIFFS.h>
 
 #include <stdint.h>
-#include <TouchScreen.h>
 #include "GUIslice.h"
 #include "GUIslice_ex.h"
 #include "GUIslice_drv.h"
@@ -24,15 +29,15 @@
 
 // Enumerations for pages, elements, fonts, images
 enum {E_PG_MAIN};
-enum {E_ELEM_BOX,E_ELEM_BTN_QUIT, E_ELEM_TEXT};
-enum {E_FONT_BTN};
+enum {E_ELEM_BOX, E_ELEM_BTN_QUIT1, E_ELEM_BTN_QUIT2, E_ELEM_TEXT};
+enum {E_FONT_BTN, E_FONT_AATEXT};
 
 bool    m_bQuit = false;
 
 // Instantiate the GUI
 #define MAX_PAGE            1
-#define MAX_FONT            1
-#define MAX_ELEM_PG_MAIN    3
+#define MAX_FONT            2
+#define MAX_ELEM_PG_MAIN    4
 
 gslc_tsGui                  m_gui;
 gslc_tsDriver               m_drv;
@@ -77,7 +82,8 @@ void setup()
   if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
 
   // Load Fonts
-  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_FNAME,"Final-Frontier-28",28)) { return; }
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,NULL,3)) { return; }
+  if (!gslc_FontAdd(&m_gui,E_FONT_AATEXT,GSLC_FONTREF_FNAME,"Final-Frontier-28",28)) { return; }
 
   // -----------------------------------
   // Create page elements
@@ -91,11 +97,14 @@ void setup()
   gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
 
   // Create Quit button with text label
-  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT1,E_PG_MAIN,
     (gslc_tsRect){120,40,80,40},(char*)"Quit",0,E_FONT_BTN,&CbBtnQuit);
 
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT2,E_PG_MAIN,
+    (gslc_tsRect){120,100,80,40},(char*)"Quit",0,E_FONT_AATEXT,&CbBtnQuit);
+
   pElemRef = gslc_ElemCreateTxt(&m_gui,E_ELEM_TEXT,E_PG_MAIN,
-    (gslc_tsRect){30,80,260,120},(char*)"Antialias Demo Text",0,E_FONT_BTN);
+    (gslc_tsRect){30,160,260,40},(char*)"Antialias Demo Text",0,E_FONT_AATEXT);
 
 
 
@@ -120,4 +129,3 @@ void loop()
     while (1) { }
   }
 }
-

--- a/arduino/gslc_ex19_ard/gslc_ex19_ard.ino
+++ b/arduino/gslc_ex19_ard/gslc_ex19_ard.ino
@@ -1,0 +1,131 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 19 (ESP8266/ESP32):
+//   - Accept touch input, text button, text box
+//   - Antialiased Fonts
+//   - NOTE: This is Example demonstrates text antialiasing with the TFT_eSPI library.
+//     The font which can be found in the TFT_eSPI source in the libraries
+//     examples/Smooth Fonts/Print_Smooth_Font/data folder has to be uploaded to SPIFFS first
+
+// Font file is stored in SPIFFS
+
+#if !defined(ESP8266) && !defined(ESP32)
+  #error "This example only works on ESP8266 / ESP32"
+#endif
+
+
+#define FS_NO_GLOBALS
+#include <SPIFFS.h>
+
+#include <stdint.h>
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN};
+enum {E_ELEM_BOX, E_ELEM_BTN_QUIT1, E_ELEM_BTN_QUIT2, E_ELEM_TEXT};
+enum {E_FONT_BTN, E_FONT_AATEXT};
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_FONT            2
+#define MAX_ELEM_PG_MAIN    4
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui,void *pvElem,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+void setup()
+{
+
+  bool            bOk = true;
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  analogReadResolution(10);
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+
+  // Init SPIFFS for Font Loading
+  if (!SPIFFS.begin()) {
+    Serial.println("SPIFFS initialisation failed!");
+    while (1) yield(); // Stay here twiddling thumbs waiting
+  }
+
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,NULL,3)) { return; }
+  if (!gslc_FontAdd(&m_gui,E_FONT_AATEXT,GSLC_FONTREF_FNAME,"Final-Frontier-28",28)) { return; }
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,20,300,200});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT1,E_PG_MAIN,
+    (gslc_tsRect){120,40,80,40},(char*)"Quit",0,E_FONT_BTN,&CbBtnQuit);
+
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT2,E_PG_MAIN,
+    (gslc_tsRect){120,100,80,40},(char*)"Quit",0,E_FONT_AATEXT,&CbBtnQuit);
+
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_ELEM_TEXT,E_PG_MAIN,
+    (gslc_tsRect){30,160,260,40},(char*)"Antialias Demo Text",0,E_FONT_AATEXT);
+
+
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+}
+
+void loop()
+{
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) { }
+  }
+}

--- a/arduino/gslc_ex19_ard/gslc_ex19_ard.ino
+++ b/arduino/gslc_ex19_ard/gslc_ex19_ard.ino
@@ -8,7 +8,19 @@
 //   - Antialiased Fonts
 //   - NOTE: This is Example demonstrates text antialiasing with the TFT_eSPI library.
 //     The font which can be found in the TFT_eSPI source in the libraries
-//     examples/Smooth Fonts/Print_Smooth_Font/data folder has to be uploaded to SPIFFS first
+//     examples/Smooth Fonts/Print_Smooth_Font/data folder has to be uploaded to SPIFFS first.
+//     Instructions from Bodmer/TFT_eSPI:
+//       ---
+//       The fonts used are in the sketch data folder, press Ctrl+K to view.
+//       Upload the fonts and icons to SPIFFS (must set at least 1M for SPIFFS) using the
+//       "Tools"  "ESP8266 (or ESP32) Sketch Data Upload" menu option in the IDE.
+//       To add this option follow instructions here for the ESP8266:
+//       https://github.com/esp8266/arduino-esp8266fs-plugin
+//       or for the ESP32:
+//       https://github.com/me-no-dev/arduino-esp32fs-plugin
+//       Close the IDE and open again to see the new menu option.
+//       ---
+//
 
 // Font file is stored in SPIFFS
 
@@ -17,8 +29,14 @@
 #endif
 
 
+// Define FS_NO_GLOBALS ahead of FS include to enable
+// both SPIFFS and SD access.
 #define FS_NO_GLOBALS
-#include <SPIFFS.h>
+#include <FS.h>
+
+#if defined(ESP32)
+  #include <SPIFFS.h>
+#endif
 
 #include <stdint.h>
 #include "GUIslice.h"
@@ -65,18 +83,15 @@ void setup()
   gslc_tsElemRef* pElemRef = NULL;
 
   // Initialize debug output
-  analogReadResolution(10);
   Serial.begin(9600);
   gslc_InitDebug(&DebugOut);
   //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
-
 
   // Init SPIFFS for Font Loading
   if (!SPIFFS.begin()) {
     Serial.println("SPIFFS initialisation failed!");
     while (1) yield(); // Stay here twiddling thumbs waiting
   }
-
 
   // Initialize
   if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2109,7 +2109,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
   bGlowEn   = pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN; // Does the element support glow state?
   bGlowing  = gslc_ElemGetGlow(pGui,pElemRef); // Element should be glowing (if enabled)
   bGlowNow  = bGlowEn & bGlowing; // Element is currently glowing
-
+  gslc_tsColor colBg = GSLC_COL_BLACK;
 
   // --------------------------------------------------------------------------
   // Background
@@ -2128,8 +2128,10 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
   // - This also changes the fill color if selected and glow state is enabled
   if (pElem->nFeatures & GSLC_ELEM_FEA_FILL_EN) {
     if (bGlowEn && bGlowing) {
+      colBg = pElem->colElemFillGlow;
       gslc_DrawFillRect(pGui,rElemInner,pElem->colElemFillGlow);
     } else {
+      colBg = pElem->colElemFill;
       gslc_DrawFillRect(pGui,rElemInner,pElem->colElemFill);
     }
   } else {
@@ -2213,7 +2215,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
     int16_t nY1 = nY0 + nElemH - 2*nMargin;
 
     gslc_DrvDrawTxtAlign(pGui,nX0,nY0,nX1,nY1,pElem->eTxtAlign,pElem->pTxtFont,
-            pElem->pStrBuf,pElem->eTxtFlags,colTxt);
+            pElem->pStrBuf,pElem->eTxtFlags,colTxt,colBg);
 
 #else // DRV_OVERRIDE_TXT_ALIGN
 
@@ -2255,7 +2257,7 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
     nTxtY -= nTxtOffsetY;
 
     // Call the driver text rendering routine
-    gslc_DrvDrawTxt(pGui,nTxtX,nTxtY,pElem->pTxtFont,pElem->pStrBuf,pElem->eTxtFlags,colTxt);
+    gslc_DrvDrawTxt(pGui,nTxtX,nTxtY,pElem->pTxtFont,pElem->pStrBuf,pElem->eTxtFlags,colTxt,colBg);
 
 #endif // DRV_OVERRIDE_TXT_ALIGN
 

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -461,7 +461,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
   return true;
 }
 
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
 {
   uint16_t  nTxtScale = pFont->nSize;
   uint16_t  nColRaw = gslc_DrvAdaptColorToRaw(colTxt);

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -274,10 +274,11 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
 /// \param[in]  colTxt:      Color to draw text
+/// \param[in]  colBg:       unused in ADAGFX, defaults to black
 ///
 /// \return true if success, false if failure
 ///
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt,gslc_tsColor colBg);
 
 
 // -----------------------------------------------------------------------

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -249,7 +249,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 }
 
 bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int8_t eTxtAlign,
-        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
+        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
 {
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
   uint16_t nTxtScale = pFont->nSize;
@@ -301,7 +301,7 @@ bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,i
 
 // This method is not recommended for use with TFT_eSPI. DrvDrawTxtAlign()
 // should be used instead.
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
 {
   uint16_t nTxtScale = pFont->nSize;
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);

--- a/src/GUIslice_drv_m5stack.h
+++ b/src/GUIslice_drv_m5stack.h
@@ -276,10 +276,11 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
 /// \param[in]  colTxt:      Color to draw text
+/// \param[in]  colBg:       unused in m5stack, defaults to black
 ///
 /// \return true if success, false if failure
 ///
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt,gslc_tsColor colBg);
 
 ///
 /// Draw a text string in a bounding box using the specified alignment
@@ -294,11 +295,12 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
 /// \param[in]  colTxt:      Color to draw text
+/// \param[in]  colBg:       unused in m5stack, defaults to black
 ///
 /// \return true if success, false if failure
 ///
 bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int8_t eTxtAlign,
-        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
+        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt,gslc_tsColor colBg);
 
 // -----------------------------------------------------------------------
 // Screen Management Functions

--- a/src/GUIslice_drv_sdl.c
+++ b/src/GUIslice_drv_sdl.c
@@ -557,7 +557,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 }
 
 
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
 {
   if ((pGui == NULL) || (pFont == NULL)) {
     GSLC_DEBUG_PRINT("ERROR: DrvDrawTxt(%s) with NULL ptr\n","");

--- a/src/GUIslice_drv_sdl.h
+++ b/src/GUIslice_drv_sdl.h
@@ -300,10 +300,11 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
 /// \param[in]  colTxt:      Color to draw text
+/// \param[in]  colBg:       unused in SDL, defaults to black
 ///
 /// \return true if success, false if failure
 ///
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg);
 
 
 
@@ -651,4 +652,3 @@ int gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pnP
 }
 #endif // __cplusplus
 #endif // _GUISLICE_DRV_SDL_H_
-

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -260,11 +260,13 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
 
 const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType,const void* pvFontRef,uint16_t nFontSz)
 {
+#ifdef SMOOTH_FONT
   if (eFontRefType  == GSLC_FONTREF_FNAME){
     m_disp.loadFont((const char*)pvFontRef);
     return NULL;
   }
-  else if (eFontRefType == GSLC_FONTREF_PTR) {
+#endif
+  if (eFontRefType == GSLC_FONTREF_PTR) {
     // Return pointer to Adafruit-GFX GFXfont structure
     return pvFontRef;
   }

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -260,13 +260,19 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
 
 const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType,const void* pvFontRef,uint16_t nFontSz)
 {
-  // Arduino mode currently only supports font definitions from memory
-  if (eFontRefType != GSLC_FONTREF_PTR) {
-    GSLC_DEBUG_PRINT("ERROR: DrvFontAdd(%s) failed - Arduino only supports memory-based fonts\n","");
+  if (eFontRefType  == GSLC_FONTREF_FNAME){
+    m_disp.loadFont((const char*)pvFontRef);
     return NULL;
   }
-  // Return pointer to Adafruit-GFX GFXfont structure
-  return pvFontRef;
+  else if (eFontRefType == GSLC_FONTREF_PTR) {
+    // Return pointer to Adafruit-GFX GFXfont structure
+    return pvFontRef;
+  }
+  else {
+    // Arduino mode currently only supports font definitions from memory
+    GSLC_DEBUG_PRINT("ERROR: DrvFontAdd(%s) failed - Arduino only supports memory-based fonts and fonts stored in SPIFFS\n","");
+    return NULL;
+  }
 }
 
 void gslc_DrvFontsDestruct(gslc_tsGui* pGui)
@@ -303,11 +309,12 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 }
 
 bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int8_t eTxtAlign,
-        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
+        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
 {
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
+  uint16_t nColBgRaw = gslc_DrvAdaptColorToRaw(colBg);
   uint16_t nTxtScale = pFont->nSize;
-  m_disp.setTextColor(nColRaw);
+  m_disp.setTextColor(nColRaw,nColBgRaw);
   // TFT_eSPI font API differs from Adafruit-GFX's setFont() API
   if (pFont->pvFont == NULL) {
     m_disp.setTextFont(1);
@@ -355,11 +362,12 @@ bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,i
 
 // This method is not recommended for use with TFT_eSPI. DrvDrawTxtAlign()
 // should be used instead.
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt)
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
 {
   uint16_t nTxtScale = pFont->nSize;
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
-  m_disp.setTextColor(nColRaw);
+  uint16_t nColBgRaw = gslc_DrvAdaptColorToRaw(colBg);
+  m_disp.setTextColor(nColRaw,nColBgRaw);
   // m_disp.setCursor(nTxtX,nTxtY);
   m_disp.setTextSize(nTxtScale);
 

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -260,13 +260,7 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
 
 const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType,const void* pvFontRef,uint16_t nFontSz)
 {
-#ifdef SMOOTH_FONT
-  if (eFontRefType  == GSLC_FONTREF_FNAME){
-    m_disp.loadFont((const char*)pvFontRef);
-    return NULL;
-  }
-#endif
-  if (eFontRefType == GSLC_FONTREF_PTR) {
+  if (eFontRefType == GSLC_FONTREF_PTR  || eFontRefType  == GSLC_FONTREF_FNAME) {
     // Return pointer to Adafruit-GFX GFXfont structure
     return pvFontRef;
   }
@@ -316,12 +310,24 @@ bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,i
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
   uint16_t nColBgRaw = gslc_DrvAdaptColorToRaw(colBg);
   uint16_t nTxtScale = pFont->nSize;
-  m_disp.setTextColor(nColRaw,nColBgRaw);
+
+  #ifdef SMOOTH_FONT
+    m_disp.setTextColor(nColRaw,nColBgRaw);
+  #else
+    m_disp.setTextColor(nColRaw);
+  #endif
+
   // TFT_eSPI font API differs from Adafruit-GFX's setFont() API
   if (pFont->pvFont == NULL) {
     m_disp.setTextFont(1);
   } else {
-    m_disp.setFreeFont((const GFXfont *)pFont->pvFont);
+    #ifdef SMOOTH_FONT
+      if (pFont->eFontRefType  == GSLC_FONTREF_FNAME){
+        m_disp.loadFont((const char*)pFont->pvFont);
+      }
+    #else
+      m_disp.setFreeFont((const GFXfont *)pFont->pvFont);
+    #endif
   }
   m_disp.setTextSize(nTxtScale);
 
@@ -369,7 +375,14 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
   uint16_t nTxtScale = pFont->nSize;
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
   uint16_t nColBgRaw = gslc_DrvAdaptColorToRaw(colBg);
-  m_disp.setTextColor(nColRaw,nColBgRaw);
+  #ifdef SMOOTH_FONT
+      if (pFont->eFontRefType  == GSLC_FONTREF_FNAME){
+        m_disp.loadFont((const char*)pFont->pvFont);
+        m_disp.setTextColor(nColRaw,nColBgRaw);
+      }
+  #else
+  m_disp.setTextColor(nColRaw);
+  #endif
   // m_disp.setCursor(nTxtX,nTxtY);
   m_disp.setTextSize(nTxtScale);
 

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -324,6 +324,8 @@ bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,i
     #ifdef SMOOTH_FONT
       if (pFont->eFontRefType  == GSLC_FONTREF_FNAME){
         m_disp.loadFont((const char*)pFont->pvFont);
+      } else {
+        m_disp.setFreeFont((const GFXfont *)pFont->pvFont);
       }
     #else
       m_disp.setFreeFont((const GFXfont *)pFont->pvFont);
@@ -353,6 +355,12 @@ bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,i
 
   m_disp.drawString(pStr,nTxtX,nTxtY);
 
+  #ifdef SMOOTH_FONT
+    if (pFont->eFontRefType  == GSLC_FONTREF_FNAME){
+      m_disp.unloadFont();
+    }
+  #endif
+
   // For now, always return true
   return true;
 }
@@ -379,6 +387,8 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
       if (pFont->eFontRefType  == GSLC_FONTREF_FNAME){
         m_disp.loadFont((const char*)pFont->pvFont);
         m_disp.setTextColor(nColRaw,nColBgRaw);
+      } else {
+        m_disp.setTextColor(nColRaw);
       }
   #else
   m_disp.setTextColor(nColRaw);
@@ -400,6 +410,11 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
     }
     m_disp.println();
   }
+  #ifdef SMOOTH_FONT
+    if (pFont->eFontRefType  == GSLC_FONTREF_FNAME){
+      m_disp.unloadFont();
+    }
+  #endif
 
   return true;
 }

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -229,9 +229,11 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect);
 ///
 /// Load a font from a resource and return pointer to it
 ///
-/// \param[in]  eFontRefType:   Font reference type (GSLC_FONTREF_PTR for Arduino)
-/// \param[in]  pvFontRef:      Font reference pointer (Pointer to the GFXFont array)
-/// \param[in]  nFontSz:        Typeface size to use
+/// \param[in]  eFontRefType:   Font reference type:
+///                             - GSLC_FONTREF_PTR for Standard TFT_eSPI Fonts
+///                             - GSLC_FONTREF_FNAME for antialiased Font in SPIFFS
+/// \param[in]  pvFontRef:      Font reference pointer / SPIFFS font filename without ext.
+/// \param[in]  nFontSz:        Typeface size to use, ignored for SPIFFS font
 ///
 /// \return Void ptr to driver-specific font if load was successful, NULL otherwise
 ///
@@ -276,10 +278,11 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
 /// \param[in]  colTxt:      Color to draw text
+/// \param[in]  colBg:       Color of Background for antialias blending
 ///
 /// \return true if success, false if failure
 ///
-bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg);
 
 ///
 /// Draw a text string in a bounding box using the specified alignment
@@ -294,11 +297,12 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 /// \param[in]  pStr:        String to display
 /// \param[in]  eTxtFlags:   Flags associated with text string
 /// \param[in]  colTxt:      Color to draw text
-///
+/// \param[in]  colBg:       Color of Background for antialias blending
+//⁠
 /// \return true if success, false if failure
 ///
 bool gslc_DrvDrawTxtAlign(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int8_t eTxtAlign,
-        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt);
+        gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg);
 
 // -----------------------------------------------------------------------
 // Screen Management Functions

--- a/src/GUIslice_ex.c
+++ b/src/GUIslice_ex.c
@@ -2156,7 +2156,7 @@ bool gslc_ElemXTextboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
   gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
   gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
   gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
-
+  gslc_tsColor colBg = GSLC_COL_BLACK;
   // Fetch the element's extended data structure
   gslc_tsXTextbox* pBox;
   pBox = (gslc_tsXTextbox*)(pElem->pXData);
@@ -2177,7 +2177,8 @@ bool gslc_ElemXTextboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
 
   // Clear the background (inset from frame)
   gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
-  gslc_DrawFillRect(pGui,rInner,(bGlow)?pElem->colElemFillGlow:pElem->colElemFill);
+  colBg = (bGlow)?pElem->colElemFillGlow:pElem->colElemFill;
+  gslc_DrawFillRect(pGui,rInner,colBg);
 
   uint16_t          nBufPos = 0;
 
@@ -2229,7 +2230,7 @@ bool gslc_ElemXTextboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
 
     nTxtPixX = pElem->rElem.x + pBox->nMargin + 0 * pBox->nChSizeX;
     nTxtPixY = pElem->rElem.y + pBox->nMargin + nCurY * pBox->nChSizeY;
-    gslc_DrvDrawTxt(pGui,nTxtPixX,nTxtPixY,pElem->pTxtFont,(char*)&(pBox->pBuf[nBufPos]),pElem->eTxtFlags,colTxt);
+    gslc_DrvDrawTxt(pGui,nTxtPixX,nTxtPixY,pElem->pTxtFont,(char*)&(pBox->pBuf[nBufPos]),pElem->eTxtFlags,colTxt,colBg);
 
     nCurY++;
   } // nOutRow
@@ -2298,7 +2299,7 @@ bool gslc_ElemXTextboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
           acChToDraw[1] = 0;
           nTxtPixX = pElem->rElem.x + pBox->nMargin + nCurX * pBox->nChSizeX;
           nTxtPixY = pElem->rElem.y + pBox->nMargin + nCurY * pBox->nChSizeY;
-          gslc_DrvDrawTxt(pGui,nTxtPixX,nTxtPixY,pElem->pTxtFont,(char*)&acChToDraw,pElem->eTxtFlags,colTxt);
+          gslc_DrvDrawTxt(pGui,nTxtPixX,nTxtPixY,pElem->pTxtFont,(char*)&acChToDraw,pElem->eTxtFlags,colTxt,colBg);
 
           nCurX++;
 


### PR DESCRIPTION
Hi, I tried to implement it with as little modifications to the other graphics drivers as possible, but i still had to change the definitions of gslc_DrvDrawTxt for every backend to get in the background color argument. An example 11 is also there. Just did a quick test on my hardware, it seems to compile on ADAGFX but i have tested it only on TFT_eSPI on my hardware. Seems to work at least for text boxes and buttons without changing the examples a lot.