### PR TITLE
adding touch hander class as new DRV_TOUCH to enable user specific touch

### DIFF
--- a/arduino/gslc_ex11_ard_touch_handler/gslc_ex11_ard_touch_handler.ino
+++ b/arduino/gslc_ex11_ard_touch_handler/gslc_ex11_ard_touch_handler.ino
@@ -52,7 +52,16 @@ gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
 
 
 //instantiate the touch handler
-TouchHandler_XPT2046 touchHandler;
+#if defined(__STM32F1__)
+  //usefull values for STM32  
+  SPIClass touchSPI(2);
+  TouchHandler_XPT2046 touchHandler = TouchHandler_XPT2046(/*spi=*/ touchSPI, /*spi_cs_pin=*/ PB12);
+#else  
+  //values for Arduino, to be confirmed
+  SPIClass touchSPI(2);
+  TouchHandler_XPT2046 touchHandler = TouchHandler_XPT2046(/*spi=*/ touchSPI, /*spi_cs_pin=*/ 0);
+#endif
+
 
 // Define debug message function
 static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }

--- a/arduino/gslc_ex11_ard_touch_handler/gslc_ex11_ard_touch_handler.ino
+++ b/arduino/gslc_ex11_ard_touch_handler/gslc_ex11_ard_touch_handler.ino
@@ -1,0 +1,126 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 11 (Arduino):
+//   - show the usage of the touch handler class, this class allows easy user adaption of new touch screens
+//   - Accept touch input, text button
+//   - Expected behavior: Clicking on button is shown by a lighter button color
+//
+
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+
+//specific touch handler class
+//in order to adopt for new touch displays:
+//  - copying this file to your home dir
+//  - rename it 
+//  - edit it
+//  - include your adopted touch handler  
+//  - instantiate your touch handler
+//  - done
+#include "GUIslice_th_XPT2046.h"
+
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN};
+enum {E_ELEM_BOX,E_ELEM_BTN_QUIT};
+enum {E_FONT_BTN};
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_FONT            1
+#define MAX_ELEM_PG_MAIN    2
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+
+//instantiate the touch handler
+TouchHandler_XPT2046 touchHandler;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui,void *pvElem,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+void setup()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // register touchHandler and start it
+  gslc_InitTouchHandler(&touchHandler);
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,NULL,1)) { return; }
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,50,300,150});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
+    (gslc_tsRect){220,150,80,40},(char*)"Quit",0,E_FONT_BTN,&CbBtnQuit);  //place the botton out of the middle to be able to check if flipping / swapping is correct
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+}
+
+void loop()
+{
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will do nothing.
+  
+  //if (m_bQuit) {
+  //  gslc_Quit(&m_gui);
+  //  while (1) { }
+  //}
+  
+}
+
+
+

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -87,7 +87,8 @@ extern "C" {
   //  #define DRV_TOUCH_ADA_FT6206      // Adafruit FT6206 touch driver
   //  #define DRV_TOUCH_ADA_SIMPLE      // Adafruit Touchscreen
   //  #define DRV_TOUCH_TFT_ESPI        // TFT_eSPI integrated XPT2046 touch driver
-  //  #define DRV_TOUCH_XPT2046             // Arduino build in XPT2046 touch driver (<XPT2046_touch.h>)
+  //  #define DRV_TOUCH_XPT2046         // Arduino build in XPT2046 touch driver (<XPT2046_touch.h>)
+  //  #define DRV_TOUCH_HANDLER         // touch handler class
 
 
 // =============================================================================
@@ -158,7 +159,7 @@ extern "C" {
 
   // USE Arduino STM32 PIN Notations
   // - Define to use Arduino STM32 PIN Notations
-  //#define STM32_NOTATION
+  // #define STM32_NOTATION
 
   #if defined(STM32_NOTATION)
     // NOTE: Using Arduino STM32 pin notation
@@ -336,6 +337,10 @@ extern "C" {
 
   // Define pressure threshold for detecting a touch
   #define ADATOUCH_PRESS_MIN 0
+
+// -----------------------------------------------------------------------------
+#elif defined(DRV_TOUCH_HANDLER)
+  // touch handler class
 
 // -----------------------------------------------------------------------------
 #else

--- a/src/GUIslice_th.cpp
+++ b/src/GUIslice_th.cpp
@@ -1,0 +1,118 @@
+// Abstract touch handler (TH) class
+// This is the abstract base class for creating specific touch handlers 
+// The touch handler performs the adaption in between the GUIslice framework and any touch driver
+// The touch handler used is specified in the main program by calling gslc_InitTouchHandler(&touchHandler);
+
+
+#include "GUIslice_th.h"
+
+
+///////////////////////////////////////////////////
+// Point x,y,z Class for usage in the touch handler
+
+THPoint::THPoint(void) {
+  x = y = z = 0;
+}
+
+THPoint::THPoint(int16_t x0, int16_t y0, int16_t z0) {
+  x = x0;
+  y = y0;
+  z = z0;
+}
+
+bool THPoint::operator==(THPoint p1) {
+  return  ((p1.x == x) && (p1.y == y) && (p1.z == z));
+}
+
+bool THPoint::operator!=(THPoint p1) {
+  return  ((p1.x != x) || (p1.y != y) || (p1.z != z));
+}
+
+
+///////////////////////////////////////////////////
+// Abstract TouchHandler - you have to inherit this 
+
+void TouchHandler::setSize(uint16_t _disp_xSize, uint16_t _disp_ySize)
+{
+    disp_xSize = _disp_xSize;
+    disp_ySize = _disp_ySize;
+}    
+
+void TouchHandler::setCalibration(uint16_t _ts_xMin, uint16_t _ts_xMax, uint16_t _ts_yMin, uint16_t _ts_yMax)
+{
+    ts_xMin = _ts_xMin;
+    ts_xMax = _ts_xMax;
+    ts_yMin = _ts_yMin;
+    ts_yMax = _ts_yMax;
+}    
+
+void TouchHandler::setSwapFlip(bool _swapXY,bool _flipX,bool _flipY)
+{
+    swapXY = _swapXY;
+    flipX = _flipX;
+    flipY = _flipY;
+}
+
+THPoint TouchHandler::scale(THPoint pIn)
+{
+    THPoint pOut;
+    
+    pOut.x = map(pIn.x, ts_xMin,ts_xMax, 0,disp_xSize);
+    pOut.y = map(pIn.y, ts_yMin,ts_yMax, 0,disp_ySize);
+    pOut.z = pIn.z;
+
+    pOut.x = constrain(pOut.x,0,disp_xSize-1);
+    pOut.y = constrain(pOut.y,0,disp_ySize-1);
+    pOut.z = constrain(pOut.z,0,4095);
+
+    if (swapXY)
+    {
+        uint16_t x = pOut.x;
+        pOut.x = pOut.y;
+        pOut.y = x;
+    }
+
+    if (flipX)
+        pOut.x = ( (!swapXY) ? disp_xSize-1 : disp_ySize-1 ) - pOut.x;
+        
+    if (flipY)
+        pOut.y = ( (!swapXY) ? disp_ySize-1 : disp_xSize-1 ) - pOut.y;
+        
+    //Serial.print("disp_xSize= ");Serial.println(disp_xSize);
+        
+    return pOut;
+}
+
+
+// overwrite this with your code to add initialisation of the touch driver used
+void TouchHandler::begin(void) {
+   return;
+}
+
+
+// overwrite this with your code to return the scaled touch coordinates
+THPoint TouchHandler::getPoint(void) {
+   return THPoint();
+}
+
+
+/////////////////////////////////
+// init and set the touch handler 
+
+// Pointer to touch handler used by GUIslice 
+TouchHandler *pTouchHandler = NULL;  // NULL => no handler is available
+
+// Init and set the touch hander
+void gslc_InitTouchHandler(TouchHandler *pTH) {
+    //begin
+    pTH->begin();
+    //set the touch handler to be used by GUIslice_drv_...
+    pTouchHandler = pTH;
+}
+
+// Get the touch handler
+TouchHandler* gslc_getTouchHandler(void)
+{
+    return pTouchHandler;
+}
+

--- a/src/GUIslice_th.h
+++ b/src/GUIslice_th.h
@@ -1,0 +1,69 @@
+// Abstract touch handler (TH) class
+// This is the abstract base class for creating specific touch handlers 
+// The touch handler performs the adaption in between the GUIslice framework and any touch driver
+// The touch handler used is specified in the main program by calling gslc_InitTouchHandler(&touchHandler);
+
+#ifndef _GUISLICE_TH_H_
+#define _GUISLICE_TH_H_
+
+#include <Arduino.h>
+
+///////////////////////////////////////////////////
+// Point x,y,z Class for usage in the touch handler
+
+class THPoint {
+ public:
+  THPoint(void);
+  THPoint(int16_t x, int16_t y, int16_t z);
+  
+  bool operator==(THPoint);
+  bool operator!=(THPoint);
+
+  int16_t x, y, z;
+};
+
+
+///////////////////////////////////////////////////
+// Abstract TouchHandler - you have to inherit this 
+
+class TouchHandler {
+ public:
+  //in order to create a specific touch handler you have to write your own constructor
+  TouchHandler() {};
+
+  void setSize(uint16_t _disp_xSize, uint16_t _disp_ySize);
+  void setCalibration(uint16_t ts_xMin, uint16_t ts_xMax, uint16_t ts_yMin, uint16_t ts_yMax);
+  //order of operations: map, swap, constraint, flip 
+  void setSwapFlip(bool _swapXY,bool _flipX,bool _flipY);
+
+  THPoint scale(THPoint pIn);
+  
+  //in order to create a specific touch handler you have to overwrite this methods
+  virtual void begin(void);
+  virtual THPoint getPoint(void);
+
+private:
+    //landscape perspective: x: width, y: heigth
+    uint16_t disp_xSize = 320;
+    uint16_t disp_ySize = 240;
+
+    uint16_t ts_xMin = 0;
+    uint16_t ts_xMax = 4095;
+    uint16_t ts_yMin = 0;
+    uint16_t ts_yMax = 4095;
+    
+    bool swapXY = false;    
+    bool flipX = false;    
+    bool flipY = false;    
+};
+
+
+
+/////////////////////////////////
+// init and set the touch handler 
+
+void gslc_InitTouchHandler(TouchHandler *pTHO);     
+TouchHandler* gslc_getTouchHandler(void);     
+
+
+#endif

--- a/src/GUIslice_th_XPT2046.h
+++ b/src/GUIslice_th_XPT2046.h
@@ -1,0 +1,60 @@
+// touch handler (TH) for XPT2046 using the arduino built in driver <XPT2046_touch.h>
+
+// The touch handler performs the adaption in between the GUIslice framework and any touch driver
+// The touch handler used is specified in the main program by calling gslc_InitTouchHandler(&touchHandler);
+
+#ifndef _GUISLICE_TH_XPT2046_H_
+#define _GUISLICE_TH_XPT2046_H_
+
+#include <Arduino.h>
+#include <GUIslice_th.h>
+#include <XPT2046_touch.h>
+
+class TouchHandler_XPT2046: public TouchHandler {
+    public:   
+            
+        #if defined(__STM32F1__)
+            //default constructor for STM32F1
+            //spi(SPIClass(2)): Create an SPI instance on SPI2 port
+            //touchDriver(XPT2046_touch(PB12, spi)): Chip Select pin, SPI port                  
+            TouchHandler_XPT2046(void) : spi(SPIClass(2)), touchDriver(XPT2046_touch(PB12, spi)) {
+                setCalibration(398,3877,280,3805);
+                setSwapFlip(true,false,true);
+            }            
+        #endif
+        // parameters:
+        //   spi object to be used
+        //   chip select pin for spi
+        TouchHandler_XPT2046(SPIClass &spi, uint8_t spi_cs_pin ) : spi(spi), touchDriver(XPT2046_touch(spi_cs_pin, spi)) {
+            //empirical calibration values, can be updated by calling setCalibration in the user program
+            setCalibration(398,3877,280,3805);
+            //swapping and flipping to adopt to default GUIslice orientation
+            setSwapFlip(true,false,true);
+        }            
+   
+        //begin is called by gslc_InitTouchHandler
+        void begin(void) {
+            //init the touch driver
+            touchDriver.begin();
+        }
+                   
+        //this method returns the scaled point provided by the touch driver 
+        THPoint getPoint(void) {
+            //get the coordinates from the touch driver
+            TS_Point pt = touchDriver.getPoint();
+            //Serial.print("pt= ");Serial.print(pt.x);Serial.print(",");Serial.print(pt.y);Serial.print(",");Serial.println(pt.z);
+    
+            //perform scaling (this includes swapping and flipping)
+            THPoint ps = scale( THPoint(pt.x,pt.y,pt.z) );
+            //Serial.print("ps= ");Serial.print(ps.x);Serial.print(",");Serial.print(ps.y);Serial.print(",");Serial.println(ps.z);
+            
+            return ps;
+        };
+
+      SPIClass spi; 
+      XPT2046_touch touchDriver;
+            
+};
+
+
+#endif

--- a/src/GUIslice_th_XPT2046.h
+++ b/src/GUIslice_th_XPT2046.h
@@ -11,21 +11,11 @@
 #include <XPT2046_touch.h>
 
 class TouchHandler_XPT2046: public TouchHandler {
-    public:   
-            
-        #if defined(__STM32F1__)
-            //default constructor for STM32F1
-            //spi(SPIClass(2)): Create an SPI instance on SPI2 port
-            //touchDriver(XPT2046_touch(PB12, spi)): Chip Select pin, SPI port                  
-            TouchHandler_XPT2046(void) : spi(SPIClass(2)), touchDriver(XPT2046_touch(PB12, spi)) {
-                setCalibration(398,3877,280,3805);
-                setSwapFlip(true,false,true);
-            }            
-        #endif
+    public:
         // parameters:
         //   spi object to be used
         //   chip select pin for spi
-        TouchHandler_XPT2046(SPIClass &spi, uint8_t spi_cs_pin ) : spi(spi), touchDriver(XPT2046_touch(spi_cs_pin, spi)) {
+        TouchHandler_XPT2046(SPIClass &spi, uint8_t spi_cs_pin) : spi(spi), touchDriver(XPT2046_touch(spi_cs_pin, spi)) {
             //empirical calibration values, can be updated by calling setCalibration in the user program
             setCalibration(398,3877,280,3805);
             //swapping and flipping to adopt to default GUIslice orientation


### PR DESCRIPTION
As discussed here a PR adding a new touch handler class.
The touch handler class is included as an own driver into GUIslice which can be selected as the other drivers via defines. 
The user can now add a own touch driver just by performing the steps below.
Thus no modification / adoption of the GUIslice library itself is required to test / add a new touch driver.

To create a new user specific touch handler
- copy the full functional example GUIslice_th_XPT2046.h to the user application directory
- rename it 
- adopt it to the specific touch display

In the user program (I have added an example arduino gslc_ex11_ard_touch_handler) just
- include your adopted touch handler  
- instantiate your touch handler
- call   gslc_InitTouchHandler(&touchHandler);

I have successfully tested the touch handler with a STM32F1 and a 2.4" TFT SPI 240x320.
Please have I look at the text headers of the files, I did not know what has to be added.