### PR TITLE
fixed extends for dynamic rotation, added simple rotate function, added example

### DIFF
--- a/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
+++ b/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
@@ -1,0 +1,115 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 17 (Arduino):
+//   - show the usage of the dynamic rotation
+//   - Accept touch input, text button
+//   - Expected behavior: Clicking on button rotates the screen
+//
+
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN};
+enum {E_ELEM_BOX,E_ELEM_BTN_ROTATE};
+enum {E_FONT_BTN};
+
+bool    m_bRotate = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_FONT            1
+#define MAX_ELEM_PG_MAIN    2
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+bool CbBtnRotate(void* pvGui,void *pvElem,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bRotate = true;
+  }
+  return true;
+}
+
+void setup()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,NULL,1)) { return; }
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,50,220,150});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create rotate button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_ROTATE,E_PG_MAIN,
+    (gslc_tsRect){20,60,80,40},(char*)"Rotate",0,E_FONT_BTN,&CbBtnRotate);  //place the botton out of the middle to be able to check if flipping / swapping is correct
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bRotate = false;
+}
+
+uint8_t rotation = 1;
+void loop()
+{
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we change the rotation
+  
+  if (m_bRotate) {    
+    gslc_DrvRotate(&m_gui, rotation);
+    rotation++;
+
+    m_bRotate = false;
+    
+  }
+  //delay(1000);
+  
+}
+
+
+

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -103,9 +103,9 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
 
   #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS) || defined(DRV_DISP_TFT_ESPI) || defined(DRV_DISP_M5STACK)
     pGui->nRotation		= GSLC_ROTATE;
-    pGui->nSwapXY		= ADATOUCH_SWAP_XY;
-    pGui->nFlipX		= ADATOUCH_FLIP_X;
-    pGui->nFlipY		= ADATOUCH_FLIP_Y;
+    pGui->nSwapXY		= ADATOUCH_SWAP_XY ^ TOUCH_ROTATION_SWAPXY(GSLC_TOUCH_ROTATE);
+    pGui->nFlipX		= ADATOUCH_FLIP_X  ^ TOUCH_ROTATION_FLIPX (GSLC_TOUCH_ROTATE);
+    pGui->nFlipY		= ADATOUCH_FLIP_Y  ^ TOUCH_ROTATION_FLIPY (GSLC_TOUCH_ROTATE);
   #endif
 
   pGui->nPageMax        = nMaxPage;

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -133,8 +133,9 @@ extern "C" {
   #define ADAGFX_PIN_CLK
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     1
 
@@ -194,8 +195,9 @@ extern "C" {
 
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     1
 
@@ -215,8 +217,9 @@ extern "C" {
 
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     1
 
@@ -227,8 +230,9 @@ extern "C" {
   #define TFT_LIGHT_PIN    32   // display backlight
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     0
 
@@ -352,14 +356,27 @@ extern "C" {
 
 // -----------------------------------------------------------------------------
 
-  // Define any Touch Axis Swapping and Flipping
+
+  // Default rotation of the touch, you can specify values 0,1,2,3, rotation is clockwise
+  // it is useful to specify the GLSC_TOUCH_ROTATE_OFFSET as an offset to the GLSC_ROTATE,
+  // thus changing GLSC_ROTATE automatically adopts the GLSC_TOUCH_ROTATE
+  #define GSLC_TOUCH_ROTATE 1
+  
+  // TODO: maybe those macros should be moved to one include file which is included by all drivers
+  #define TOUCH_ROTATION_DATA 0x6350
+  #define TOUCH_ROTATION_SWAPXY(rotation) ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 2 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPX(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 1 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPY(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 0 ) & 0x01 )
+  
   // - Set any of the following to 1 to perform touch display
   //   remapping functions, 0 to disable. Use DBG_TOUCH to determine which
   //   remapping modes should be enabled for your display
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
-  #define ADATOUCH_SWAP_XY  1
+  // - NOTE: Both settings, GLSC_TOUCH_ROTATE and SWAP / FLIP are applied, 
+  //         try to set _SWAP_XY and _FLIP_X/Y to 0 and only use GLSC_TOUCH_ROTATE
+  #define ADATOUCH_SWAP_XY  0
   #define ADATOUCH_FLIP_X   0
-  #define ADATOUCH_FLIP_Y   1
+  #define ADATOUCH_FLIP_Y   0
 
   // Define the maximum number of touch events that are handled
   // per gslc_Update() call. Normally this can be set to 1 but certain

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -241,30 +241,30 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
       m_disp.readcommand8(ILI9341_RDIMGFMT);
       m_disp.readcommand8(ILI9341_RDSELFDIAG);
 
-      // Rotate display from native portrait orientation to landscape
-      // NOTE: The touch events in gslc_TDrvGetTouch() will also need rotation
       m_disp.setRotation( pGui->nRotation );
-      if (pGui->nRotation == 0 || pGui->nRotation == 2) {
+      #if (GSLC_ROTATE == 0) || (GSLC_ROTATE == 2)
         pGui->nDispW = ILI9341_TFTWIDTH;
         pGui->nDispH = ILI9341_TFTHEIGHT;
-      }
-      else {
+      #elif (GSLC_ROTATE == 1) || (GSLC_ROTATE == 3)
         pGui->nDispW = ILI9341_TFTHEIGHT;
         pGui->nDispH = ILI9341_TFTWIDTH;
-      }
+      #else
+        #error "Wrong GLSC_ROTATE value"
+      #endif
 
     #elif defined(DRV_DISP_ADAGFX_ILI9341_8BIT)
       uint16_t identifier = m_disp.readID();
       m_disp.begin(identifier);
       m_disp.setRotation( pGui->nRotation );
-      if (pGui->nRotation == 0 || pGui->nRotation == 2) {
+      #if (GSLC_ROTATE == 0) || (GSLC_ROTATE == 2)
         pGui->nDispW = ILI9341_TFTWIDTH;
         pGui->nDispH = ILI9341_TFTHEIGHT;
-      }
-      else {
+      #elif (GSLC_ROTATE == 1) || (GSLC_ROTATE == 3)
         pGui->nDispW = ILI9341_TFTHEIGHT;
         pGui->nDispH = ILI9341_TFTWIDTH;
-      }
+      #else
+        #error "Wrong GLSC_ROTATE value"
+      #endif
 
     #elif defined(DRV_DISP_ADAGFX_SSD1306)
       m_disp.begin(SSD1306_SWITCHCAPVCC);
@@ -1294,6 +1294,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
 bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY, uint8_t nFlipX, uint8_t nFlipY )
 {
     bool redraw     = pGui->nRotation != nRotation;
+    bool swapDispay = (nRotation ^ pGui->nRotation) & 0x01;
     pGui->nRotation = nRotation;
     pGui->nSwapXY   = nSwapXY;
     pGui->nFlipX    = nFlipX;
@@ -1305,6 +1306,18 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
     if( redraw ) {
         gslc_PageRedrawSet( pGui, true );
         gslc_PageRedrawGo( pGui );
+    }
+
+    // change between portrait <=> landscape
+    if( swapDispay ) {
+        // exchange pGui->nDispH <=> pGui->nDispW
+        uint16_t w = pGui->nDispW;
+        pGui->nDispW = pGui->nDispH;
+        pGui->nDispH = w;
+        
+        // new defaults for clipping region
+        gslc_tsRect rClipRect = {0,0,pGui->nDispW,pGui->nDispH};
+        gslc_DrvSetClipRect(pGui,&rClipRect);
     }
 
     return( true );
@@ -1325,7 +1338,7 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
 {
     nRotation = nRotation & 0x03;
     uint8_t nSwapXY = (pGui->nSwapXY > 0) ^ ( (pGui->nRotation ^ nRotation) & 1 );
-    uint8_t nFlipX  = (pGui->nFlipX > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 );
+    uint8_t nFlipX  = (pGui->nFlipX > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 ) ^ ( (pGui->nRotation ^ nRotation) & 1 );
     uint8_t nFlipY  = (pGui->nFlipY > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 );
     //Serial.print("s,x,y=");Serial.print(nSwapXY);Serial.print(',');Serial.print(nFlipX);Serial.print(',');Serial.println(nFlipY);;
     return gslc_DrvRotateSwapFlip(pGui, nRotation, nSwapXY, nFlipX, nFlipY);

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1324,7 +1324,7 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
 }
 
 ///
-/// Change rotation, automatically adapt touchscreen axes swap/flip
+/// Change rotation, automatically adapt touchscreen axes swap/flip based on nRotation vs GLSC_TOUCH_ROTATE
 ///
 /// The function assumes that the touchscreen settings for swap and flip in GUIslice_config_ard.h 
 /// are valid for the rotation defined in GUIslice_config_ard.h
@@ -1336,10 +1336,9 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
 ///
 bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
 {
-    nRotation = nRotation & 0x03;
-    uint8_t nSwapXY = (pGui->nSwapXY > 0) ^ ( (pGui->nRotation ^ nRotation) & 1 );
-    uint8_t nFlipX  = (pGui->nFlipX > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 ) ^ ( (pGui->nRotation ^ nRotation) & 1 );
-    uint8_t nFlipY  = (pGui->nFlipY > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 );
+    uint8_t nSwapXY = ADATOUCH_SWAP_XY ^ TOUCH_ROTATION_SWAPXY(GSLC_TOUCH_ROTATE - GSLC_ROTATE + nRotation);
+    uint8_t nFlipX  = ADATOUCH_FLIP_X  ^ TOUCH_ROTATION_FLIPX (GSLC_TOUCH_ROTATE - GSLC_ROTATE + nRotation);
+    uint8_t nFlipY  = ADATOUCH_FLIP_Y  ^ TOUCH_ROTATION_FLIPY (GSLC_TOUCH_ROTATE - GSLC_ROTATE + nRotation);
     //Serial.print("s,x,y=");Serial.print(nSwapXY);Serial.print(',');Serial.print(nFlipX);Serial.print(',');Serial.println(nFlipY);;
     return gslc_DrvRotateSwapFlip(pGui, nRotation, nSwapXY, nFlipX, nFlipY);
 }

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1310,6 +1310,27 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
     return( true );
 }
 
+///
+/// Change rotation, automatically adapt touchscreen axes swap/flip
+///
+/// The function assumes that the touchscreen settings for swap and flip in GUIslice_config_ard.h 
+/// are valid for the rotation defined in GUIslice_config_ard.h
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nRotation:   Screen Rotation value (0, 1, 2 or 3)
+///
+/// \return true if successful
+///
+bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
+{
+    nRotation = nRotation & 0x03;
+    uint8_t nSwapXY = (pGui->nSwapXY > 0) ^ ( (pGui->nRotation ^ nRotation) & 1 );
+    uint8_t nFlipX  = (pGui->nFlipX > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 );
+    uint8_t nFlipY  = (pGui->nFlipY > 0)  ^ ( (pGui->nRotation ^ nRotation) >> 1 );
+    //Serial.print("s,x,y=");Serial.print(nSwapXY);Serial.print(',');Serial.print(nFlipX);Serial.print(',');Serial.println(nFlipY);;
+    return gslc_DrvRotateSwapFlip(pGui, nRotation, nSwapXY, nFlipX, nFlipY);
+}
+
 
 // =======================================================================
 // Private Functions

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -544,6 +544,19 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
 ///
 bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY, uint8_t nFlipX, uint8_t nFlipY );
 
+///
+/// Change rotation, automatically adapt touchscreen axes swap/flip
+///
+/// The function assumes that the touchscreen settings for swap and flip in GUIslice_config_ard.h 
+/// are valid for the rotation defined in GUIslice_config_ard.h
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nRotation:   Screen Rotation value (0, 1, 2 or 3)
+///
+/// \return true if successful
+///
+bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation);
+
 
 // =======================================================================
 // Private Functions


### PR DESCRIPTION
Hi ImpulseAdventure,

as discussed in #68 here a PR trying to fix the dynamic
`bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY, uint8_t nFlipX, uint8_t nFlipY )`
function. 

Furthermore I have added the function 
`bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)`
This function auto sets nSwapXY, nFlipX and nFlipY by inspecting the change of nRotation to the previous pGui->nRotation.

Finally this was tested on a STM32F1 with ILI9341 and XPT2046. The according
example is added as gslc_ex17_ard.ino

For me it works perfect, and I assume that it works with every combination display / touch.
But I was only able to test it on my hardware.

It only requires 
```
#define ADATOUCH_SWAP_XY  
#define ADATOUCH_FLIP_X   
#define ADATOUCH_FLIP_Y   

```
in GUIslice_config_ard.h to be set correctly for the 
`#define GSLC_ROTATE`
that is defined in GUIslice_config_ard.h