### PR TITLE
Dynamic Screen Rotation

### DIFF
--- a/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
+++ b/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
@@ -1,0 +1,115 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 17 (Arduino):
+//   - show the usage of the dynamic rotation
+//   - Accept touch input, text button
+//   - Expected behavior: Clicking on button rotates the screen
+//
+
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN};
+enum {E_ELEM_BOX,E_ELEM_BTN_ROTATE};
+enum {E_FONT_BTN};
+
+bool    m_bRotate = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_FONT            1
+#define MAX_ELEM_PG_MAIN    2
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+bool CbBtnRotate(void* pvGui,void *pvElem,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bRotate = true;
+  }
+  return true;
+}
+
+void setup()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,NULL,1)) { return; }
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,50,220,150});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create rotate button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_ROTATE,E_PG_MAIN,
+    (gslc_tsRect){20,60,80,40},(char*)"Rotate",0,E_FONT_BTN,&CbBtnRotate);  //place the botton out of the middle to be able to check if flipping / swapping is correct
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bRotate = false;
+}
+
+uint8_t rotation = 1;
+void loop()
+{
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we change the rotation
+  
+  if (m_bRotate) {    
+    gslc_DrvRotate(&m_gui, rotation);
+    rotation++;
+
+    m_bRotate = false;
+    
+  }
+  //delay(1000);
+  
+}
+
+
+

--- a/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
+++ b/arduino/gslc_ex17_ard/gslc_ex17_ard.ino
@@ -4,7 +4,7 @@
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 // - Example 17 (Arduino):
-//   - show the usage of the dynamic rotation
+//   - Show the usage of dynamic rotation
 //   - Accept touch input, text button
 //   - Expected behavior: Clicking on button rotates the screen
 //
@@ -25,7 +25,8 @@ enum {E_PG_MAIN};
 enum {E_ELEM_BOX,E_ELEM_BTN_ROTATE};
 enum {E_FONT_BTN};
 
-bool    m_bRotate = false;
+bool      m_bRotate = false;
+uint8_t   m_nRotation = 1;
 
 // Instantiate the GUI
 #define MAX_PAGE            1
@@ -91,7 +92,7 @@ void setup()
   m_bRotate = false;
 }
 
-uint8_t rotation = 1;
+
 void loop()
 {
   // Periodically call GUIslice update function
@@ -99,16 +100,16 @@ void loop()
 
   // In a real program, we would detect the button press and take an action.
   // For this Arduino demo, we change the rotation
-  
-  if (m_bRotate) {    
-    gslc_DrvRotate(&m_gui, rotation);
-    rotation++;
+
+  if (m_bRotate) {
+    gslc_GuiRotate(&m_gui, m_nRotation);
+    m_nRotation = (m_nRotation+1) % 4;
 
     m_bRotate = false;
-    
+
   }
   //delay(1000);
-  
+
 }
 
 

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -103,9 +103,9 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
 
   #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS) || defined(DRV_DISP_TFT_ESPI) || defined(DRV_DISP_M5STACK)
     pGui->nRotation		= GSLC_ROTATE;
-    pGui->nSwapXY		= ADATOUCH_SWAP_XY;
-    pGui->nFlipX		= ADATOUCH_FLIP_X;
-    pGui->nFlipY		= ADATOUCH_FLIP_Y;
+    pGui->nSwapXY		= ADATOUCH_SWAP_XY ^ TOUCH_ROTATION_SWAPXY(GSLC_TOUCH_ROTATE);
+    pGui->nFlipX		= ADATOUCH_FLIP_X  ^ TOUCH_ROTATION_FLIPX (GSLC_TOUCH_ROTATE);
+    pGui->nFlipY		= ADATOUCH_FLIP_Y  ^ TOUCH_ROTATION_FLIPY (GSLC_TOUCH_ROTATE);
   #endif
 
   pGui->nPageMax        = nMaxPage;

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -3337,7 +3337,7 @@ bool gslc_GuiRotate(gslc_tsGui* pGui, uint8_t nRotation)
   #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
     return gslc_DrvRotate(pGui,nRotation);
   #else
-    #error "GuiRotate() not supported in current DRV_DISP_* mode yet"
+    GSLC_DEBUG_PRINT("ERROR: GuiRotate(%s) not supported in current DRV_DISP_* mode yet\n","");
     return false;
   #endif
 }

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -4,7 +4,7 @@
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 //
-// - Version 0.10.4   (2018/10/13)
+// - Version 0.10.4   (2018/10/29)
 // =======================================================================
 //
 // The MIT License
@@ -3327,6 +3327,19 @@ bool gslc_SetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol)
   }
   gslc_PageFlipSet(pGui,true);
   return true;
+}
+
+bool gslc_GuiRotate(gslc_tsGui* pGui, uint8_t nRotation)
+{
+  // Simple wrapper for driver-specific rotation
+
+  // TODO: For now, only DRV_DISP_ADAGFX supports dynamic rotation.
+  #if defined(DRV_DISP_ADAGFX) || defined(DRV_DISP_ADAGFX_AS)
+    return gslc_DrvRotate(pGui,nRotation);
+  #else
+    #error "GuiRotate() not supported in current DRV_DISP_* mode yet"
+    return false;
+  #endif
 }
 
 // Trigger a touch event on an element

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -71,8 +71,8 @@ extern "C" {
 // NOTE: In the future, these checks may be removed.
 #ifndef GSLC_TOUCH_ROTATE
   #warning "Config: GSLC_TOUCH_ROTATE not defined. Please update GUIslice_config to latest. Using default."
-  // Apply a default to allow compilation to proceed
-  #define GSLC_TOUCH_ROTATE GSLC_ROTATE
+  // Apply a backward-compatible default to allow compilation to proceed
+  #define GSLC_TOUCH_ROTATE 0
 #endif
 
 

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -7,7 +7,7 @@
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 //
-// - Version 0.10.3   (2018/10/06)
+// - Version 0.10.4   (2018/10/29)
 // =======================================================================
 //
 // The MIT License
@@ -62,6 +62,17 @@ extern "C" {
   #define GSLC_PMEM PROGMEM
 #else
   #define GSLC_PMEM
+#endif
+
+
+// Detect cases where recently added config parameters are missing
+// as this would indicate that the config file is out-of-date and needs
+// updating. Flag this to the user with a compiler warning and offer default.
+// NOTE: In the future, these checks may be removed.
+#ifndef GSLC_TOUCH_ROTATE
+  #warning "Config: GSLC_TOUCH_ROTATE not defined. Please update GUIslice_config to latest. Using default."
+  // Apply a default to allow compilation to proceed
+  #define GSLC_TOUCH_ROTATE GSLC_ROTATE
 #endif
 
 
@@ -265,6 +276,15 @@ typedef enum {
   GSLC_TOUCH_UP_IN      = GSLC_TOUCH_UP   | GSLC_TOUCH_IN,  ///< Touch up inside tracked element
   GSLC_TOUCH_UP_OUT     = GSLC_TOUCH_UP   | GSLC_TOUCH_OUT, ///< Touch up outside tracked element
 } gslc_teTouch;
+
+
+/// Additional definitions for Touch Handling
+/// These macros define the transforms used in remapping the touchscreen
+/// inputs on the basis of the GUI nRotation setting.
+  #define TOUCH_ROTATION_DATA 0x6350
+  #define TOUCH_ROTATION_SWAPXY(rotation) ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 2 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPX(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 1 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPY(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 0 ) & 0x01 )
 
 
 /// Event types
@@ -2181,6 +2201,19 @@ bool gslc_SetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol);
 ///
 bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw);
 
+
+///
+/// Dynamically change rotation, automatically adapt touchscreen axes swap/flip
+///
+/// The function assumes that the touchscreen settings for swap and flip
+/// in the GUIslice config are valid for the configured GSLC_ROTATE.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nRotation:   Screen Rotation value (0, 1, 2 or 3)
+///
+/// \return true if success, false otherwise
+///
+bool gslc_GuiRotate(gslc_tsGui* pGui, uint8_t nRotation);
 
 
 ///

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -133,8 +133,9 @@ extern "C" {
   #define ADAGFX_PIN_CLK
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     1
 
@@ -194,8 +195,9 @@ extern "C" {
 
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     1
 
@@ -215,8 +217,9 @@ extern "C" {
 
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     1
 
@@ -227,8 +230,9 @@ extern "C" {
   #define TFT_LIGHT_PIN    32   // display backlight
 
   // Set Default rotation
+  // you can specify values 0,1,2,3, rotation is clockwise
   // - Note that if you change this you will likely have to change
-  //   ADATOUCH_FLIP_X & ADATOUCH_FLIP_Y as well to ensure that the touch screen
+  //   GLSC_TOUCH_ROTATE as well to ensure that the touch screen
   //   orientation matches the display rotation
   #define GSLC_ROTATE     0
 
@@ -352,14 +356,27 @@ extern "C" {
 
 // -----------------------------------------------------------------------------
 
-  // Define any Touch Axis Swapping and Flipping
+
+  // Default rotation of the touch, you can specify values 0,1,2,3, rotation is clockwise
+  // it is useful to specify the GLSC_TOUCH_ROTATE_OFFSET as an offset to the GLSC_ROTATE,
+  // thus changing GLSC_ROTATE automatically adopts the GLSC_TOUCH_ROTATE
+  #define GSLC_TOUCH_ROTATE 1
+  
+  // TODO: maybe those macros should be moved to one include file which is included by all drivers
+  #define TOUCH_ROTATION_DATA 0x6350
+  #define TOUCH_ROTATION_SWAPXY(rotation) ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 2 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPX(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 1 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPY(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 0 ) & 0x01 )
+  
   // - Set any of the following to 1 to perform touch display
   //   remapping functions, 0 to disable. Use DBG_TOUCH to determine which
   //   remapping modes should be enabled for your display
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
-  #define ADATOUCH_SWAP_XY  1
+  // - NOTE: Both settings, GLSC_TOUCH_ROTATE and SWAP / FLIP are applied, 
+  //         try to set _SWAP_XY and _FLIP_X/Y to 0 and only use GLSC_TOUCH_ROTATE
+  #define ADATOUCH_SWAP_XY  0
   #define ADATOUCH_FLIP_X   0
-  #define ADATOUCH_FLIP_Y   1
+  #define ADATOUCH_FLIP_Y   0
 
   // Define the maximum number of touch events that are handled
   // per gslc_Update() call. Normally this can be set to 1 but certain

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -361,18 +361,13 @@ extern "C" {
   // it is useful to specify the GLSC_TOUCH_ROTATE_OFFSET as an offset to the GLSC_ROTATE,
   // thus changing GLSC_ROTATE automatically adopts the GLSC_TOUCH_ROTATE
   #define GSLC_TOUCH_ROTATE 1
-  
-  // TODO: maybe those macros should be moved to one include file which is included by all drivers
-  #define TOUCH_ROTATION_DATA 0x6350
-  #define TOUCH_ROTATION_SWAPXY(rotation) ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 2 ) & 0x01 )
-  #define TOUCH_ROTATION_FLIPX(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 1 ) & 0x01 )
-  #define TOUCH_ROTATION_FLIPY(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 0 ) & 0x01 )
-  
+
+
   // - Set any of the following to 1 to perform touch display
   //   remapping functions, 0 to disable. Use DBG_TOUCH to determine which
   //   remapping modes should be enabled for your display
   // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
-  // - NOTE: Both settings, GLSC_TOUCH_ROTATE and SWAP / FLIP are applied, 
+  // - NOTE: Both settings, GLSC_TOUCH_ROTATE and SWAP / FLIP are applied,
   //         try to set _SWAP_XY and _FLIP_X/Y to 0 and only use GLSC_TOUCH_ROTATE
   #define ADATOUCH_SWAP_XY  0
   #define ADATOUCH_FLIP_X   0

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -357,9 +357,10 @@ extern "C" {
 // -----------------------------------------------------------------------------
 
 
-  // Default rotation of the touch, you can specify values 0,1,2,3, rotation is clockwise
-  // it is useful to specify the GLSC_TOUCH_ROTATE_OFFSET as an offset to the GLSC_ROTATE,
-  // thus changing GLSC_ROTATE automatically adopts the GLSC_TOUCH_ROTATE
+  // Specify the default rotation/orientation of the touch device, which must
+  // be in the range 0,1,2,3. It may be necessary to enable DBG_TOUCH to
+  // determine the correct value for your device, along with example ex17.
+  // Rotation value is defined in a clockwise direction.
   #define GSLC_TOUCH_ROTATE 1
 
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -544,6 +544,19 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX, int16_t* pnY, uint16_t* pn
 ///
 bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY, uint8_t nFlipX, uint8_t nFlipY );
 
+///
+/// Change rotation, automatically adapt touchscreen axes swap/flip
+///
+/// The function assumes that the touchscreen settings for swap and flip in GUIslice_config_ard.h 
+/// are valid for the rotation defined in GUIslice_config_ard.h
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nRotation:   Screen Rotation value (0, 1, 2 or 3)
+///
+/// \return true if successful
+///
+bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation);
+
 
 // =======================================================================
 // Private Functions


### PR DESCRIPTION
This PR merges the contributions from @espHorst PR #70 along with some additional edits.
Please refer to #70 for details.

---
**Add GuiRotate() to support dynamic screen rotation (#70) in DRV_DISP_ADAGFX**

- NOTE: Breaking change for configuration update. GUIslice_config_*.h will
  require an update to add the new GSLC_TOUCH_ROTATE parameter. The most
  minimal update would require adding the following line:
  `#define GSLC_TOUCH_ROTATE 1` (the number may need to be changed to a
  value between 0..3 to provide correct touch detection)
- Add GuiRotate() as simple wrapper for DrvRotate(). Note that only
  DRV_DISP_ADAGFX and DRV_DISP_ADAGFX_AS modes are supported at the moment,
  with others to follow.
- Add compiler warning to detect config file needing update for GSLC_TOUCH_ROTATE
- Relocated TOUCH_ROTATION_* macros into GUIslice.h from config
- Update example gslc_ex17_ard to use GuiRotate instead of DrvRotate
