### PR TITLE
M5stack built-in button navigation

### DIFF
--- a/examples/arduino/ex23_m5_input_btn/ex23_m5_input_btn.ino
+++ b/examples/arduino/ex23_m5_input_btn/ex23_m5_input_btn.ino
@@ -1,0 +1,238 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 23 (M5stack): Dynamic content with integrated button control
+//   - Same as Example 04, except adds GPIO pin input control
+//     IMPORTANT: See notes under Button Control
+//   - Demonstrates push buttons, checkboxes and slider controls
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. Therefore, it may not
+//     run on Arduino devices with limited memory. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+//
+
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN};
+enum {E_ELEM_BOX,E_ELEM_BTN_QUIT,E_ELEM_TXT_COUNT,E_ELEM_PROGRESS,E_ELEM_PROGRESS1,
+      E_ELEM_CHECK1,E_ELEM_RADIO1,E_ELEM_RADIO2,E_ELEM_SLIDER,E_ELEM_TXT_SLIDER};
+enum {E_FONT_BTN,E_FONT_TXT};
+enum {E_GROUP1};
+
+bool        m_bQuit = false;
+
+// Free-running counter for display
+unsigned    m_nCount = 0;
+
+
+// Instantiate the GUI
+#define MAX_PAGE                1
+#define MAX_FONT                2
+
+// Define the maximum number of elements per page
+#define MAX_ELEM_PG_MAIN          16                                        // # Elems total
+#define MAX_ELEM_PG_MAIN_RAM      MAX_ELEM_PG_MAIN                          // # Elems in RAM
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+gslc_tsXGauge               m_sXGauge,m_sXGauge1;
+gslc_tsXCheckbox            m_asXCheck[3];
+gslc_tsXSlider              m_sXSlider;
+
+#define MAX_INPUT_MAP       5
+gslc_tsInputMap             m_asInputMap[MAX_INPUT_MAP];
+
+#define MAX_STR             15
+
+  // Save some element references for quick access
+  gslc_tsElemRef*  m_pElemCnt        = NULL;
+  gslc_tsElemRef*  m_pElemProgress   = NULL;
+  gslc_tsElemRef*  m_pElemProgress1  = NULL;
+  gslc_tsElemRef*  m_pElemSlider     = NULL;
+  gslc_tsElemRef*  m_pElemSliderTxt  = NULL;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui, void *pvElem, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+	if (eTouch == GSLC_TOUCH_UP_IN) {
+		m_bQuit = true;
+	}
+	return true;
+}
+
+
+// Create page elements
+bool InitOverlays()
+{
+  gslc_tsElemRef* pElemRef;
+
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPageElem,MAX_ELEM_PG_MAIN_RAM,m_asPageElemRef,MAX_ELEM_PG_MAIN);
+
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX,E_PG_MAIN,(gslc_tsRect){10,50,300,150});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
+    (gslc_tsRect){160,80,80,40},(char*)"Quit",0,E_FONT_BTN,&CbBtnQuit);
+
+  // Create counter
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,60,50,10},
+    (char*)"Count:",0,E_FONT_TXT);
+  static char mstr1[8] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_ELEM_TXT_COUNT,E_PG_MAIN,(gslc_tsRect){80,60,50,10},
+    mstr1,sizeof(mstr1),E_FONT_TXT);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_YELLOW);
+  m_pElemCnt = pElemRef; // Save for quick access
+
+  // Create progress bar (horizontal)
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,80,50,10},
+    (char*)"Progress:",0,E_FONT_TXT);
+  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
+    (gslc_tsRect){80,80,50,10},0,100,0,GSLC_COL_GREEN,false);
+  m_pElemProgress = pElemRef; // Save for quick access
+
+  // Second progress bar (vertical)
+  // - Demonstration of vertical bar with offset zero-pt showing both positive and negative range
+  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
+    (gslc_tsRect){280,80,10,100},-25,75,-15,GSLC_COL_RED,true);
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_BLUE_DK3,GSLC_COL_BLACK,GSLC_COL_BLACK);
+  m_pElemProgress1 = pElemRef; // Save for quick access
+
+
+  // Create checkbox 1
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,100,20,20},
+    (char*)"Check1:",0,E_FONT_TXT);
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui,E_ELEM_CHECK1,E_PG_MAIN,&m_asXCheck[0],
+    (gslc_tsRect){80,100,20,20},false,GSLCX_CHECKBOX_STYLE_X,GSLC_COL_BLUE_LT2,false);
+
+  // Create radio 1
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,135,20,20},
+    (char*)"Radio1:",0,E_FONT_TXT);
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui,E_ELEM_RADIO1,E_PG_MAIN,&m_asXCheck[1],
+    (gslc_tsRect){80,135,20,20},true,GSLCX_CHECKBOX_STYLE_ROUND,GSLC_COL_ORANGE,false);
+  gslc_ElemSetGroup(&m_gui,pElemRef,E_GROUP1);
+
+  // Create radio 2
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,160,20,20},
+    (char*)"Radio2:",0,E_FONT_TXT);
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui,E_ELEM_RADIO2,E_PG_MAIN,&m_asXCheck[2],
+    (gslc_tsRect){80,160,20,20},true,GSLCX_CHECKBOX_STYLE_ROUND,GSLC_COL_ORANGE,false);
+  gslc_ElemSetGroup(&m_gui,pElemRef,E_GROUP1);
+
+  // Create slider
+  pElemRef = gslc_ElemXSliderCreate(&m_gui,E_ELEM_SLIDER,E_PG_MAIN,&m_sXSlider,
+    (gslc_tsRect){160,140,100,20},0,100,60,5,false);
+  gslc_ElemXSliderSetStyle(&m_gui,pElemRef,true,(gslc_tsColor){0,0,128},10,
+          5,(gslc_tsColor){64,64,64});
+  m_pElemSlider = pElemRef; // Save for quick access
+
+
+  static char mstr2[8] = "Slider:";
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){160,160,60,20},
+    mstr2,sizeof(mstr2),E_FONT_TXT);
+  static char mstr3[6] = "???";
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_ELEM_TXT_SLIDER,E_PG_MAIN,(gslc_tsRect){220,160,40,20},
+    mstr3,sizeof(mstr3),E_FONT_TXT);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_ORANGE);
+  m_pElemSliderTxt = pElemRef; // Save for quick access
+
+  return true;
+}
+
+
+void setup()
+{
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // Create the GUI input mapping (pin event to GUI action)
+  gslc_InitInputMap(&m_gui, m_asInputMap, MAX_INPUT_MAP);
+  gslc_InputMapAdd(&m_gui, GSLC_INPUT_PIN_ASSERT, GSLC_PIN_BTN_A,      GSLC_ACTION_FOCUS_PREV, 0);
+  gslc_InputMapAdd(&m_gui, GSLC_INPUT_PIN_ASSERT, GSLC_PIN_BTN_B,      GSLC_ACTION_SELECT, 0);
+  gslc_InputMapAdd(&m_gui, GSLC_INPUT_PIN_ASSERT, GSLC_PIN_BTN_C,      GSLC_ACTION_FOCUS_NEXT, 0);
+  gslc_InputMapAdd(&m_gui, GSLC_INPUT_PIN_ASSERT, GSLC_PIN_BTN_A_LONG, GSLC_ACTION_SET_REL, -10);
+  gslc_InputMapAdd(&m_gui, GSLC_INPUT_PIN_ASSERT, GSLC_PIN_BTN_C_LONG, GSLC_ACTION_SET_REL, +10);
+
+  // Use default font
+  if (!gslc_FontAdd(&m_gui, E_FONT_BTN, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+  if (!gslc_FontAdd(&m_gui,E_FONT_TXT,GSLC_FONTREF_PTR,NULL,1)) { return; }
+
+  // Create graphic elements
+  InitOverlays();
+
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+}
+
+void loop()
+{
+  char                acTxt[MAX_STR];
+
+  // General counter
+  m_nCount++;
+
+  // Update elements on active page
+
+  snprintf(acTxt,MAX_STR,"%u",m_nCount/5);
+  gslc_ElemSetTxtStr(&m_gui,m_pElemCnt,acTxt);
+
+  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,((m_nCount/1)%100));
+
+  // NOTE: A more efficient method is to move the following
+  //       code into the slider position callback function.
+  //       Please see example 07.
+  int nPos = gslc_ElemXSliderGetPos(&m_gui,m_pElemSlider);
+  snprintf(acTxt,MAX_STR,"%u",nPos);
+  gslc_ElemSetTxtStr(&m_gui,m_pElemSliderTxt,acTxt);
+
+  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
+
+
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // Slow down updates
+  delay(10);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) { }
+  }
+}

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -64,8 +64,6 @@
 
 // ========================================================================
 
-
-
 /// Global debug output function
 /// - The user assigns this function via gslc_InitDebug()
 GSLC_CB_DEBUG_OUT g_pfDebugOut = NULL;
@@ -449,16 +447,23 @@ void gslc_Update(gslc_tsGui* pGui)
     return; // No page added yet
   }
 
+  // The touch handling logic is used by both the touchscreen
+  // handler as well as the GPIO/pin/keyboard input controller
   #if !defined(DRV_TOUCH_NONE)
 
   // ---------------------------------------------
   // Touch handling
   // ---------------------------------------------
 
+  // TODO: Move the physical button / GPIO handling (pfuncPinPoll)
+  //       outside of !defined(DRV_TOUCH_NONE) check so that we can
+  //       enable physical button handling without requiring
+  //       all of the other touch driver logic.
+
   int16_t               nTouchX = 0;
   int16_t               nTouchY = 0;
   uint16_t              nTouchPress = 0;
-  bool                  bEvent = true;      // xxx FIXME: Should this be false?
+  bool                  bEvent = false;
   gslc_teInputRawEvent  eInputEvent = GSLC_INPUT_NONE;
   int16_t               nInputVal = 0;
 
@@ -487,6 +492,8 @@ void gslc_Update(gslc_tsGui* pGui)
     // --------------------------------------------------------------
     // First check physical pin inputs
     // --------------------------------------------------------------
+
+    #if (GSLC_FEATURE_INPUT)
     int16_t  nPinNum = -1;
     int16_t  nPinState = 0;
     GSLC_CB_PIN_POLL  pfuncPinPoll = pGui->pfuncPinPoll;
@@ -498,6 +505,7 @@ void gslc_Update(gslc_tsGui* pGui)
         nInputVal = nPinNum;
       }
     } 
+    #endif // GSLC_FEATURE_INPUT
 
     // --------------------------------------------------------------
     // If no event found yet, check touch / keyboard
@@ -511,7 +519,6 @@ void gslc_Update(gslc_tsGui* pGui)
     // If event found, handle it
     // --------------------------------------------------------------
     if (bEvent) {
-
       // Track and handle the input events
       // - Handle the events on the current page
       switch (eInputEvent) {

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -281,6 +281,21 @@ typedef enum {
 } gslc_teAction;
 
 
+/// General purpose pin/button constants
+typedef enum {
+  GSLC_PIN_BTN_A,           ///< Button A (short press)
+  GSLC_PIN_BTN_A_LONG,      ///< Button A (long press)
+  GSLC_PIN_BTN_B,           ///< Button B (short press)
+  GSLC_PIN_BTN_B_LONG,      ///< Button B (long press)
+  GSLC_PIN_BTN_C,           ///< Button C (short press)
+  GSLC_PIN_BTN_C_LONG,      ///< Button C (long press)
+  GSLC_PIN_BTN_D,           ///< Button D (short press)
+  GSLC_PIN_BTN_D_LONG,      ///< Button D (long press)
+  GSLC_PIN_BTN_E,           ///< Button E (short press)
+  GSLC_PIN_BTN_E_LONG,      ///< Button E (long press)
+} gslc_tePin;
+
+
 /// Processed event from input raw events and actions
 typedef enum {
   GSLC_TOUCH_NONE         = 0,          ///< No touch event active
@@ -1876,9 +1891,10 @@ bool gslc_InitTouch(gslc_tsGui* pGui,const char* acDev);
 /// \param[out] pnX:         Ptr to int to contain latest touch X coordinate
 /// \param[out] pnY:         Ptr to int to contain latest touch Y coordinate
 /// \param[out] pnPress:     Ptr to int to contain latest touch pressure value
-/// xxx TODO doc
 ///
 /// \return true if touch event, false otherwise
+///
+/// \todo Doc
 ///
 bool gslc_GetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pnPress, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 
@@ -2880,9 +2896,10 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pPage:       Pointer to current page
 /// \param[in]  nKey:        Keyboard / External pin input value
-/// xxx TODO doc
 ///
 /// \return none
+///
+/// \todo Doc
 ///
 void gslc_TrackInput(gslc_tsGui* pGui,gslc_tsPage* pPage,gslc_teInputRawEvent eInputEvent,int16_t nInputVal);
 

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -326,8 +326,13 @@ extern "C" {
   // M5stack integrated button handler
   #define DRV_TOUCH_IN_DISP   // Use the display driver (M5stack) for touch events
 
+  // NOTE: Long-press detection is only available in the latest
+  //       M5stack library releases. Uncomment the following
+  //       if the Btn wasReleasefor() API is available.
+  //
   // Define duration (in ms) for a long-press button event
-  #define M5STACK_TOUCH_PRESS_LONG  300 
+  //#define M5STACK_TOUCH_PRESS_LONG  300
+
 
 // -----------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_XPT2046)

--- a/src/GUIslice_config_ard.h
+++ b/src/GUIslice_config_ard.h
@@ -83,11 +83,12 @@ extern "C" {
   // - Uncomment one of the following touchscreen drivers DRV_TOUCH_*
   //   applicable to the controller chip in use
 
-  //  #define DRV_TOUCH_NONE            // No touchscreen support
+  //  #define DRV_TOUCH_NONE            // No touchscreen support & no input (GPIO / keyboard)
       #define DRV_TOUCH_ADA_STMPE610    // Adafruit STMPE610 touch driver
   //  #define DRV_TOUCH_ADA_FT6206      // Adafruit FT6206 touch driver
   //  #define DRV_TOUCH_ADA_SIMPLE      // Adafruit Touchscreen
   //  #define DRV_TOUCH_TFT_ESPI        // TFT_eSPI integrated XPT2046 touch driver
+  //  #define DRV_TOUCH_M5STACK         // M5stack integrated button driver
   //  #define DRV_TOUCH_XPT2046         // Arduino build in XPT2046 touch driver (<XPT2046_touch.h>)
   //  #define DRV_TOUCH_HANDLER         // touch handler class
 
@@ -321,6 +322,14 @@ extern "C" {
   #define TFT_ESPI_TOUCH_CALIB { 321,3498,280,3593,3 }
 
 // -----------------------------------------------------------------------------
+#elif defined(DRV_TOUCH_M5STACK)
+  // M5stack integrated button handler
+  #define DRV_TOUCH_IN_DISP   // Use the display driver (M5stack) for touch events
+
+  // Define duration (in ms) for a long-press button event
+  #define M5STACK_TOUCH_PRESS_LONG  300 
+
+// -----------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_XPT2046)
   // Arduino built in XPT2046 touch driver (<XPT2046_touch.h>)
 
@@ -398,12 +407,12 @@ extern "C" {
   // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
   //   limited on the baseline Arduino (ATmega328P) devices.
   #if defined(__AVR__)
-    #define DEBUG_ERR               0   // Disable by default on low-mem Arduino
+    #define DEBUG_ERR               0   // Debugging disabled by default on low-mem Arduino
   #else
     // For all other devices, DEBUG_ERR is enabled by default.
     // Since this mode increases FLASH memory considerably, it may be
     // necessary to disable this feature.
-    #define DEBUG_ERR               1   // Enable debug reporting
+    #define DEBUG_ERR               1   // Debugging enabled by default
   #endif
 
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -491,9 +491,10 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev);
 /// \param[out] pnX:         Ptr to X coordinate of last touch event
 /// \param[out] pnY:         Ptr to Y coordinate of last touch event
 /// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
-/// xxx TODO doc
 ///
 /// \return true if an event was detected or false otherwise
+///
+/// \todo Doc
 ///
 bool gslc_DrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pnPress, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 
@@ -523,9 +524,9 @@ bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev);
 /// \param[out] pnX:         Ptr to X coordinate of last touch event
 /// \param[out] pnY:         Ptr to Y coordinate of last touch event
 /// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
-/// xxx TODO doc
 ///
 /// \return true if an event was detected or false otherwise
+/// \todo Doc
 ///
 bool gslc_TDrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pnPress, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -884,29 +884,6 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
     return gslc_DrvRotateSwapFlip(pGui, nRotation, nSwapXY, nFlipX, nFlipY);
 }
 
-bool gslc_DrvGetInput(gslc_tsGui* pGui, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal)
-{
-  if (pGui == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "DrvGetInput";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
-    return false;
-  }
-
-  *peInputEvent = GSLC_INPUT_NONE;
-  *pnInputVal = 0;
-
-  // Trigger the M5 update routine
-  M5.update();
-
-  if      (M5.BtnA.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_A; }
-  else if (M5.BtnB.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_B; }
-  else if (M5.BtnC.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_C; }
-  else return false; // No pin event detected
-
-  // If we reached here, then we had a button event
-  return true;
-}
-
 
 // =======================================================================
 // Private Functions

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -744,6 +744,74 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui)
 }
 
 // -----------------------------------------------------------------------
+// Touch Functions (via display driver)
+// -----------------------------------------------------------------------
+
+
+#if defined(DRV_TOUCH_IN_DISP)
+
+bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
+  if (pGui == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: DrvInitTouch(%s) called with NULL ptr\n","");
+    return false;
+  }
+
+  // For M5stack, no extra initialization is required to support the buttons
+
+  // Nothing further to do with driver
+  return true;
+}
+
+
+bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal)
+{
+
+  if ((pGui == NULL) || (pGui->pvDriver == NULL)) {
+    GSLC_DEBUG_PRINT("ERROR: DrvGetTouch(%s) called with NULL ptr\n","");
+    return false;
+  }
+
+  // Assign defaults
+  *pnX = 0;
+  *pnY = 0;
+  *pnPress = 0;
+
+  *peInputEvent = GSLC_INPUT_NONE;
+  *pnInputVal = 0;
+
+  // Trigger the M5 update routine
+  M5.update();
+
+  if (M5.BtnA.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
+	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+	  *pnInputVal = GSLC_PIN_BTN_A_LONG;
+  } else if (M5.BtnA.wasReleased()) {
+	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+	  *pnInputVal = GSLC_PIN_BTN_A;
+  }	else if (M5.BtnB.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
+	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+	  *pnInputVal = GSLC_PIN_BTN_B_LONG;
+  }	else if (M5.BtnB.wasReleased()) {
+	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+	  *pnInputVal = GSLC_PIN_BTN_B;
+  }	else if (M5.BtnC.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
+	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+	  *pnInputVal = GSLC_PIN_BTN_C_LONG;
+  }	else if (M5.BtnC.wasReleased()) {
+	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+	  *pnInputVal = GSLC_PIN_BTN_C;
+  } else {
+	  return false; // No pin event detected
+  }
+
+  // If we reached here, then we had a button event
+	return true;
+}
+
+#endif // DRV_TOUCH_IN_DISP
+
+
+// -----------------------------------------------------------------------
 // Dynamic Screen rotation and Touch axes swap/flip functions
 // -----------------------------------------------------------------------
 
@@ -809,6 +877,29 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
     uint8_t nFlipY  = ADATOUCH_FLIP_Y  ^ TOUCH_ROTATION_FLIPY (GSLC_TOUCH_ROTATE - GSLC_ROTATE + nRotation);
     //Serial.print("s,x,y=");Serial.print(nSwapXY);Serial.print(',');Serial.print(nFlipX);Serial.print(',');Serial.println(nFlipY);;
     return gslc_DrvRotateSwapFlip(pGui, nRotation, nSwapXY, nFlipX, nFlipY);
+}
+
+bool gslc_DrvGetInput(gslc_tsGui* pGui, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal)
+{
+  if (pGui == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "DrvGetInput";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return false;
+  }
+
+  *peInputEvent = GSLC_INPUT_NONE;
+  *pnInputVal = 0;
+
+  // Trigger the M5 update routine
+  M5.update();
+
+  if      (M5.BtnA.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_A; }
+	else if (M5.BtnB.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_B; }
+	else if (M5.BtnC.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_C; }
+	else return false; // No pin event detected
+
+  // If we reached here, then we had a button event
+	return true;
 }
 
 

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -782,30 +782,35 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPre
   // Trigger the M5 update routine
   M5.update();
 
+  // Btn.wasReleasefor() is only available in the latest M5stack versions.
+#if defined(M5STACK_TOUCH_PRESS_LONG)
   if (M5.BtnA.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
-	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
-	  *pnInputVal = GSLC_PIN_BTN_A_LONG;
+    *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+    *pnInputVal = GSLC_PIN_BTN_A_LONG;
+  }  else if (M5.BtnB.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
+    *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+    *pnInputVal = GSLC_PIN_BTN_B_LONG;
+  }  else if (M5.BtnC.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
+    *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+    *pnInputVal = GSLC_PIN_BTN_C_LONG;
   } else if (M5.BtnA.wasReleased()) {
-	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
-	  *pnInputVal = GSLC_PIN_BTN_A;
-  }	else if (M5.BtnB.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
-	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
-	  *pnInputVal = GSLC_PIN_BTN_B_LONG;
-  }	else if (M5.BtnB.wasReleased()) {
-	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
-	  *pnInputVal = GSLC_PIN_BTN_B;
-  }	else if (M5.BtnC.wasReleasefor(M5STACK_TOUCH_PRESS_LONG)) {
-	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
-	  *pnInputVal = GSLC_PIN_BTN_C_LONG;
-  }	else if (M5.BtnC.wasReleased()) {
-	  *peInputEvent = GSLC_INPUT_PIN_ASSERT;
-	  *pnInputVal = GSLC_PIN_BTN_C;
+#else
+  if (M5.BtnA.wasReleased()) {
+#endif
+    *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+    *pnInputVal = GSLC_PIN_BTN_A;
+  }  else if (M5.BtnB.wasReleased()) {
+    *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+    *pnInputVal = GSLC_PIN_BTN_B;
+  }  else if (M5.BtnC.wasReleased()) {
+    *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+    *pnInputVal = GSLC_PIN_BTN_C;
   } else {
-	  return false; // No pin event detected
+    return false; // No pin event detected
   }
 
   // If we reached here, then we had a button event
-	return true;
+  return true;
 }
 
 #endif // DRV_TOUCH_IN_DISP
@@ -894,12 +899,12 @@ bool gslc_DrvGetInput(gslc_tsGui* pGui, gslc_teInputRawEvent* peInputEvent, int1
   M5.update();
 
   if      (M5.BtnA.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_A; }
-	else if (M5.BtnB.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_B; }
-	else if (M5.BtnC.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_C; }
-	else return false; // No pin event detected
+  else if (M5.BtnB.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_B; }
+  else if (M5.BtnC.wasReleased()) { *peInputEvent = GSLC_INPUT_PIN_ASSERT; *pnInputVal = GSLC_PIN_BTN_C; }
+  else return false; // No pin event detected
 
   // If we reached here, then we had a button event
-	return true;
+  return true;
 }
 
 

--- a/src/GUIslice_drv_m5stack.h
+++ b/src/GUIslice_drv_m5stack.h
@@ -563,8 +563,6 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
 ///
 bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation);
 
-/// \todo Doc
-bool gslc_DrvGetInput(gslc_tsGui* pGui, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 
 // =======================================================================
 // Private Functions

--- a/src/GUIslice_drv_m5stack.h
+++ b/src/GUIslice_drv_m5stack.h
@@ -49,6 +49,13 @@ extern "C" {
 #include <stdio.h>
 
 
+// ------------------------------------------------------------------------
+// Error Strings
+// ------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
 
 
 // =======================================================================
@@ -488,6 +495,43 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY, cons
 ///
 void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
 
+
+// -----------------------------------------------------------------------
+// Touch Functions (if using display driver library)
+// -----------------------------------------------------------------------
+
+#if defined(DRV_TOUCH_IN_DISP)
+// Use M5stack's integrated button handler
+
+///
+/// Perform any touch-specific initialization
+/// - This function doesn't do anything in M5stack
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  acDev:       Device path to touchscreen
+///                          eg. "/dev/input/touchscreen"
+///
+/// \return true if successful
+///
+bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev);
+
+
+///
+/// Get the last touch event from the internal button handler
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[out] pnX:         Ptr to X coordinate of last touch event (UNUSED)
+/// \param[out] pnY:         Ptr to Y coordinate of last touch event (UNUSED)
+/// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch) (UNUSED)
+///
+/// \return true if an event was detected or false otherwise
+/// \todo Doc
+///
+bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal);
+
+#endif // DRV_TOUCH_IN_DISP
+
+
 // -----------------------------------------------------------------------
 // Dynamic Screen rotation and Touch axes swap/flip functions
 // -----------------------------------------------------------------------
@@ -519,6 +563,8 @@ bool gslc_DrvRotateSwapFlip(gslc_tsGui* pGui, uint8_t nRotation, uint8_t nSwapXY
 ///
 bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation);
 
+/// \todo Doc
+bool gslc_DrvGetInput(gslc_tsGui* pGui, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 
 // =======================================================================
 // Private Functions

--- a/src/GUIslice_drv_sdl.h
+++ b/src/GUIslice_drv_sdl.h
@@ -426,9 +426,9 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
 /// \param[out] pnX:         Ptr to X coordinate of last touch event
 /// \param[out] pnY:         Ptr to Y coordinate of last touch event
 /// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
-/// xxx TODO doc
 ///
 /// \return true if an event was detected or false otherwise
+/// \todo Doc
 ///
 bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal);
 
@@ -629,9 +629,9 @@ bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev);
 /// \param[out] pnX:         Ptr to X coordinate of last touch event
 /// \param[out] pnY:         Ptr to Y coordinate of last touch event
 /// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, >0 for touch)
-/// xxx TODO doc
 ///
 /// \return non-zero if an event was detected or 0 otherwise
+/// \todo Doc
 ///
 bool gslc_TDrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pnPress, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -517,9 +517,9 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev);
 /// \param[out] pnX:         Ptr to X coordinate of last touch event
 /// \param[out] pnY:         Ptr to Y coordinate of last touch event
 /// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
-/// xxx TODO doc
 ///
 /// \return true if an event was detected or false otherwise
+/// \todo Doc
 ///
 bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal);
 
@@ -551,9 +551,9 @@ bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev);
 /// \param[out] pnX:         Ptr to X coordinate of last touch event
 /// \param[out] pnY:         Ptr to Y coordinate of last touch event
 /// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
-/// xxx TODO doc
 ///
 /// \return true if an event was detected or false otherwise
+/// \todo Doc
 ///
 bool gslc_TDrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pnPress, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
 


### PR DESCRIPTION
This PR adds support for M5stack's built-in buttons, enabling them to navigate through the GUI per #66 
- Example `arduino/ex23_m5_input_btn` has been created to demonstrate its usage
- `GUIslice_config_ard.h` must set `DRV_TOUCH_M5STACK` to 1 to enable the M5stack button navigation feature

Note that slider control (via long-presses) is only enabled if `M5STACK_TOUCH_PRESS_LONG` is defined.
- By default, long press button detection is disabled as it is only available in the most recent releases for the M5stack library (which provides the `Btn.wasReleasefor()` API). Uncommenting the `M5STACK_TOUCH_PRESS_LONG` line in the config file will enable the long-press feature.