### PR TITLE
Add support for MCUFRIEND displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - Includes cross-platform **GUIslice Builder** (beta) desktop application to generate layouts
 - *Platform-independent GUI core currently supports*: SDL1.2, SDL2.0, Adafruit-GFX, TFT_eSPI
 - *Devices*: Raspberry Pi, Arduino, ESP8266 / NodeMCU, ESP32, M5stack, Feather M0 (Cortex-M0), nRF52 (Cortex-M4F), LINUX, Beaglebone Black, STM32
-- *Typical displays*: PiTFT, Waveshare, Adafruit TFT 3.5" / 2.8" / 2.4" / 2.2" / 1.44", OLED 0.96", 4D Cape
+- *Typical displays*: PiTFT, Adafruit TFT 3.5" / 2.8" / 2.4" / 2.2" / 1.44", OLED 0.96", mcufriend, Waveshare, 4D Cape
 - *Display drivers include*: ILI9341, ST7735, SSD1306, HX8357, PCD8544
 - *Touchscreen control including*: STMPE610, FT6206, XPT2046, 4-wire, tslib
 - Foreign characters / UTF-8 encoding (in SDL mode), anti-aliased fonts (in TFT_eSPI mode)

--- a/configs/ard-adagfx-mcufriend-simple.h
+++ b/configs/ard-adagfx-mcufriend-simple.h
@@ -1,0 +1,239 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration #???) for:
+//   - CPU:     Arduino UNO (ATmega328P)
+//              Arduino Mega2560 (ATmega2560)
+//   - Display: mcufriend (various)
+//   - Touch:   Simple Analog (Resistive)
+//   - Wiring:  Uno/MEGA shield
+//              - Display pinout defined by mcufriend_kbv library
+//              - Touch pinout:
+//                  CPU     Touch
+//                  ----    -------
+//                  A1      YP / Y+
+//                  A2      XM / X-
+//                  7       YM / Y-
+//                  6       XP / X+
+//
+//   - Example display:
+//     - 
+//
+// DIRECTIONS:
+// - To use this example configuration, rename the file as "GUIslice_config_ard.h"
+//   and copy into the GUIslice/src directory.
+//
+// WIRING:
+// - The pinout configuration may need to be modified to match your wiring
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2018 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX           // Adafruit-GFX library
+  #define DRV_DISP_ADAGFX_MCUFRIEND // MCUFRIEND_kbv display driver
+  #define DRV_TOUCH_ADA_SIMPLE      // Adafruit_TouchScreen touch driver
+
+
+  // -----------------------------------------------------------------------------
+  // Pinout
+  // -----------------------------------------------------------------------------
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+  // -----------------------------------------------------------------------------
+  // Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  // - Note that changing this value may require a change
+  //   to GSLC_TOUCH_ROTATE as well to ensure the touch screen
+  //   orientation matches the display.
+  #define GSLC_ROTATE     1
+
+  // Set Default rotation of the touch overlay
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_TOUCH_ROTATE 3
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Pinout for DRV_TOUCH_SIMPLE 4-wire resistive touchscreen
+  #define ADATOUCH_PIN_YP   A1    // "Y+": Must be an analog pin
+  #define ADATOUCH_PIN_XM   A2    // "X-": Must be an analog pin
+  #define ADATOUCH_PIN_YM   7     // "Y-": Can be a digital pin
+  #define ADATOUCH_PIN_XP   6     // "X+": Can be a digital pin
+  #define ADATOUCH_RX       300   // "rxplate"
+
+  // Calibration for DRV_TOUCH_STMPE610 & DRV_TOUCH_SIMPLE
+  // - These values may need to be updated to match your display
+  // - Typically used in resistive displays
+  // - These values can be determined from the Adafruit touchtest example sketch
+  //   (check for min and max values reported from program as you touch display
+  //   corners)
+  // - Note that X & Y directions reference the display's natural orientation
+  #define ADATOUCH_X_MIN    100
+  #define ADATOUCH_Y_MIN    150
+  #define ADATOUCH_X_MAX    900
+  #define ADATOUCH_Y_MAX    900
+
+  // DRV_TOUCH_SIMPLE: Define pressure threshold for detecting a touch
+  #define ADATOUCH_PRESS_MIN  10
+  #define ADATOUCH_PRESS_MAX  1000
+
+  // -----------------------------------------------------------------------------
+  // Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to 1 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1 to enable, 0 to disable
+
+  // -----------------------------------------------------------------------------
+  // Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XGAUGE_RADIAL  0   // XGauge control with radial support
+  #define GSLC_FEATURE_XGAUGE_RAMP    0   // XGauge control with ramp support
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define how touch orientation changes with display orientation
+  #define TOUCH_ROTATION_DATA 0x6350
+  #define TOUCH_ROTATION_SWAPXY(rotation) ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 2 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPX(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 1 ) & 0x01 )
+  #define TOUCH_ROTATION_FLIPY(rotation)  ((( TOUCH_ROTATION_DATA >> ((rotation&0x03)*4) ) >> 0 ) & 0x01 )
+
+  // - Set any of the following to 1 to perform touch display
+  //   remapping functions, 0 to disable. Use DBG_TOUCH to determine which
+  //   remapping modes should be enabled for your display
+  // - Please refer to "docs/GUIslice_config_guide.xlsx" for detailed examples
+  // - NOTE: Both settings, GLSC_TOUCH_ROTATE and SWAP / FLIP are applied, 
+  //         try to set _SWAP_XY and _FLIP_X/Y to 0 and only use GLSC_TOUCH_ROTATE
+  #define ADATOUCH_SWAP_XY  0
+  #define ADATOUCH_FLIP_X   0
+  #define ADATOUCH_FLIP_Y   0
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default:pink)
+
+  #define GSLC_USE_FLOAT      0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM 1
+
+  #define GSLC_LOCAL_STR      0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN  30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -79,6 +79,12 @@
   #elif defined(DRV_DISP_ADAGFX_PCD8544)
     #include <Adafruit_PCD8544.h>
     #include <SPI.h>
+  #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
+    #include <MCUFRIEND_kbv.h>
+    #if (GSLC_SD_EN)
+      #include <SD.h>   // Include support for SD card access
+    #endif
+
   #else
     #error "CONFIG: Need to enable a supported DRV_DISP_ADAGFX_* option in GUIslice_config_ard.h"
   #endif
@@ -179,6 +185,10 @@ extern "C" {
   #else
     Adafruit_PCD8544 m_disp(ADAGFX_PIN_CLK, ADAGFX_PIN_MOSI, DAGFX_PIN_DC, ADAGFX_PIN_CS, ADAGFX_PIN_RST);
   #endif
+
+// ------------------------------------------------------------------------
+#elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
+  MCUFRIEND_kbv m_disp;
 
 // ------------------------------------------------------------------------
 #endif // DRV_DISP_ADAGFX_*
@@ -295,6 +305,13 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
     #elif defined(DRV_DISP_ADAGFX_PCD8544)
       m_disp.begin();
       //m_disp.setContrast(50); Set the contrast level
+
+    #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
+      uint16_t identifier = m_disp.readID();
+      m_disp.begin(identifier);
+      m_disp.setRotation(pGui->nRotation);
+      pGui->nDispW = m_disp.width();
+      pGui->nDispH = m_disp.height();
 
     #endif
 


### PR DESCRIPTION
- Initial support for MCUFRIEND displays #82 
- Uses the [MCUFRIEND_kbv](https://github.com/prenticedavid/MCUFRIEND_kbv) library
- Adds config mode: `DRV_DISP_ADAGFX_MCUFRIEND`
- Example config added: `ard-adagfx-mcufriend-simple.h`
