### PR TITLE
Fix: touch constraints after display remapping in TDrvGetTouch()

### DIFF
--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1267,12 +1267,12 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
 
     // For resistive displays, perform constraint and scaling
     #if defined(DRV_TOUCH_ADA_STMPE610) || defined(DRV_TOUCH_ADA_SIMPLE) || defined(DRV_TOUCH_XPT2046)
-      // Perform constraining to input boundaries
-      nInputX = constrain(nInputX,ADATOUCH_X_MIN,ADATOUCH_X_MAX);
-      nInputY = constrain(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX);
       // Perform scaling from input to output
       nOutputX = map(nInputX,ADATOUCH_X_MIN,ADATOUCH_X_MAX,0,nDispOutMaxX);
       nOutputY = map(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX,0,nDispOutMaxY);
+      // Perform constraining to OUTPUT boundaries .kbv
+      nOutputX = constrain(nOutputX,0,nDispOutMaxX);
+      nOutputY = constrain(nOutputY,0,nDispOutMaxY);
     #else
       // No scaling from input to output
       nOutputX = nInputX;

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -1156,11 +1156,11 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     // For resistive displays, perform constraint and scaling
     #if defined(DRV_TOUCH_ADA_STMPE610) || defined(DRV_TOUCH_ADA_SIMPLE)
       // Perform scaling from input to output
-      nOutputX = map(nInputX, ADATOUCH_X_MIN, ADATOUCH_X_MAX, 0, nDispOutMaxX);
-      nOutputY = map(nInputY, ADATOUCH_Y_MIN, ADATOUCH_Y_MAX, 0, nDispOutMaxY);
+      nOutputX = map(nInputX,ADATOUCH_X_MIN,ADATOUCH_X_MAX,0,nDispOutMaxX);
+      nOutputY = map(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX,0,nDispOutMaxY);
       // Perform constraining to OUTPUT boundaries
-      nOutputX = constrain(nOutputX, 0, nDispOutMaxX);
-      nOutputY = constrain(nOutputY, 0, nDispOutMaxY);
+      nOutputX = constrain(nOutputX,0,nDispOutMaxX);
+      nOutputY = constrain(nOutputY,0,nDispOutMaxY);
     #else
       // No scaling from input to output
       nOutputX = nInputX;

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -1155,12 +1155,12 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
 
     // For resistive displays, perform constraint and scaling
     #if defined(DRV_TOUCH_ADA_STMPE610) || defined(DRV_TOUCH_ADA_SIMPLE)
-      // Perform constraining to input boundaries
-      nInputX = constrain(nInputX,ADATOUCH_X_MIN,ADATOUCH_X_MAX);
-      nInputY = constrain(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX);
       // Perform scaling from input to output
-      nOutputX = map(nInputX,ADATOUCH_X_MIN,ADATOUCH_X_MAX,0,nDispOutMaxX);
-      nOutputY = map(nInputY,ADATOUCH_Y_MIN,ADATOUCH_Y_MAX,0,nDispOutMaxY);
+      nOutputX = map(nInputX, ADATOUCH_X_MIN, ADATOUCH_X_MAX, 0, nDispOutMaxX);
+      nOutputY = map(nInputY, ADATOUCH_Y_MIN, ADATOUCH_Y_MAX, 0, nDispOutMaxY);
+      // Perform constraining to OUTPUT boundaries
+      nOutputX = constrain(nOutputX, 0, nDispOutMaxX);
+      nOutputY = constrain(nOutputY, 0, nDispOutMaxY);
     #else
       // No scaling from input to output
       nOutputX = nInputX;


### PR DESCRIPTION
- Integrated changes from @prenticedavid GUIslice/mcufriend 4a48e066