### PR TITLE
4wire touch release workaround

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -3260,12 +3260,12 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   if ((pGui->nTouchLastPress == 0) && (nPress > 0)) {
     eTouch = GSLC_TOUCH_DOWN;
     #ifdef DBG_TOUCH
-    GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchDown\n",nX,nY,nPress);
+    GSLC_DEBUG_PRINT("Trk:                                           (%3d,%3d) P=%3u : TouchDown\n",nX,nY,nPress);
     #endif
   } else if ((pGui->nTouchLastPress > 0) && (nPress == 0)) {
     eTouch = GSLC_TOUCH_UP;
     #ifdef DBG_TOUCH
-    GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchUp\n",nX,nY,nPress);
+    GSLC_DEBUG_PRINT("Trk:                                           (%3d,%3d) P=%3u : TouchUp\n",nX,nY,nPress);
     #endif
 
   } else if ((pGui->nTouchLastX != nX) || (pGui->nTouchLastY != nY)) {
@@ -3273,7 +3273,7 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
     if (nPress > 0) {
       eTouch = GSLC_TOUCH_MOVE;
       #ifdef DBG_TOUCH
-      GSLC_DEBUG_PRINT(" TS : (%3d,%3d) Pressure=%3u : TouchMove\n",nX,nY,nPress);
+      GSLC_DEBUG_PRINT("Trk:                                           (%3d,%3d) P=%3u : TouchMove\n",nX,nY,nPress);
       #endif
     }
   }

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1129,7 +1129,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
   #elif defined(DRV_TOUCH_ADA_SIMPLE)
 
   uint16_t  nRawX,nRawY;
-  uint8_t   nRawPress;
+  int16_t   nRawPress;
 
   TSPoint p = m_touch.getPoint();
 
@@ -1140,12 +1140,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
   // Note that the minimum is not "> 0" as some
   // displays may produce a (small) non-zero value
   // when not touched.
-  #if defined(ADATOUCH_PRESS_MIN) && defined(ADATOUCH_PRESS_MAX)
   if ((p.z > ADATOUCH_PRESS_MIN) && (p.z < ADATOUCH_PRESS_MAX)) {
-  #else
-  if ((p.z > 10) && (p.z < 1000)) {
-  #endif
-
     nRawX = p.x;
     nRawY = p.y;
     nRawPress = p.z;


### PR DESCRIPTION
Workaround for Adafruit_TouchScreen intermittent touch release (#96)
- Applies to `DRV_TOUCH_ADA_SIMPLE` mode