### PR TITLE
Touch controllers with swapped XY

### DIFF
--- a/configs/ard-adagfx-hx8347-xpt2046.h
+++ b/configs/ard-adagfx-hx8347-xpt2046.h
@@ -133,7 +133,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3837
   #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/ard-adagfx-hx8347-xpt2046.h
+++ b/configs/ard-adagfx-hx8347-xpt2046.h
@@ -130,11 +130,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_XPT2046:
   #define ADATOUCH_X_MIN    246
-  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_X_MAX    3837
+  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-hx8357-simple.h
+++ b/configs/ard-adagfx-hx8357-simple.h
@@ -147,14 +147,16 @@ extern "C" {
 
   // Calibration settings from diag_ard_touch_calib:
   #define ADATOUCH_X_MIN    100
-  #define ADATOUCH_Y_MIN    150
   #define ADATOUCH_X_MAX    900
+  #define ADATOUCH_Y_MIN    150
   #define ADATOUCH_Y_MAX    900
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
 
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-hx8357-simple.h
+++ b/configs/ard-adagfx-hx8357-simple.h
@@ -150,13 +150,12 @@ extern "C" {
   #define ADATOUCH_X_MAX    900
   #define ADATOUCH_Y_MIN    150
   #define ADATOUCH_Y_MAX    900
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
-
-  // Certain touch controllers may swap X & Y coords
-  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-hx8357-stmpe610.h
+++ b/configs/ard-adagfx-hx8357-stmpe610.h
@@ -136,11 +136,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_ADA_STMPE610 [240x320]:
   #define ADATOUCH_X_MIN    244
-  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_X_MAX    3858
+  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-hx8357-stmpe610.h
+++ b/configs/ard-adagfx-hx8357-stmpe610.h
@@ -139,7 +139,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3858
   #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/ard-adagfx-ili9341-simple.h
+++ b/configs/ard-adagfx-ili9341-simple.h
@@ -147,14 +147,16 @@ extern "C" {
 
   // Calibration settings from diag_ard_touch_calib:
   #define ADATOUCH_X_MIN    100
-  #define ADATOUCH_Y_MIN    150
   #define ADATOUCH_X_MAX    900
+  #define ADATOUCH_Y_MIN    150
   #define ADATOUCH_Y_MAX    900
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
 
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-ili9341-simple.h
+++ b/configs/ard-adagfx-ili9341-simple.h
@@ -150,13 +150,12 @@ extern "C" {
   #define ADATOUCH_X_MAX    900
   #define ADATOUCH_Y_MIN    150
   #define ADATOUCH_Y_MAX    900
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
-
-  // Certain touch controllers may swap X & Y coords
-  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-ili9341-stmpe610.h
+++ b/configs/ard-adagfx-ili9341-stmpe610.h
@@ -136,11 +136,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_ADA_STMPE610 [240x320]:
   #define ADATOUCH_X_MIN    244
-  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_X_MAX    3858
+  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-adagfx-ili9341-stmpe610.h
+++ b/configs/ard-adagfx-ili9341-stmpe610.h
@@ -139,7 +139,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3858
   #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/ard-adagfx-ili9341-xpt2046.h
+++ b/configs/ard-adagfx-ili9341-xpt2046.h
@@ -133,7 +133,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3837
   #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/ard-adagfx-ili9341-xpt2046.h
+++ b/configs/ard-adagfx-ili9341-xpt2046.h
@@ -130,11 +130,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_XPT2046:
   #define ADATOUCH_X_MIN    246
-  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_X_MAX    3837
+  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-shld-adafruit_28_res.h
+++ b/configs/ard-shld-adafruit_28_res.h
@@ -135,11 +135,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_ADA_STMPE610 [240x320]:
   #define ADATOUCH_X_MIN    244
-  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_X_MAX    3858
+  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-shld-adafruit_28_res.h
+++ b/configs/ard-shld-adafruit_28_res.h
@@ -138,7 +138,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3858
   #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/ard-shld-generic1_35_touch.h
+++ b/configs/ard-shld-generic1_35_touch.h
@@ -141,14 +141,16 @@ extern "C" {
 
   // Calibration settings from diag_ard_touch_calib:
   #define ADATOUCH_X_MIN    136
-  #define ADATOUCH_Y_MIN    942
   #define ADATOUCH_X_MAX    900
+  #define ADATOUCH_Y_MIN    942
   #define ADATOUCH_Y_MAX    139
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
 
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4C: Example pin configurations
@@ -165,8 +167,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    893
-  //#define ADATOUCH_Y_MIN    99
   //#define ADATOUCH_X_MAX    104
+  //#define ADATOUCH_Y_MIN    99
   //#define ADATOUCH_Y_MAX    892
 
   // MCUFRIEND_ID == 0x2053:
@@ -175,8 +177,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    138
-  //#define ADATOUCH_Y_MIN    132
   //#define ADATOUCH_X_MAX    891
+  //#define ADATOUCH_Y_MIN    132
   //#define ADATOUCH_Y_MAX    909
 
   // MCUFRIEND_ID == 0x7783:
@@ -186,8 +188,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    181
-  //#define ADATOUCH_Y_MIN    934
   //#define ADATOUCH_X_MAX    937
+  //#define ADATOUCH_Y_MIN    934
   //#define ADATOUCH_Y_MAX    219
 
   // MCUFRIEND_ID == 0x7789:
@@ -196,8 +198,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    885
-  //#define ADATOUCH_Y_MIN    111
   //#define ADATOUCH_X_MAX    148
+  //#define ADATOUCH_Y_MIN    111
   //#define ADATOUCH_Y_MAX    902
 
   // MCUFRIEND_ID == 0x8031:
@@ -206,8 +208,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    889
-  //#define ADATOUCH_Y_MIN    121
   //#define ADATOUCH_X_MAX    151
+  //#define ADATOUCH_Y_MIN    121
   //#define ADATOUCH_Y_MAX    886
 
   // MCUFRIEND_ID == 0x9320:
@@ -216,8 +218,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   9
   //#define ADATOUCH_PIN_XP   8
   //#define ADATOUCH_X_MIN    897
-  //#define ADATOUCH_Y_MIN    944
   //#define ADATOUCH_X_MAX    122
+  //#define ADATOUCH_Y_MIN    944
   //#define ADATOUCH_Y_MAX    141
 
   // MCUFRIEND_ID == 0x9327:
@@ -226,8 +228,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    126
-  //#define ADATOUCH_Y_MIN    106
   //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    106
   //#define ADATOUCH_Y_MAX    966
 
   // MCUFRIEND_ID == 0x9340:
@@ -237,8 +239,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7 
   //#define ADATOUCH_PIN_XP   6 
   //#define ADATOUCH_X_MIN    145
-  //#define ADATOUCH_Y_MIN    937
   //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    937
   //#define ADATOUCH_Y_MAX    165
 
   // MCUFRIEND_ID == 0x9341:
@@ -248,8 +250,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    905
-  //#define ADATOUCH_Y_MIN    950
   //#define ADATOUCH_X_MAX    187
+  //#define ADATOUCH_Y_MIN    950
   //#define ADATOUCH_Y_MAX    202
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .

--- a/configs/ard-shld-generic1_35_touch.h
+++ b/configs/ard-shld-generic1_35_touch.h
@@ -144,13 +144,12 @@ extern "C" {
   #define ADATOUCH_X_MAX    900
   #define ADATOUCH_Y_MIN    942
   #define ADATOUCH_Y_MAX    139
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
-
-  // Certain touch controllers may swap X & Y coords
-  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4C: Example pin configurations

--- a/configs/ard-shld-mcufriend_4wire.h
+++ b/configs/ard-shld-mcufriend_4wire.h
@@ -147,14 +147,16 @@ extern "C" {
   //   calibration values may not provide accurate touch tracking, therefore
   //   using the diag_ard_touch_calib utility is strongly recommended.
   #define ADATOUCH_X_MIN    905
-  #define ADATOUCH_Y_MIN    950
   #define ADATOUCH_X_MAX    187
+  #define ADATOUCH_Y_MIN    950
   #define ADATOUCH_Y_MAX    202
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
 
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4C: Example pin configurations
@@ -171,8 +173,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    893
-  //#define ADATOUCH_Y_MIN    99
   //#define ADATOUCH_X_MAX    104
+  //#define ADATOUCH_Y_MIN    99
   //#define ADATOUCH_Y_MAX    892
 
   // MCUFRIEND_ID == 0x2053:
@@ -181,8 +183,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    138
-  //#define ADATOUCH_Y_MIN    132
   //#define ADATOUCH_X_MAX    891
+  //#define ADATOUCH_Y_MIN    132
   //#define ADATOUCH_Y_MAX    909
 
   // MCUFRIEND_ID == 0x7783:
@@ -192,8 +194,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    181
-  //#define ADATOUCH_Y_MIN    934
   //#define ADATOUCH_X_MAX    937
+  //#define ADATOUCH_Y_MIN    934
   //#define ADATOUCH_Y_MAX    219
 
   // MCUFRIEND_ID == 0x7789:
@@ -202,8 +204,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    885
-  //#define ADATOUCH_Y_MIN    111
   //#define ADATOUCH_X_MAX    148
+  //#define ADATOUCH_Y_MIN    111
   //#define ADATOUCH_Y_MAX    902
 
   // MCUFRIEND_ID == 0x8031:
@@ -212,8 +214,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    889
-  //#define ADATOUCH_Y_MIN    121
   //#define ADATOUCH_X_MAX    151
+  //#define ADATOUCH_Y_MIN    121
   //#define ADATOUCH_Y_MAX    886
 
   // MCUFRIEND_ID == 0x9320:
@@ -222,8 +224,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   9
   //#define ADATOUCH_PIN_XP   8
   //#define ADATOUCH_X_MIN    897
-  //#define ADATOUCH_Y_MIN    944
   //#define ADATOUCH_X_MAX    122
+  //#define ADATOUCH_Y_MIN    944
   //#define ADATOUCH_Y_MAX    141
 
   // MCUFRIEND_ID == 0x9327:
@@ -232,8 +234,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    126
-  //#define ADATOUCH_Y_MIN    106
   //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    106
   //#define ADATOUCH_Y_MAX    966
 
   // MCUFRIEND_ID == 0x9340:
@@ -243,8 +245,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7 
   //#define ADATOUCH_PIN_XP   6 
   //#define ADATOUCH_X_MIN    145
-  //#define ADATOUCH_Y_MIN    937
   //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    937
   //#define ADATOUCH_Y_MAX    165
 
   // MCUFRIEND_ID == 0x9341:
@@ -254,8 +256,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    905
-  //#define ADATOUCH_Y_MIN    950
   //#define ADATOUCH_X_MAX    187
+  //#define ADATOUCH_Y_MIN    950
   //#define ADATOUCH_Y_MAX    202
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .

--- a/configs/ard-shld-mcufriend_4wire.h
+++ b/configs/ard-shld-mcufriend_4wire.h
@@ -150,13 +150,12 @@ extern "C" {
   #define ADATOUCH_X_MAX    187
   #define ADATOUCH_Y_MIN    950
   #define ADATOUCH_Y_MAX    202
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // Touch overlay resistance value
   // - In most cases, this value can be left as-is
   #define ADATOUCH_RX       300   // "rxplate"
-
-  // Certain touch controllers may swap X & Y coords
-  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4C: Example pin configurations

--- a/configs/ard-shld-mcufriend_xpt2046.h
+++ b/configs/ard-shld-mcufriend_xpt2046.h
@@ -123,7 +123,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    187
   #define ADATOUCH_Y_MIN    950
   #define ADATOUCH_Y_MAX    202
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/ard-shld-mcufriend_xpt2046.h
+++ b/configs/ard-shld-mcufriend_xpt2046.h
@@ -120,11 +120,12 @@ extern "C" {
   //   calibration values may not provide accurate touch tracking, therefore
   //   using the diag_ard_touch_calib utility is strongly recommended.
   #define ADATOUCH_X_MIN    905
-  #define ADATOUCH_Y_MIN    950
   #define ADATOUCH_X_MAX    187
+  #define ADATOUCH_Y_MIN    950
   #define ADATOUCH_Y_MAX    202
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4C: Example pin configurations
@@ -141,8 +142,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    893
-  //#define ADATOUCH_Y_MIN    99
   //#define ADATOUCH_X_MAX    104
+  //#define ADATOUCH_Y_MIN    99
   //#define ADATOUCH_Y_MAX    892
 
   // MCUFRIEND_ID == 0x2053:
@@ -151,8 +152,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    138
-  //#define ADATOUCH_Y_MIN    132
   //#define ADATOUCH_X_MAX    891
+  //#define ADATOUCH_Y_MIN    132
   //#define ADATOUCH_Y_MAX    909
 
   // MCUFRIEND_ID == 0x7783:
@@ -162,8 +163,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    181
-  //#define ADATOUCH_Y_MIN    934
   //#define ADATOUCH_X_MAX    937
+  //#define ADATOUCH_Y_MIN    934
   //#define ADATOUCH_Y_MAX    219
 
   // MCUFRIEND_ID == 0x7789:
@@ -172,8 +173,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    885
-  //#define ADATOUCH_Y_MIN    111
   //#define ADATOUCH_X_MAX    148
+  //#define ADATOUCH_Y_MIN    111
   //#define ADATOUCH_Y_MAX    902
 
   // MCUFRIEND_ID == 0x8031:
@@ -182,8 +183,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    889
-  //#define ADATOUCH_Y_MIN    121
   //#define ADATOUCH_X_MAX    151
+  //#define ADATOUCH_Y_MIN    121
   //#define ADATOUCH_Y_MAX    886
 
   // MCUFRIEND_ID == 0x9320:
@@ -192,8 +193,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   9
   //#define ADATOUCH_PIN_XP   8
   //#define ADATOUCH_X_MIN    897
-  //#define ADATOUCH_Y_MIN    944
   //#define ADATOUCH_X_MAX    122
+  //#define ADATOUCH_Y_MIN    944
   //#define ADATOUCH_Y_MAX    141
 
   // MCUFRIEND_ID == 0x9327:
@@ -202,8 +203,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   6
   //#define ADATOUCH_PIN_XP   7
   //#define ADATOUCH_X_MIN    126
-  //#define ADATOUCH_Y_MIN    106
   //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    106
   //#define ADATOUCH_Y_MAX    966
 
   // MCUFRIEND_ID == 0x9340:
@@ -213,8 +214,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7 
   //#define ADATOUCH_PIN_XP   6 
   //#define ADATOUCH_X_MIN    145
-  //#define ADATOUCH_Y_MIN    937
   //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    937
   //#define ADATOUCH_Y_MAX    165
 
   // MCUFRIEND_ID == 0x9341:
@@ -224,8 +225,8 @@ extern "C" {
   //#define ADATOUCH_PIN_YM   7
   //#define ADATOUCH_PIN_XP   6
   //#define ADATOUCH_X_MIN    905
-  //#define ADATOUCH_Y_MIN    950
   //#define ADATOUCH_X_MAX    187
+  //#define ADATOUCH_Y_MIN    950
   //#define ADATOUCH_Y_MAX    202
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .

--- a/configs/ard-shld-waveshare_28_touch.h
+++ b/configs/ard-shld-waveshare_28_touch.h
@@ -129,11 +129,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_XPT2046:
   #define ADATOUCH_X_MIN    246
-  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_X_MAX    3837
+  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/ard-shld-waveshare_28_touch.h
+++ b/configs/ard-shld-waveshare_28_touch.h
@@ -132,7 +132,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3837
   #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/esp-tftespi-default-stmpe610.h
+++ b/configs/esp-tftespi-default-stmpe610.h
@@ -141,11 +141,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_ADA_STMPE610 [240x320]:
   #define ADATOUCH_X_MIN    244
-  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_X_MAX    3858
+  #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/esp-tftespi-default-stmpe610.h
+++ b/configs/esp-tftespi-default-stmpe610.h
@@ -144,7 +144,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3858
   #define ADATOUCH_Y_MIN    141
   #define ADATOUCH_Y_MAX    3717
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/esp-tftespi-default-xpt2046.h
+++ b/configs/esp-tftespi-default-xpt2046.h
@@ -135,11 +135,12 @@ extern "C" {
   // Calibration settings from diag_ard_touch_calib:
   // DRV_TOUCH_XPT2046:
   #define ADATOUCH_X_MIN    246
-  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_X_MAX    3837
+  #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/esp-tftespi-default-xpt2046.h
+++ b/configs/esp-tftespi-default-xpt2046.h
@@ -138,7 +138,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    3837
   #define ADATOUCH_Y_MIN    3925
   #define ADATOUCH_Y_MAX    370
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/esp-tftespi-default-xpt2046_int.h
+++ b/configs/esp-tftespi-default-xpt2046_int.h
@@ -122,7 +122,6 @@ extern "C" {
 
   // Calibration data from TFT_eSPI for integrated XPT2046
   #define TFT_ESPI_TOUCH_CALIB { 321,3498,280,3593,3 }
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/esp-tftespi-default-xpt2046_int.h
+++ b/configs/esp-tftespi-default-xpt2046_int.h
@@ -123,7 +123,8 @@ extern "C" {
   // Calibration data from TFT_eSPI for integrated XPT2046
   #define TFT_ESPI_TOUCH_CALIB { 321,3498,280,3593,3 }
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/mult-shld-adafruit_24_feather_touch.h
+++ b/configs/mult-shld-adafruit_24_feather_touch.h
@@ -173,11 +173,12 @@ extern "C" {
 
   // Calibration settings from diag_ard_touch_calib:
   #define ADATOUCH_X_MIN    3824
-  #define ADATOUCH_Y_MIN    191
   #define ADATOUCH_X_MAX    235
+  #define ADATOUCH_Y_MIN    191
   #define ADATOUCH_Y_MAX    3725
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/mult-shld-adafruit_24_feather_touch.h
+++ b/configs/mult-shld-adafruit_24_feather_touch.h
@@ -176,7 +176,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    235
   #define ADATOUCH_Y_MIN    191
   #define ADATOUCH_Y_MAX    3725
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/configs/mult-shld-adafruit_35_feather_touch.h
+++ b/configs/mult-shld-adafruit_35_feather_touch.h
@@ -173,11 +173,12 @@ extern "C" {
 
   // Calibration settings from diag_ard_touch_calib:
   #define ADATOUCH_X_MIN    3824
-  #define ADATOUCH_Y_MIN    191
   #define ADATOUCH_X_MAX    235
+  #define ADATOUCH_Y_MIN    191
   #define ADATOUCH_Y_MAX    3725
 
-
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration

--- a/configs/mult-shld-adafruit_35_feather_touch.h
+++ b/configs/mult-shld-adafruit_35_feather_touch.h
@@ -176,7 +176,6 @@ extern "C" {
   #define ADATOUCH_X_MAX    235
   #define ADATOUCH_Y_MIN    191
   #define ADATOUCH_Y_MAX    3725
-
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
 

--- a/examples/arduino/diag_ard_touch_calib/diag_ard_touch_calib.ino
+++ b/examples/arduino/diag_ard_touch_calib/diag_ard_touch_calib.ino
@@ -36,6 +36,7 @@
 #else
   #error "Calibration only supported for resistive touch displays"
 #endif // DRV_TOUCH_*
+#define DO_CALIB
 // ------------------------------------------------------------
 
 // Import optional libraries
@@ -1236,7 +1237,12 @@ void setup()
   DrawBackground();
 
   // Initialize settings and report
-  GSLC_DEBUG_PRINT("\n=== Touch Calibration & Testing ===\n\n", "");
+  #if defined(DO_CALIB)
+    GSLC_DEBUG_PRINT("\n=== Touch Calibration ===\n\n", "");
+  #else
+    GSLC_DEBUG_PRINT("\n=== Touch Testing ===\n\n", "");
+  #endif
+
   #if defined(DRV_TOUCH_TYPE_RES)
     // Reset to calibration defaults from configuration
     m_nTouchCalXMin = ADATOUCH_X_MIN;

--- a/examples/arduino/diag_ard_touch_detect/diag_ard_touch_detect.ino
+++ b/examples/arduino/diag_ard_touch_detect/diag_ard_touch_detect.ino
@@ -183,7 +183,7 @@ bool DetectPins()
     }
   }
   else {
-    GSLC_DEBUG_PRINT("\nERROR - Touchscreen is probably broken\n", "");
+    GSLC_DEBUG_PRINT("\nERROR - Touchscreen is probably broken (or wrong DRV_TOUCH_* touch driver\n", "");
     bRet = false;
   }
 
@@ -200,6 +200,8 @@ void setup()
   Serial.begin(9600);
   gslc_InitDebug(&DebugOut);
   //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  GSLC_DEBUG_PRINT("\n=== Touch Pin Detection ===\n\n", "");
 
   // Detect pins before we initialize the display driver
   DetectId();

--- a/examples/arduino/diag_ard_touch_test/diag_ard_touch_test.ino
+++ b/examples/arduino/diag_ard_touch_test/diag_ard_touch_test.ino
@@ -390,7 +390,12 @@ void setup()
   DrawBackground();
 
   // Initialize settings and report
-  GSLC_DEBUG_PRINT("\n=== Touch Calibration & Testing ===\n\n", "");
+  #if defined(DO_CALIB)
+    GSLC_DEBUG_PRINT("\n=== Touch Calibration ===\n\n", "");
+  #else
+    GSLC_DEBUG_PRINT("\n=== Touch Testing ===\n\n", "");
+  #endif
+
   #if defined(DRV_TOUCH_TYPE_RES)
     // Reset to calibration defaults from configuration
     m_nTouchCalXMin = ADATOUCH_X_MIN;

--- a/examples/arduino/diag_ard_touch_test/diag_ard_touch_test.ino
+++ b/examples/arduino/diag_ard_touch_test/diag_ard_touch_test.ino
@@ -94,7 +94,7 @@ uint16_t  m_nTouchCalXMax;
 uint16_t  m_nTouchCalYMin;
 uint16_t  m_nTouchCalYMax;
 
-
+bool m_bRemapYX = false;
 
 bool m_bTouchCoordValid = false;
 
@@ -304,6 +304,7 @@ void DoFsm(bool bTouchDown, bool bTouchUp, int16_t nTouchX, int16_t nTouchY, uin
     // Assign the new touch calibration
     gslc_SetTouchRemapCal(&m_gui, m_nTouchCalXMin, m_nTouchCalXMax, m_nTouchCalYMin, m_nTouchCalYMax);
     gslc_SetTouchRemapEn(&m_gui, true);
+    gslc_SetTouchRemapYX(&m_gui, m_bRemapYX);
 
     m_eState = STATE_TEST_MSG;
     break;
@@ -396,8 +397,13 @@ void setup()
     m_nTouchCalXMax = ADATOUCH_X_MAX;
     m_nTouchCalYMin = ADATOUCH_Y_MIN;
     m_nTouchCalYMax = ADATOUCH_Y_MAX;
-    GSLC_DEBUG_PRINT("CALIB: Config defaults: XMin=%u XMax=%u YMin=%u YMax=%u\n",
-      ADATOUCH_X_MIN, ADATOUCH_X_MAX, ADATOUCH_Y_MIN, ADATOUCH_Y_MAX);
+    #if defined(ADATOUCH_REMAP_YX)
+      m_bRemapYX = ADATOUCH_REMAP_YX;
+    #else
+      m_bRemapYX = false;
+    #endif
+    GSLC_DEBUG_PRINT("CALIB: Config defaults: XMin=%u XMax=%u YMin=%u YMax=%u RemapYX=%u\n",
+      ADATOUCH_X_MIN, ADATOUCH_X_MAX, ADATOUCH_Y_MIN, ADATOUCH_Y_MAX,m_bRemapYX);
 
     #if defined(DRV_DISP_ADAGFX_MCUFRIEND)
       // For MCUFRIEND displays, report the ID

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -137,6 +137,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
       pGui->nTouchCalXMax = 1000;
       pGui->nTouchCalYMin = 100;
       pGui->nTouchCalYMax = 1000;
+      pGui->bTouchRemapYX = false;
     #endif // !DRV_TOUCH_NONE
 
   #endif
@@ -3492,6 +3493,17 @@ void gslc_SetTouchRemapCal(gslc_tsGui* pGui,uint16_t nXMin, uint16_t nXMax, uint
   pGui->nTouchCalYMin = nYMin;
   pGui->nTouchCalYMax = nYMax;
 }
+
+void gslc_SetTouchRemapYX(gslc_tsGui* pGui, bool bSwap)
+{
+  if (pGui == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "SetTouchRemapYX";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return;
+  }
+  pGui->bTouchRemapYX = bSwap;
+}
+
 
 #endif // !DRV_TOUCH_NONE
 

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -716,6 +716,7 @@ typedef struct {
   int16_t             nTouchLastY;      ///< Last touch event Y coord
   uint16_t            nTouchLastPress;  ///< Last touch event pressure (0=none))
   bool                bTouchRemapEn;    ///< Enable touch remapping?
+  bool                bTouchRemapYX;    ///< Enable touch controller swapping of X & Y
 
 
   void*               pvDriver;         ///< Driver-specific members (gslc_tsDriver*)
@@ -1973,6 +1974,15 @@ void gslc_SetTouchRemapEn(gslc_tsGui* pGui, bool bEn);
 ///
 void gslc_SetTouchRemapCal(gslc_tsGui* pGui,uint16_t nXMin, uint16_t nXMax, uint16_t nYMin, uint16_t nYMax);
 
+///
+/// Configure touchscreen XY swap
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  bSwap:       Enable touchscreen XY swap
+///
+/// \return none
+///
+void gslc_SetTouchRemapYX(gslc_tsGui* pGui, bool bSwap);
 
 #endif // !DRV_TOUCH_NONE
 

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1155,6 +1155,16 @@ bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
     pGui->nTouchCalYMax = ADATOUCH_Y_MAX;
   #endif // DRV_TOUCH_TYPE_RES
 
+  // Support touch controllers with swapped X & Y
+  #if defined(ADATOUCH_REMAP_YX)
+    // Capture swap setting from config file
+    pGui->bTouchRemapYX = ADATOUCH_REMAP_YX;
+  #else
+    // For backward compatibility with older config files
+    // that have not defined this config option
+    pGui->bTouchRemapYX = false;
+  #endif
+
   #if defined(DRV_TOUCH_ADA_STMPE610)
     #if (ADATOUCH_I2C_HW)
     if (!m_touch.begin(ADATOUCH_I2C_ADDR)) {
@@ -1541,6 +1551,16 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     // Input assignment
     nRawX = m_nLastRawX;
     nRawY = m_nLastRawY;
+
+    // Handle any hardware swapping in native orientation
+    // This is done prior to any flip/swap as a result of
+    // rotation away from the native orientation.
+    // In most cases, the following is not used, but there
+    // may be touch modules that have swapped their X&Y convention.
+    if (pGui->bTouchRemapYX) {
+      nRawX = m_nLastRawY;
+      nRawY = m_nLastRawX;
+    }
 
     nInputX = nRawX;
     nInputY = nRawY;

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.39"
+#define GUISLICE_VER "0.11.0.40"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.37"
+#define GUISLICE_VER "0.11.0.39"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.42"
+#define GUISLICE_VER "0.11.0.43"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.43"
+#define GUISLICE_VER "0.11.0.44"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.40"
+#define GUISLICE_VER "0.11.0.41"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.41"
+#define GUISLICE_VER "0.11.0.42"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.9"
+#define GUISLICE_VER "0.11.0.37"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
This PR provides an enhancement to detect and support external touch controllers that have swapped X & Y coordinates, per #113 .
- An enhanced calibration sketch has been provided
- Additional config option is available: `ADATOUCH_REMAP_YX` which will normally be 0 except for these particular displays.

A few other improvements have been made in this release, including a more consistent reporting of calibration values and diagnostic header messaging.