### PR TITLE
Add support for multi-layered pages & popups

### DIFF
--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -179,7 +179,7 @@ bool InitOverlays()
   // Checkbox element
   pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK1, E_PG_MAIN, &m_asXCheck[0],
     (gslc_tsRect) {
-    200, 120, 30, 30
+    100, 160, 30, 30
   }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
 
   // -----------------------------------

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -146,9 +146,9 @@ bool InitOverlays()
   // above sequence is E_PG_GLOBAL. Therefore, we should explicitly ensure
   // that the main page is the current page.
   gslc_SetPageCur(&m_gui, E_PG_MAIN);
-  // Now mark the E_PG_GLOBAL as a "global" page which means that it's elements
+  // Now mark the E_PG_GLOBAL as a "base" page which means that it's elements
   // are always visible. This is useful for common page elements.
-  gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);
+  gslc_SetPageBase(&m_gui, E_PG_GLOBAL);
 
   // -----------------------------------
   // PAGE: GLOBAL

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -124,9 +124,7 @@ bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, 
     else if (nElemId == E_ELEM_ALERT_CANCEL) {
       GSLC_DEBUG_PRINT("INFO: Alert popup selected Cancel\n", "");
       // Dispose of alert
-      gslc_SetStackPage(&m_gui, GSLC_STACK_OVR, GSLC_PAGE_NONE);
-      gslc_SetStackState(&m_gui, GSLC_STACK_GLB, true);
-      gslc_SetStackState(&m_gui, GSLC_STACK_CUR, true);
+      gslc_PopupHide(&m_gui);
     }
   }
   return true;

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -26,7 +26,7 @@
 // Defines for resources
 
 // Enumerations for pages, elements, fonts, images
-enum { E_PG_GLOBAL, E_PG_MAIN, E_PG_CONFIG, E_PG_ALERT };
+enum { E_PG_BASE, E_PG_MAIN, E_PG_CONFIG, E_PG_ALERT };
 enum {
   E_ELEM_BTN_QUIT, E_ELEM_TAB_MAIN, E_ELEM_TAB_CONFIG, E_ELEM_BTN_ALERT,
   E_ELEM_TXT_COUNT, E_ELEM_PROGRESS,
@@ -46,11 +46,11 @@ unsigned  m_nCount = 0;
 #define MAX_FONT                3
 
 // Define the maximum number of elements per page
-#define MAX_ELEM_PG_GLOBAL      8                  // # Elems total on Global page
+#define MAX_ELEM_PG_BASE      8                  // # Elems total on Global page
 #define MAX_ELEM_PG_MAIN        3                  // # Elems total on Main page
 #define MAX_ELEM_PG_CONFIG      6                  // # Elems total on Extra page
 #define MAX_ELEM_PG_ALERT       4                  // # Elems total on Alert popup page
-#define MAX_ELEM_PG_GLOBAL_RAM  MAX_ELEM_PG_GLOBAL // # Elems in RAM
+#define MAX_ELEM_PG_BASE_RAM  MAX_ELEM_PG_BASE // # Elems in RAM
 #define MAX_ELEM_PG_MAIN_RAM    MAX_ELEM_PG_MAIN   // # Elems in RAM
 #define MAX_ELEM_PG_CONFIG_RAM  MAX_ELEM_PG_CONFIG // # Elems in RAM
 #define MAX_ELEM_PG_ALERT_RAM   MAX_ELEM_PG_ALERT  // # Elems in RAM
@@ -59,8 +59,8 @@ gslc_tsGui                  m_gui;
 gslc_tsDriver               m_drv;
 gslc_tsFont                 m_asFont[MAX_FONT];
 gslc_tsPage                 m_asPage[MAX_PAGE];
-gslc_tsElem                 m_asGlbElem[MAX_ELEM_PG_GLOBAL_RAM];
-gslc_tsElemRef              m_asGlbElemRef[MAX_ELEM_PG_GLOBAL];
+gslc_tsElem                 m_asGlbElem[MAX_ELEM_PG_BASE_RAM];
+gslc_tsElemRef              m_asGlbElemRef[MAX_ELEM_PG_BASE];
 gslc_tsElem                 m_asMainElem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsElem                 m_asConfigElem[MAX_ELEM_PG_CONFIG_RAM];
@@ -97,8 +97,9 @@ void SetTabHighlight(int16_t nTabSel)
 // - Show example of common callback function
 bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
 {
-  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
-  gslc_tsElem* pElem = pElemRef->pElem;
+  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
   int16_t nElemId = pElem->nId;
   if (eTouch == GSLC_TOUCH_UP_IN) {
     if (nElemId == E_ELEM_BTN_QUIT) {
@@ -138,61 +139,55 @@ bool InitOverlays()
 {
   gslc_tsElemRef*  pElemRef = NULL;
 
-  gslc_PageAdd(&m_gui, E_PG_GLOBAL, m_asGlbElem, MAX_ELEM_PG_GLOBAL_RAM, m_asGlbElemRef, MAX_ELEM_PG_GLOBAL);
+  gslc_PageAdd(&m_gui, E_PG_BASE, m_asGlbElem, MAX_ELEM_PG_BASE_RAM, m_asGlbElemRef, MAX_ELEM_PG_BASE);
   gslc_PageAdd(&m_gui, E_PG_MAIN, m_asMainElem, MAX_ELEM_PG_MAIN_RAM, m_asMainElemRef, MAX_ELEM_PG_MAIN);
   gslc_PageAdd(&m_gui, E_PG_CONFIG, m_asConfigElem, MAX_ELEM_PG_CONFIG_RAM, m_asConfigElemRef, MAX_ELEM_PG_CONFIG);
   gslc_PageAdd(&m_gui, E_PG_ALERT, m_asAlertElem, MAX_ELEM_PG_ALERT_RAM, m_asAlertElemRef, MAX_ELEM_PG_ALERT);
 
   // Note that the current page defaults to the first page added, which in the
-  // above sequence is E_PG_GLOBAL. Therefore, we should explicitly ensure
+  // above sequence is E_PG_BASE. Therefore, we should explicitly ensure
   // that the main page is the current page.
   gslc_SetPageCur(&m_gui, E_PG_MAIN);
-  // Now mark the E_PG_GLOBAL as a "base" page which means that it's elements
+  // Now mark the E_PG_BASE as a "base" page which means that it's elements
   // are always visible. This is useful for common page elements.
-  gslc_SetPageBase(&m_gui, E_PG_GLOBAL);
+  gslc_SetPageBase(&m_gui, E_PG_BASE);
 
   // -----------------------------------
-  // PAGE: GLOBAL
+  // PAGE: BASE
   // Create title
-  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 10, 10, 100, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_BASE, (gslc_tsRect) { 10, 10, 100, 20 },
     (char*)"GUIslice Demo", 0, E_FONT_TITLE);
   gslc_ElemSetTxtAlign(&m_gui, pElemRef, GSLC_ALIGN_MID_LEFT);
   gslc_ElemSetFillEn(&m_gui, pElemRef, false);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
 
-  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_GLOBAL,
-    (gslc_tsRect) {
-    240, 5, 50, 25
-  }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnCommon);
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_BASE,
+    (gslc_tsRect) { 240, 5, 50, 25 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnCommon);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED_DK2, GSLC_COL_RED_DK4, GSLC_COL_RED_DK1);
 
-  pElemRef = gslc_ElemCreateLine(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, 0, 35, 320, 35);
+  pElemRef = gslc_ElemCreateLine(&m_gui, GSLC_ID_AUTO, E_PG_BASE, 0, 35, 320, 35);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLACK, GSLC_COL_GRAY, GSLC_COL_GRAY);
 
 
   // Create counter
-  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 110, 10, 50, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_BASE, (gslc_tsRect) { 110, 10, 50, 20 },
     (char*)"Count:", 0, E_FONT_TXT);
   static char mstr1[8] = "";
-  pElemRef = gslc_ElemCreateTxt(&m_gui, E_ELEM_TXT_COUNT, E_PG_GLOBAL, (gslc_tsRect) { 170, 10, 50, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_ELEM_TXT_COUNT, E_PG_BASE, (gslc_tsRect) { 170, 10, 50, 20 },
     mstr1, sizeof(mstr1), E_FONT_TXT);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_PURPLE);
   m_pElemCnt = pElemRef; // Save for quick access
 
 
   // Create Tab label buttons, start with main with framed highlight
-  m_pElemTabMain = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_MAIN, E_PG_GLOBAL,
-    (gslc_tsRect) {
-    30, 50, 50, 20
-  }, (char*)"Main", 0, E_FONT_BTN, &CbBtnCommon);
-  m_pElemTabConfig = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_CONFIG, E_PG_GLOBAL,
-    (gslc_tsRect) {
-    90, 50, 50, 20
-  }, (char*)"Extra", 0, E_FONT_BTN, &CbBtnCommon);
+  m_pElemTabMain = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_MAIN, E_PG_BASE,
+    (gslc_tsRect) { 30, 50, 50, 20 }, (char*)"Main", 0, E_FONT_BTN, &CbBtnCommon);
+  m_pElemTabConfig = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_CONFIG, E_PG_BASE,
+    (gslc_tsRect) { 90, 50, 50, 20 }, (char*)"Extra", 0, E_FONT_BTN, &CbBtnCommon);
   SetTabHighlight(E_ELEM_TAB_MAIN);
 
   // Create tab box
-  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 20, 70, 200, 150 });
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_BASE, (gslc_tsRect) { 20, 70, 200, 150 });
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
 
   // -----------------------------------
@@ -208,18 +203,14 @@ bool InitOverlays()
 
   // Checkbox element
   pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK1, E_PG_MAIN, &m_asXCheck[0],
-    (gslc_tsRect) {
-    100, 160, 30, 30
-  }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
+    (gslc_tsRect) { 100, 160, 30, 30 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
 
   // -----------------------------------
   // PAGE: CONFIG
 
   // Create Dummy button
   pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_ALERT, E_PG_CONFIG,
-    (gslc_tsRect) {
-    60, 170, 50, 20
-  }, (char*)"Alert", 0, E_FONT_BTN, &CbBtnCommon);
+    (gslc_tsRect) { 60, 170, 50, 20 }, (char*)"Alert", 0, E_FONT_BTN, &CbBtnCommon);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GREEN_DK2, GSLC_COL_GREEN_DK4, GSLC_COL_GREEN_DK1);
 
   // Create a few labels & checkboxes
@@ -227,17 +218,13 @@ bool InitOverlays()
   int16_t    nSpaceY = 30;
 
   pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK2, E_PG_CONFIG, &m_asXCheck[1],
-    (gslc_tsRect) {
-    60, nPosY, 20, 20
-  }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
+    (gslc_tsRect) { 60, nPosY, 20, 20 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
   pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
     (char*)"Data 1", 0, E_FONT_TXT);
   nPosY += nSpaceY;
 
   pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK3, E_PG_CONFIG, &m_asXCheck[2],
-    (gslc_tsRect) {
-    60, nPosY, 20, 20
-  }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
+    (gslc_tsRect) { 60, nPosY, 20, 20 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
   pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
     (char*)"Data 2", 0, E_FONT_TXT);
   nPosY += nSpaceY;
@@ -262,16 +249,12 @@ bool InitOverlays()
 
   // Create OK button
   pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_ALERT_OK, E_PG_ALERT,
-    (gslc_tsRect) {
-    160 - 40 - 30, 120 + 30, 2 * 30, 2 * 10
-  }, (char*)"OK", 0, E_FONT_BTN, &CbBtnCommon);
+    (gslc_tsRect) { 160 - 40 - 30, 120 + 30, 2 * 30, 2 * 10 }, (char*)"OK", 0, E_FONT_BTN, &CbBtnCommon);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK2, GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
 
   // Create Cancel button
   pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_ALERT_CANCEL, E_PG_ALERT,
-    (gslc_tsRect) {
-    160 + 40 - 30, 120 + 30, 2 * 30, 2 * 10
-  }, (char*)"Cancel", 0, E_FONT_BTN, &CbBtnCommon);
+    (gslc_tsRect) { 160 + 40 - 30, 120 + 30, 2 * 30, 2 * 10 }, (char*)"Cancel", 0, E_FONT_BTN, &CbBtnCommon);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK2, GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
 
 
@@ -321,7 +304,7 @@ void loop()
   gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress, ((m_nCount / 2) % 100));
 
   // We can change or disable the global page as needed:
-  //   gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);    // Set to E_PG_GLOBAL
+  //   gslc_SetPageGlobal(&m_gui, E_PG_BASE);    // Set to E_PG_BASE
   //   gslc_SetPageGlobal(&m_gui, GSLC_PAGE_NONE); // Disable
 
   // Periodically call GUIslice update function

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -1,0 +1,277 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 24 (Arduino):
+//   - Multiple page handling, tab dialog, global elements
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. Therefore, it may not
+//     run on Arduino devices with limited memory. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+// - To support a larger number of GUI elements, it is recommended to
+//   use a CPU that provides more than 2KB of SRAM (eg. ATmega2560).
+//
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum { E_PG_GLOBAL, E_PG_MAIN, E_PG_CONFIG };
+enum {
+  E_ELEM_BTN_QUIT, E_ELEM_TAB_MAIN, E_ELEM_TAB_CONFIG, E_ELEM_BTN_CALC,
+  E_ELEM_TXT_COUNT, E_ELEM_PROGRESS,
+  E_ELEM_CHECK1, E_ELEM_CHECK2, E_ELEM_CHECK3
+};
+enum { E_FONT_BTN, E_FONT_TXT, E_FONT_TITLE };
+
+bool      m_bQuit = false;
+
+// Free-running counter for display
+unsigned  m_nCount = 0;
+
+// Instantiate the GUI
+#define MAX_PAGE                3
+#define MAX_FONT                3
+
+// Define the maximum number of elements per page
+#define MAX_ELEM_PG_GLOBAL      8                  // # Elems total on Global page
+#define MAX_ELEM_PG_MAIN        3                  // # Elems total on Main page
+#define MAX_ELEM_PG_CONFIG      6                  // # Elems total on Extra page
+#define MAX_ELEM_PG_GLOBAL_RAM  MAX_ELEM_PG_GLOBAL // # Elems in RAM
+#define MAX_ELEM_PG_MAIN_RAM    MAX_ELEM_PG_MAIN   // # Elems in RAM
+#define MAX_ELEM_PG_CONFIG_RAM  MAX_ELEM_PG_CONFIG // # Elems in RAM
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asGlbElem[MAX_ELEM_PG_GLOBAL_RAM];
+gslc_tsElemRef              m_asGlbElemRef[MAX_ELEM_PG_GLOBAL];
+gslc_tsElem                 m_asMainElem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asConfigElem[MAX_ELEM_PG_CONFIG_RAM];
+gslc_tsElemRef              m_asConfigElemRef[MAX_ELEM_PG_CONFIG];
+
+gslc_tsXGauge               m_sXGauge;
+gslc_tsXCheckbox            m_asXCheck[3];
+
+
+#define MAX_STR             8
+
+// Save some element pointers for quick access
+gslc_tsElemRef*  m_pElemCnt = NULL;
+gslc_tsElemRef*  m_pElemProgress = NULL;
+gslc_tsElemRef*  m_pElemTabMain = NULL;
+gslc_tsElemRef*  m_pElemTabConfig = NULL;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Update the tab dialog button highlights
+void SetTabHighlight(int16_t nTabSel)
+{
+  gslc_ElemSetCol(&m_gui, m_pElemTabMain, (nTabSel == E_ELEM_TAB_MAIN) ? GSLC_COL_WHITE : GSLC_COL_BLUE_DK2,
+    GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
+  gslc_ElemSetCol(&m_gui, m_pElemTabConfig, (nTabSel == E_ELEM_TAB_CONFIG) ? GSLC_COL_WHITE : GSLC_COL_BLUE_DK2,
+    GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
+}
+
+// Button callbacks
+// - Show example of common callback function
+bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+  int16_t nElemId = pElem->nId;
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    if (nElemId == E_ELEM_BTN_QUIT) {
+      m_bQuit = true;
+    }
+    else if (nElemId == E_ELEM_TAB_CONFIG) {
+      gslc_SetPageCur(&m_gui, E_PG_CONFIG);
+      SetTabHighlight(E_ELEM_TAB_CONFIG);
+    }
+    else if (nElemId == E_ELEM_TAB_MAIN) {
+      gslc_SetPageCur(&m_gui, E_PG_MAIN);
+      SetTabHighlight(E_ELEM_TAB_MAIN);
+    }
+  }
+  return true;
+}
+
+
+
+// Create the default elements on each page
+bool InitOverlays()
+{
+  gslc_tsElemRef*  pElemRef = NULL;
+
+  gslc_PageAdd(&m_gui, E_PG_GLOBAL, m_asGlbElem, MAX_ELEM_PG_GLOBAL_RAM, m_asGlbElemRef, MAX_ELEM_PG_GLOBAL);
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asMainElem, MAX_ELEM_PG_MAIN_RAM, m_asMainElemRef, MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui, E_PG_CONFIG, m_asConfigElem, MAX_ELEM_PG_CONFIG_RAM, m_asConfigElemRef, MAX_ELEM_PG_CONFIG);
+
+  // Note that the current page defaults to the first page added, which in the
+  // above sequence is E_PG_GLOBAL. Therefore, we should explicitly ensure
+  // that the main page is the current page.
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+  // Now mark the E_PG_GLOBAL as a "global" page which means that it's elements
+  // are always visible. This is useful for common page elements.
+  gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);
+
+  // -----------------------------------
+  // PAGE: GLOBAL
+  // Create title
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 10, 10, 100, 20 },
+    (char*)"GUIslice Demo", 0, E_FONT_TITLE);
+  gslc_ElemSetTxtAlign(&m_gui, pElemRef, GSLC_ALIGN_MID_LEFT);
+  gslc_ElemSetFillEn(&m_gui, pElemRef, false);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_GLOBAL,
+    (gslc_tsRect) { 240, 5, 50, 25 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnCommon);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED_DK2, GSLC_COL_RED_DK4, GSLC_COL_RED_DK1);
+
+  pElemRef = gslc_ElemCreateLine(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, 0, 35, 320, 35);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLACK, GSLC_COL_GRAY, GSLC_COL_GRAY);
+
+
+  // Create counter
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 110, 10, 50, 20 },
+    (char*)"Count:", 0, E_FONT_TXT);
+  static char mstr1[8] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_ELEM_TXT_COUNT, E_PG_GLOBAL, (gslc_tsRect) { 170, 10, 50, 20 },
+    mstr1, sizeof(mstr1), E_FONT_TXT);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_PURPLE);
+  m_pElemCnt = pElemRef; // Save for quick access
+
+
+  // Create Tab label buttons, start with main with framed highlight
+  m_pElemTabMain = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_MAIN, E_PG_GLOBAL,
+    (gslc_tsRect) { 30, 50, 50, 20 }, (char*)"Main", 0, E_FONT_BTN, &CbBtnCommon);
+  m_pElemTabConfig = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_CONFIG, E_PG_GLOBAL,
+    (gslc_tsRect) { 90, 50, 50, 20 }, (char*)"Extra", 0, E_FONT_BTN, &CbBtnCommon);
+  SetTabHighlight(E_ELEM_TAB_MAIN);
+
+  // Create tab box
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 20, 70, 280, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
+
+  // -----------------------------------
+  // PAGE: MAIN
+
+  // Create progress bar
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 40, 120, 50, 10 },
+    (char*)"Progress:", 0, E_FONT_TXT);
+  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_ELEM_PROGRESS, E_PG_MAIN, &m_sXGauge, (gslc_tsRect) { 100, 120, 50, 10 },
+    0, 100, 0, GSLC_COL_GREEN, false);
+  m_pElemProgress = pElemRef; // Save for quick access
+
+
+  // Checkbox element
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK1, E_PG_MAIN, &m_asXCheck[0],
+    (gslc_tsRect) {
+    200, 120, 30, 30
+  }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
+
+  // -----------------------------------
+  // PAGE: CONFIG
+
+  // Create Dummy button
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_CALC, E_PG_CONFIG,
+    (gslc_tsRect) { 60, 170, 50, 20 }, (char*)"Calc", 0, E_FONT_BTN, &CbBtnCommon);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GREEN_DK2, GSLC_COL_GREEN_DK4, GSLC_COL_GREEN_DK1);
+
+  // Create a few labels & checkboxes
+  int16_t    nPosY = 80;
+  int16_t    nSpaceY = 30;
+
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK2, E_PG_CONFIG, &m_asXCheck[1],
+    (gslc_tsRect) { 60, nPosY, 20, 20 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
+    (char*)"Data 1", 0, E_FONT_TXT);
+  nPosY += nSpaceY;
+
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK3, E_PG_CONFIG, &m_asXCheck[2],
+    (gslc_tsRect) { 60, nPosY, 20, 20 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
+    (char*)"Data 2", 0, E_FONT_TXT);
+  nPosY += nSpaceY;
+
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
+    (char*)"Data 3", 0, E_FONT_TXT);
+  nPosY += nSpaceY;
+
+  return true;
+}
+
+
+void setup()
+{
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  // Initialize
+  if (!gslc_Init(&m_gui, &m_drv, m_asPage, MAX_PAGE, m_asFont, MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui, E_FONT_BTN, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+  if (!gslc_FontAdd(&m_gui, E_FONT_TXT, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+  if (!gslc_FontAdd(&m_gui, E_FONT_TITLE, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+
+  // Create page elements
+  InitOverlays();
+
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+
+  m_bQuit = false;
+}
+
+void loop()
+{
+  char              acTxt[MAX_STR];
+
+
+  m_nCount++;
+
+  // Perform drawing updates
+  // - Note: we can make the updates conditional on the active
+  //   page by checking gslc_GetPageCur() first.
+
+  snprintf(acTxt, MAX_STR, "%u", m_nCount);
+  gslc_ElemSetTxtStr(&m_gui, m_pElemCnt, acTxt);
+
+  gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress, ((m_nCount / 2) % 100));
+
+  // We can change or disable the global page as needed:
+  //   gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);    // Set to E_PG_GLOBAL
+  //   gslc_SetPageGlobal(&m_gui, GSLC_PAGE_NONE); // Disable
+
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // Slow down updates
+  delay(100);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) {}
+  }
+}
+
+

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -4,7 +4,8 @@
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 // - Example 24 (Arduino):
-//   - Multiple page handling, tab dialog, global elements
+//   - Multiple page handling, tab dialog, global (base layer) elements
+//     and popup dialog
 //   - NOTE: This is the simple version of the example without
 //     optimizing for memory consumption. Therefore, it may not
 //     run on Arduino devices with limited memory. A "minimal"

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -162,7 +162,7 @@ bool InitOverlays()
   SetTabHighlight(E_ELEM_TAB_MAIN);
 
   // Create tab box
-  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 20, 70, 280, 150 });
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 20, 70, 200, 150 });
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
 
   // -----------------------------------

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -114,16 +114,12 @@ bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, 
     else if (nElemId == E_ELEM_BTN_ALERT) {
       // Show alert popup, modal
       gslc_ElemSetTxtStr(&m_gui, m_pElemAlertMsg, "Alert Message!");
-      gslc_SetStackPage(&m_gui, GSLC_STACK_OVR, E_PG_ALERT);
-      gslc_SetStackState(&m_gui, GSLC_STACK_GLB, false);
-      gslc_SetStackState(&m_gui, GSLC_STACK_CUR, false);
+      gslc_PopupShow(&m_gui,E_PG_ALERT,true); // Use false for modeless
     }
     else if (nElemId == E_ELEM_ALERT_OK) {
       GSLC_DEBUG_PRINT("INFO: Alert popup selected OK\n", "");
       // Dispose of alert
-      gslc_SetStackPage(&m_gui, GSLC_STACK_OVR, GSLC_PAGE_NONE);
-      gslc_SetStackState(&m_gui, GSLC_STACK_GLB, true);
-      gslc_SetStackState(&m_gui, GSLC_STACK_CUR, true);
+      gslc_PopupHide(&m_gui);
     }
     else if (nElemId == E_ELEM_ALERT_CANCEL) {
       GSLC_DEBUG_PRINT("INFO: Alert popup selected Cancel\n", "");

--- a/examples/arduino/ex25_ard_popup/ex25_ard_popup.ino
+++ b/examples/arduino/ex25_ard_popup/ex25_ard_popup.ino
@@ -1,0 +1,280 @@
+//
+// GUIslice Library Example
+// - Paul Conti
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 25 (Arduino):
+//   - Popup dialog to confirm QUIT
+//   - Use of EXTRA Fonts 
+//   - Accept touch input, text button
+//   - Expected behavior: Clicking on button terminates program
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+//
+
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+#include <Adafruit_GFX.h>
+
+// Note that font files are located within the Adafruit-GFX library folder:
+//<Fonts !Start!>
+#include "Fonts/FreeSans9pt7b.h"
+//<Fonts !End!>
+
+// ------------------------------------------------
+// Defines for resources
+// ------------------------------------------------
+//<Resources !Start!>
+//<Resources !End!>
+
+// ------------------------------------------------
+// Enumerations for pages, elements, fonts, images
+// ------------------------------------------------
+//<Enum !Start!>
+enum { E_PG_MAIN, E_PG_POPUP };
+enum {
+  E_BOX2, E_BTN_CANCEL, E_BTN_OK, E_BTN_QUIT
+  , E_PROGRESS, E_TXT1, E_TXT2, E_TXT_STATUS
+};
+enum { E_FONT_SANS1, E_FONT_TXT2 };
+//<Enum !End!>
+
+// ------------------------------------------------
+// Instantiate the GUI
+// ------------------------------------------------
+
+// Define the maximum number of elements per page
+//<ElementDefines !Start!>
+#define MAX_PAGE                2
+#define MAX_FONT                2
+#define MAX_ELEM_PG_MAIN 3
+#define MAX_ELEM_PG_MAIN_RAM MAX_ELEM_PG_MAIN
+#define MAX_ELEM_PG_POPUP 5
+#define MAX_ELEM_PG_POPUP_RAM MAX_ELEM_PG_POPUP
+//<ElementDefines !End!>
+
+// GUI Elements
+gslc_tsGui                      m_gui;
+gslc_tsDriver                   m_drv;
+gslc_tsFont                     m_asFont[MAX_FONT];
+gslc_tsPage                     m_asPage[MAX_PAGE];
+
+//<GUI_Extra_Elements !Start!>
+gslc_tsElem                 m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef              m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asPage2Elem[MAX_ELEM_PG_POPUP_RAM];
+gslc_tsElemRef              m_asPage2ElemRef[MAX_ELEM_PG_POPUP];
+gslc_tsXGauge                   m_sXGauge[1];
+
+#define MAX_STR                 100
+
+//<GUI_Extra_Elements !End!>
+
+// ------------------------------------------------
+// Save some element references for update loop access
+// ------------------------------------------------
+//<Save_References !Start!>
+gslc_tsElemRef*  m_pElemProgress = NULL;
+//<Save_References !End!>
+gslc_tsElemRef*  m_pTxtStatus = NULL;
+
+// ------------------------------------------------
+// Program Globals
+// ------------------------------------------------
+
+// Flag to stop program
+bool m_bQuit = false;
+
+// Free-running counter for display
+unsigned    m_nCount = 0;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { if (ch == (char)'\n') Serial.println(""); else Serial.write(ch); return 0; }
+
+// ------------------------------------------------
+// Callback Methods
+// ------------------------------------------------
+// Common Button callback
+bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    // From the element's ID we can determine which button was pressed.
+    switch (pElem->nId) {
+      //<Button Enums !Start!>
+    case E_BTN_QUIT:
+      gslc_PopupShow(&m_gui, E_PG_POPUP, true);
+      break;
+    case E_BTN_OK:
+      gslc_PopupHide(&m_gui);
+      gslc_ElemSetTxtStr(&m_gui, m_pTxtStatus, "Stopped!");
+      m_bQuit = true;
+      break;
+    case E_BTN_CANCEL:
+      gslc_PopupHide(&m_gui);
+      gslc_ElemSetTxtStr(&m_gui, m_pTxtStatus, "Keep Running!");
+      break;
+      //<Button Enums !End!>
+    default:
+      break;
+    }
+  }
+  return true;
+}
+//<Draw Callback !Start!>
+//<Draw Callback !End!>
+//<Slider Callback !Start!>
+//<Slider Callback !End!>
+//<Tick Callback !Start!>
+//<Tick Callback !End!>
+
+// ------------------------------------------------
+// Create page elements
+// ------------------------------------------------
+bool InitGUI()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  //<InitGUI !Start!>
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPage1Elem, MAX_ELEM_PG_MAIN_RAM, m_asPage1ElemRef, MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui, E_PG_POPUP, m_asPage2Elem, MAX_ELEM_PG_POPUP_RAM, m_asPage2ElemRef, MAX_ELEM_PG_POPUP);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_BLACK);
+
+  // -----------------------------------
+  // PAGE: E_PG_MAIN
+
+  // create E_BTN_QUIT button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_QUIT, E_PG_MAIN, (gslc_tsRect) { 80, 130, 80, 40 }, (char*)"QUIT", 0, E_FONT_SANS1, &CbBtnCommon);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED, GSLC_COL_BLUE_LT2, GSLC_COL_BLUE_LT4);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+
+  // Create E_TXT_STATUS modifiable text label
+  static char m_strtxt1[18] = "Program Running";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_STATUS, E_PG_MAIN, (gslc_tsRect) { 27, 21, 182, 20 },
+    (char*)m_strtxt1, 18, E_FONT_TXT2);
+  gslc_ElemSetTxtAlign(&m_gui, pElemRef, GSLC_ALIGN_MID_MID);
+
+  // Create progress bar E_PROGRESS 
+  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS, E_PG_MAIN, &m_sXGauge[0],
+    (gslc_tsRect) {
+    70, 68, 100, 20
+  }, 0, 100, 0, GSLC_COL_GREEN, false);
+
+  // -----------------------------------
+  // PAGE: E_PG_POPUP
+
+  // Create E_BOX2 box
+  pElemRef = gslc_ElemCreateBox(&m_gui, E_BOX2, E_PG_POPUP, (gslc_tsRect) { 20, 80, 200, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED, GSLC_COL_GRAY_LT2, GSLC_COL_BLACK);
+
+  // create E_BTN_OK button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_OK, E_PG_POPUP, (gslc_tsRect) { 130, 170, 80, 40 }, (char*)"YES", 0, E_FONT_SANS1, &CbBtnCommon);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED, GSLC_COL_BLUE_LT2, GSLC_COL_BLUE_LT4);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+
+  // create E_BTN_CANCEL button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_CANCEL, E_PG_POPUP, (gslc_tsRect) { 30, 170, 80, 40 }, (char*)"NO", 0, E_FONT_SANS1, &CbBtnCommon);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED, GSLC_COL_BLUE_LT2, GSLC_COL_BLUE_LT4);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+
+  // Create E_TXT1 text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT1, E_PG_POPUP, (gslc_tsRect) { 43, 100, 153, 23 },
+    (char*)"Do you really want", 0, E_FONT_SANS1);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLACK);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2);
+
+  // Create E_TXT2 text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT2, E_PG_POPUP, (gslc_tsRect) { 86, 133, 68, 23 },
+    (char*)"to Quit?", 0, E_FONT_SANS1);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLACK);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2);
+  //<InitGUI !End!>
+
+  return true;
+}
+
+void setup()
+{
+  // ------------------------------------------------
+  // Initialize
+  // ------------------------------------------------
+  Serial.begin(9600);
+  // Wait for USB Serial 
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  gslc_InitDebug(&DebugOut);
+
+  if (!gslc_Init(&m_gui, &m_drv, m_asPage, MAX_PAGE, m_asFont, MAX_FONT)) { return; }
+
+  gslc_GuiRotate(&m_gui, 0);
+
+  // ------------------------------------------------
+  // Load Fonts
+  // ------------------------------------------------
+//<Load_Fonts !Start!>
+  if (!gslc_FontAdd(&m_gui, E_FONT_SANS1, GSLC_FONTREF_PTR, &FreeSans9pt7b, 1)) { return; }
+  if (!gslc_FontAdd(&m_gui, E_FONT_TXT2, GSLC_FONTREF_PTR, NULL, 2)) { return; }
+  //<Load_Fonts !End!>
+
+    // ------------------------------------------------
+    // Create graphic elements
+    // ------------------------------------------------
+  InitGUI();
+
+  // ------------------------------------------------
+  // Save some element references for quick access
+  // ------------------------------------------------
+//<Quick_Access !Start!>
+  m_pElemProgress = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_PROGRESS);
+  //<Quick_Access !End!>
+  m_pTxtStatus = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT_STATUS);
+
+  //<Startup !Start!>
+    // ------------------------------------------------
+    // Start up display on first page
+    // ------------------------------------------------
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+  //<Startup !End!>
+
+}
+
+// -----------------------------------
+// Main event loop
+// -----------------------------------
+void loop()
+{
+
+  // ------------------------------------------------
+  // Update GUI Elements
+  // ------------------------------------------------
+
+  // Slow down updates
+  delay(10);
+
+  // General counter
+  m_nCount++;
+  gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress, ((m_nCount / 1) % 100));
+
+
+  // ------------------------------------------------
+  // Periodically call GUIslice update function
+  // ------------------------------------------------
+  gslc_Update(&m_gui);
+
+}
+

--- a/examples/arduino/ex25_ard_popup/ex25_ard_popup.ino
+++ b/examples/arduino/ex25_ard_popup/ex25_ard_popup.ino
@@ -40,10 +40,7 @@
 // ------------------------------------------------
 //<Enum !Start!>
 enum { E_PG_MAIN, E_PG_POPUP };
-enum {
-  E_BOX2, E_BTN_CANCEL, E_BTN_OK, E_BTN_QUIT
-  , E_PROGRESS, E_TXT1, E_TXT2, E_TXT_STATUS
-};
+enum { E_BTN_CANCEL, E_BTN_OK, E_BTN_QUIT, E_PROGRESS, E_TXT_STATUS };
 enum { E_FONT_SANS1, E_FONT_TXT2 };
 //<Enum !End!>
 
@@ -55,9 +52,9 @@ enum { E_FONT_SANS1, E_FONT_TXT2 };
 //<ElementDefines !Start!>
 #define MAX_PAGE                2
 #define MAX_FONT                2
-#define MAX_ELEM_PG_MAIN 3
+#define MAX_ELEM_PG_MAIN        3
 #define MAX_ELEM_PG_MAIN_RAM MAX_ELEM_PG_MAIN
-#define MAX_ELEM_PG_POPUP 5
+#define MAX_ELEM_PG_POPUP       5
 #define MAX_ELEM_PG_POPUP_RAM MAX_ELEM_PG_POPUP
 //<ElementDefines !End!>
 
@@ -68,10 +65,10 @@ gslc_tsFont                     m_asFont[MAX_FONT];
 gslc_tsPage                     m_asPage[MAX_PAGE];
 
 //<GUI_Extra_Elements !Start!>
-gslc_tsElem                 m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
-gslc_tsElemRef              m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
-gslc_tsElem                 m_asPage2Elem[MAX_ELEM_PG_POPUP_RAM];
-gslc_tsElemRef              m_asPage2ElemRef[MAX_ELEM_PG_POPUP];
+gslc_tsElem                     m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef                  m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                     m_asPage2Elem[MAX_ELEM_PG_POPUP_RAM];
+gslc_tsElemRef                  m_asPage2ElemRef[MAX_ELEM_PG_POPUP];
 gslc_tsXGauge                   m_sXGauge[1];
 
 #define MAX_STR                 100
@@ -82,8 +79,8 @@ gslc_tsXGauge                   m_sXGauge[1];
 // Save some element references for update loop access
 // ------------------------------------------------
 //<Save_References !Start!>
-gslc_tsElemRef*  m_pElemProgress = NULL;
 //<Save_References !End!>
+gslc_tsElemRef*  m_pElemProgress = NULL;
 gslc_tsElemRef*  m_pTxtStatus = NULL;
 
 // ------------------------------------------------
@@ -156,28 +153,30 @@ bool InitGUI()
   // PAGE: E_PG_MAIN
 
   // create E_BTN_QUIT button with text label
-  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_QUIT, E_PG_MAIN, (gslc_tsRect) { 80, 130, 80, 40 }, (char*)"QUIT", 0, E_FONT_SANS1, &CbBtnCommon);
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_QUIT, E_PG_MAIN,
+    (gslc_tsRect) { 80, 130, 80, 40 }, (char*)"QUIT", 0, E_FONT_SANS1, &CbBtnCommon);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED, GSLC_COL_BLUE_LT2, GSLC_COL_BLUE_LT4);
   gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
 
   // Create E_TXT_STATUS modifiable text label
   static char m_strtxt1[18] = "Program Running";
-  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_STATUS, E_PG_MAIN, (gslc_tsRect) { 27, 21, 182, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_STATUS, E_PG_MAIN,
+    (gslc_tsRect) { 27, 21, 182, 20 },
     (char*)m_strtxt1, 18, E_FONT_TXT2);
   gslc_ElemSetTxtAlign(&m_gui, pElemRef, GSLC_ALIGN_MID_MID);
+  m_pTxtStatus = pElemRef;
 
   // Create progress bar E_PROGRESS 
   pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS, E_PG_MAIN, &m_sXGauge[0],
-    (gslc_tsRect) {
-    70, 68, 100, 20
-  }, 0, 100, 0, GSLC_COL_GREEN, false);
+    (gslc_tsRect) { 70, 68, 100, 20 }, 0, 100, 0, GSLC_COL_GREEN, false);
+  m_pElemProgress = pElemRef;
 
   // -----------------------------------
   // PAGE: E_PG_POPUP
 
   // Create E_BOX2 box
-  pElemRef = gslc_ElemCreateBox(&m_gui, E_BOX2, E_PG_POPUP, (gslc_tsRect) { 20, 80, 200, 150 });
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_POPUP, (gslc_tsRect) { 20, 80, 200, 150 });
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED, GSLC_COL_GRAY_LT2, GSLC_COL_BLACK);
 
   // create E_BTN_OK button with text label
@@ -193,13 +192,13 @@ bool InitGUI()
   gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
 
   // Create E_TXT1 text label
-  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT1, E_PG_POPUP, (gslc_tsRect) { 43, 100, 153, 23 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_POPUP, (gslc_tsRect) { 43, 100, 153, 23 },
     (char*)"Do you really want", 0, E_FONT_SANS1);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLACK);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2);
 
   // Create E_TXT2 text label
-  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT2, E_PG_POPUP, (gslc_tsRect) { 86, 133, 68, 23 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_POPUP, (gslc_tsRect) { 86, 133, 68, 23 },
     (char*)"to Quit?", 0, E_FONT_SANS1);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLACK);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2, GSLC_COL_GRAY_LT2);
@@ -231,23 +230,16 @@ void setup()
   if (!gslc_FontAdd(&m_gui, E_FONT_TXT2, GSLC_FONTREF_PTR, NULL, 2)) { return; }
   //<Load_Fonts !End!>
 
-    // ------------------------------------------------
-    // Create graphic elements
-    // ------------------------------------------------
+  // ------------------------------------------------
+  // Create graphic elements
+  // ------------------------------------------------
   InitGUI();
 
-  // ------------------------------------------------
-  // Save some element references for quick access
-  // ------------------------------------------------
-//<Quick_Access !Start!>
-  m_pElemProgress = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_PROGRESS);
-  //<Quick_Access !End!>
-  m_pTxtStatus = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT_STATUS);
 
   //<Startup !Start!>
-    // ------------------------------------------------
-    // Start up display on first page
-    // ------------------------------------------------
+  // ------------------------------------------------
+  // Start up display on first page
+  // ------------------------------------------------
   gslc_SetPageCur(&m_gui, E_PG_MAIN);
   //<Startup !End!>
 

--- a/examples/linux/Makefile
+++ b/examples/linux/Makefile
@@ -108,7 +108,8 @@ SRC =   ex01_lnx_basic.c \
 	ex10_lnx_textbox.c \
 	ex11_lnx_graph.c \
 	ex18_lnx_compound.c \
-	ex22_lnx_input_key.c
+	ex22_lnx_input_key.c \
+	ex24_lnx_tabs.c
 
 # Add simple example for specific driver modes
 ifeq (SDL1,${GSLC_DRV})
@@ -185,4 +186,8 @@ ex18_lnx_compound: ex18_lnx_compound.c $(GSLC_CORE) $(GSLC_SRCS)
 ex22_lnx_input_key: ex22_lnx_input_key.c $(GSLC_CORE) $(GSLC_SRCS)
 	@echo [Building $@]
 	@$(CC) $(CFLAGS) -o $@ ex22_lnx_input_key.c $(GSLC_CORE) $(GSLC_SRCS) $(LDFLAGS) $(LDLIBS) -I . -I ../../src
+
+ex24_lnx_tabs: ex24_lnx_tabs.c $(GSLC_CORE) $(GSLC_SRCS)
+	@echo [Building $@]
+	@$(CC) $(CFLAGS) -o $@ ex24_lnx_tabs.c $(GSLC_CORE) $(GSLC_SRCS) $(LDFLAGS) $(LDLIBS) -I . -I ../../src
 

--- a/examples/linux/ex24_lnx_tabs.c
+++ b/examples/linux/ex24_lnx_tabs.c
@@ -1,0 +1,303 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 24 (LINUX):
+//   - Multiple page handling, tab dialog, global elements
+//
+
+#include "GUIslice.h"
+#include "GUIslice_ex.h"
+#include "GUIslice_drv.h"
+
+#include <libgen.h>       // For path parsing
+
+
+// Defines for resources
+#define MAX_PATH  255
+#define FONT1 "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf"
+
+// Enumerations for pages, elements, fonts, images
+enum { E_PG_GLOBAL, E_PG_MAIN, E_PG_CONFIG };
+enum {
+  E_ELEM_BTN_QUIT, E_ELEM_TAB_MAIN, E_ELEM_TAB_CONFIG, E_ELEM_BTN_CALC,
+  E_ELEM_TXT_COUNT, E_ELEM_PROGRESS,
+  E_ELEM_CHECK1, E_ELEM_CHECK2, E_ELEM_CHECK3
+};
+enum { E_FONT_BTN, E_FONT_TXT, E_FONT_TITLE };
+
+bool      m_bQuit = false;
+
+// Free-running counter for display
+unsigned  m_nCount = 0;
+
+// Instantiate the GUI
+#define MAX_PAGE            3
+#define MAX_FONT            3
+#define MAX_ELEM_PG_GLOBAL  8   // Max # elements on global page
+#define MAX_ELEM_PG_MAIN    3   // Max # elements on main page
+#define MAX_ELEM_PG_CONFIG  6   // Max # elements on second page
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asGlbElem[MAX_ELEM_PG_GLOBAL];
+gslc_tsElemRef              m_asGlbElemRef[MAX_ELEM_PG_GLOBAL];
+gslc_tsElem                 m_asMainElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asConfigElem[MAX_ELEM_PG_CONFIG];
+gslc_tsElemRef              m_asConfigElemRef[MAX_ELEM_PG_CONFIG];
+
+gslc_tsXGauge               m_sXGauge;
+gslc_tsXCheckbox            m_asXCheck[3];
+
+
+// Save some element pointers for quick access
+gslc_tsElemRef*  m_pElemCnt = NULL;
+gslc_tsElemRef*  m_pElemProgress = NULL;
+gslc_tsElemRef*  m_pElemTabMain = NULL;
+gslc_tsElemRef*  m_pElemTabConfig = NULL;
+
+#define MAX_STR             100
+
+// Configure environment variables suitable for display
+// - These may need modification to match your system
+//   environment and display type
+// - Defaults for GSLC_DEV_FB and GSLC_DEV_TOUCH are in GUIslice_config.h
+// - Note that the environment variable settings can
+//   also be set directly within the shell via export
+//   (or init script).
+//   - eg. export TSLIB_FBDEVICE=/dev/fb1
+void UserInitEnv()
+{
+#if defined(DRV_DISP_SDL1) || defined(DRV_DISP_SDL2)
+  setenv((char*)"FRAMEBUFFER",GSLC_DEV_FB,1);
+  setenv((char*)"SDL_FBDEV",GSLC_DEV_FB,1);
+  setenv((char*)"SDL_VIDEODRIVER",GSLC_DEV_VID_DRV,1);
+#endif
+
+#if defined(DRV_TOUCH_TSLIB)
+  setenv((char*)"TSLIB_FBDEVICE",GSLC_DEV_FB,1);
+  setenv((char*)"TSLIB_TSDEVICE",GSLC_DEV_TOUCH,1);
+  setenv((char*)"TSLIB_CALIBFILE",(char*)"/etc/pointercal",1);
+  setenv((char*)"TSLIB_CONFFILE",(char*)"/etc/ts.conf",1);
+  setenv((char*)"TSLIB_PLUGINDIR",(char*)"/usr/local/lib/ts",1);
+#endif
+}
+
+// Define debug message function
+static int16_t DebugOut(char ch) { fputc(ch,stderr); return 0; }
+
+// Update the tab dialog button highlights
+void SetTabHighlight(int16_t nTabSel)
+{
+  gslc_ElemSetCol(&m_gui, m_pElemTabMain, (nTabSel == E_ELEM_TAB_MAIN) ? GSLC_COL_WHITE : GSLC_COL_BLUE_DK2,
+    GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
+  gslc_ElemSetCol(&m_gui, m_pElemTabConfig, (nTabSel == E_ELEM_TAB_CONFIG) ? GSLC_COL_WHITE : GSLC_COL_BLUE_DK2,
+    GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
+}
+ 
+// Button callbacks
+// - Show example of common callback function
+bool CbBtnCommon(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
+  int16_t nElemId = pElem->nId;
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    if (nElemId == E_ELEM_BTN_QUIT) {
+      m_bQuit = true;
+    }
+    else if (nElemId == E_ELEM_TAB_CONFIG) {
+      gslc_SetPageCur(&m_gui, E_PG_CONFIG);
+      SetTabHighlight(E_ELEM_TAB_CONFIG);
+    }
+    else if (nElemId == E_ELEM_TAB_MAIN) {
+      gslc_SetPageCur(&m_gui, E_PG_MAIN);
+      SetTabHighlight(E_ELEM_TAB_MAIN);
+    }
+  }
+  return true;
+}
+
+
+// Create the default elements on each page
+bool InitOverlays()
+{
+  gslc_tsElemRef*  pElemRef = NULL;
+
+  gslc_PageAdd(&m_gui, E_PG_GLOBAL, m_asGlbElem, MAX_ELEM_PG_GLOBAL, m_asGlbElemRef, MAX_ELEM_PG_GLOBAL);
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asMainElem, MAX_ELEM_PG_MAIN, m_asMainElemRef, MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui, E_PG_CONFIG, m_asConfigElem, MAX_ELEM_PG_CONFIG, m_asConfigElemRef, MAX_ELEM_PG_CONFIG);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui,GSLC_COL_BLACK);
+
+  // Note that the current page defaults to the first page added, which in the
+  // above sequence is E_PG_GLOBAL. Therefore, we should explicitly ensure
+  // that the main page is the current page.
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+  // Now mark the E_PG_GLOBAL as a "global" page which means that it's elements
+  // are always visible. This is useful for common page elements.
+  gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);
+
+  // -----------------------------------
+  // PAGE: GLOBAL
+  // Create title
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 10, 10, 100, 20 },
+    (char*)"GUIslice Demo", 0, E_FONT_TITLE);
+  gslc_ElemSetTxtAlign(&m_gui, pElemRef, GSLC_ALIGN_MID_LEFT);
+  gslc_ElemSetFillEn(&m_gui, pElemRef, false);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_GLOBAL,
+    (gslc_tsRect) { 240, 5, 50, 25 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnCommon);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED_DK2, GSLC_COL_RED_DK4, GSLC_COL_RED_DK1);
+
+  pElemRef = gslc_ElemCreateLine(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, 0, 35, 320, 35);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLACK, GSLC_COL_GRAY, GSLC_COL_GRAY);
+
+
+  // Create counter
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 110, 10, 50, 20 },
+    (char*)"Count:", 0, E_FONT_TXT);
+  static char mstr1[8] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_ELEM_TXT_COUNT, E_PG_GLOBAL, (gslc_tsRect) { 170, 10, 50, 20 },
+    mstr1, sizeof(mstr1), E_FONT_TXT);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_PURPLE);
+  m_pElemCnt = pElemRef; // Save for quick access
+
+
+  // Create Tab label buttons, start with main with framed highlight
+  m_pElemTabMain = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_MAIN, E_PG_GLOBAL,
+    (gslc_tsRect) { 30, 50, 50, 20 }, (char*)"Main", 0, E_FONT_BTN, &CbBtnCommon);
+  m_pElemTabConfig = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_CONFIG, E_PG_GLOBAL,
+    (gslc_tsRect) { 90, 50, 50, 20 }, (char*)"Extra", 0, E_FONT_BTN, &CbBtnCommon);
+  SetTabHighlight(E_ELEM_TAB_MAIN);
+
+  // Create tab box
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 20, 70, 280, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
+
+  // -----------------------------------
+  // PAGE: MAIN
+
+  // Create progress bar
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 40, 120, 50, 10 },
+    (char*)"Progress:", 0, E_FONT_TXT);
+  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_ELEM_PROGRESS, E_PG_MAIN, &m_sXGauge, (gslc_tsRect) { 100, 120, 50, 10 },
+    0, 100, 0, GSLC_COL_GREEN, false);
+  m_pElemProgress = pElemRef; // Save for quick access
+
+
+  // Checkbox element
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK1, E_PG_MAIN, &m_asXCheck[0],
+    (gslc_tsRect) { 200, 120, 30, 30 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
+
+  // -----------------------------------
+  // PAGE: CONFIG
+
+  // Create Dummy button
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_CALC, E_PG_CONFIG,
+    (gslc_tsRect) { 60, 170, 50, 20 }, (char*)"Calc", 0, E_FONT_BTN, &CbBtnCommon);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GREEN_DK2, GSLC_COL_GREEN_DK4, GSLC_COL_GREEN_DK1);
+
+  // Create a few labels & checkboxes
+  int16_t    nPosY = 80;
+  int16_t    nSpaceY = 30;
+
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK2, E_PG_CONFIG, &m_asXCheck[1],
+    (gslc_tsRect) { 60, nPosY, 20, 20 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
+    (char*)"Data 1", 0, E_FONT_TXT);
+  nPosY += nSpaceY;
+
+  pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK3, E_PG_CONFIG, &m_asXCheck[2],
+    (gslc_tsRect) { 60, nPosY, 20, 20 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_RED_LT2, false);
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
+    (char*)"Data 2", 0, E_FONT_TXT);
+  nPosY += nSpaceY;
+
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
+    (char*)"Data 3", 0, E_FONT_TXT);
+  nPosY += nSpaceY;
+
+  return true;
+}
+
+
+int main( int argc, char* args[] )
+{
+  bool              bOk = true;
+  char              acTxt[MAX_STR];
+
+  // -----------------------------------
+  // Initialize
+  gslc_InitDebug(&DebugOut);
+  UserInitEnv();
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { exit(1); }
+
+  // Load Fonts
+  // - In this example, we are loading the same font but at
+  //   different point sizes. We could also refer to other
+  //   font files as well.
+  bOk = gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_FNAME,FONT1,12);
+  if (!bOk) { fprintf(stderr,"ERROR: FontAdd failed\n"); exit(1); }
+  bOk = gslc_FontAdd(&m_gui,E_FONT_TXT,GSLC_FONTREF_FNAME,FONT1,10);
+  if (!bOk) { fprintf(stderr,"ERROR: FontAdd failed\n"); exit(1); }
+  bOk = gslc_FontAdd(&m_gui,E_FONT_TITLE,GSLC_FONTREF_FNAME,FONT1,12);
+  if (!bOk) { fprintf(stderr,"ERROR: FontAdd failed\n"); exit(1); }
+
+
+  // -----------------------------------
+  // Create page elements
+  // -----------------------------------
+  InitOverlays(dirname(args[0])); // Pass executable path to find resource files
+
+
+  // -----------------------------------
+  // Start display
+
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+
+  // -----------------------------------
+  // Main event loop
+
+  m_bQuit = false;
+  while (!m_bQuit) {
+
+    m_nCount++;
+
+    // -----------------------------------
+    // Perform drawing updates
+    // - Note: we can make the updates conditional on the active
+    //   page by checking gslc_GetPageCur() first.
+
+    snprintf(acTxt,MAX_STR,"%u",m_nCount);
+    gslc_ElemSetTxtStr(&m_gui,m_pElemCnt,acTxt);
+
+    gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,((m_nCount/200)%100));
+
+    // We can change or disable the global page as needed:
+    //   gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);    // Set to E_PG_GLOBAL
+    //   gslc_SetPageGlobal(&m_gui, GSLC_PAGE_NONE); // Disable
+
+    // Periodically call GUIslice update function
+    gslc_Update(&m_gui);
+
+  } // bQuit
+
+
+  // -----------------------------------
+  // Close down display
+
+  gslc_Quit(&m_gui);
+
+  return 0;
+}
+

--- a/examples/linux/ex24_lnx_tabs.c
+++ b/examples/linux/ex24_lnx_tabs.c
@@ -4,7 +4,8 @@
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 // - Example 24 (LINUX):
-//   - Multiple page handling, tab dialog, global elements
+//   - Multiple page handling, tab dialog, global (base layer) elements
+//     and popup dialog
 //
 
 #include "GUIslice.h"
@@ -19,11 +20,13 @@
 #define FONT1 "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf"
 
 // Enumerations for pages, elements, fonts, images
-enum { E_PG_GLOBAL, E_PG_MAIN, E_PG_CONFIG };
+enum { E_PG_BASE, E_PG_MAIN, E_PG_CONFIG, E_PG_ALERT  };
 enum {
-  E_ELEM_BTN_QUIT, E_ELEM_TAB_MAIN, E_ELEM_TAB_CONFIG, E_ELEM_BTN_CALC,
+  E_ELEM_BTN_QUIT, E_ELEM_TAB_MAIN, E_ELEM_TAB_CONFIG, E_ELEM_BTN_ALERT,
   E_ELEM_TXT_COUNT, E_ELEM_PROGRESS,
-  E_ELEM_CHECK1, E_ELEM_CHECK2, E_ELEM_CHECK3
+  E_ELEM_CHECK1, E_ELEM_CHECK2, E_ELEM_CHECK3,
+  // E_PG_ALERT
+  E_ELEM_ALERT_OK, E_ELEM_ALERT_CANCEL,
 };
 enum { E_FONT_BTN, E_FONT_TXT, E_FONT_TITLE };
 
@@ -33,34 +36,39 @@ bool      m_bQuit = false;
 unsigned  m_nCount = 0;
 
 // Instantiate the GUI
-#define MAX_PAGE            3
+#define MAX_PAGE            4
 #define MAX_FONT            3
-#define MAX_ELEM_PG_GLOBAL  8   // Max # elements on global page
-#define MAX_ELEM_PG_MAIN    3   // Max # elements on main page
-#define MAX_ELEM_PG_CONFIG  6   // Max # elements on second page
+#define MAX_ELEM_PG_BASE    8   // # Elems total on Global page
+#define MAX_ELEM_PG_MAIN    3   // # Elems total on Main page
+#define MAX_ELEM_PG_CONFIG  6   // # Elems total on Extra page
+#define MAX_ELEM_PG_ALERT   4   // # Elems total on Alert popup page
 
 gslc_tsGui                  m_gui;
 gslc_tsDriver               m_drv;
 gslc_tsFont                 m_asFont[MAX_FONT];
 gslc_tsPage                 m_asPage[MAX_PAGE];
-gslc_tsElem                 m_asGlbElem[MAX_ELEM_PG_GLOBAL];
-gslc_tsElemRef              m_asGlbElemRef[MAX_ELEM_PG_GLOBAL];
+gslc_tsElem                 m_asGlbElem[MAX_ELEM_PG_BASE];
+gslc_tsElemRef              m_asGlbElemRef[MAX_ELEM_PG_BASE];
 gslc_tsElem                 m_asMainElem[MAX_ELEM_PG_MAIN];
 gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsElem                 m_asConfigElem[MAX_ELEM_PG_CONFIG];
 gslc_tsElemRef              m_asConfigElemRef[MAX_ELEM_PG_CONFIG];
+gslc_tsElem                 m_asAlertElem[MAX_ELEM_PG_ALERT];
+gslc_tsElemRef              m_asAlertElemRef[MAX_ELEM_PG_ALERT];
 
 gslc_tsXGauge               m_sXGauge;
 gslc_tsXCheckbox            m_asXCheck[3];
 
+
+#define MAX_STR             100
 
 // Save some element pointers for quick access
 gslc_tsElemRef*  m_pElemCnt = NULL;
 gslc_tsElemRef*  m_pElemProgress = NULL;
 gslc_tsElemRef*  m_pElemTabMain = NULL;
 gslc_tsElemRef*  m_pElemTabConfig = NULL;
+gslc_tsElemRef*  m_pElemAlertMsg = NULL;
 
-#define MAX_STR             100
 
 // Configure environment variables suitable for display
 // - These may need modification to match your system
@@ -119,6 +127,21 @@ bool CbBtnCommon(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int1
       gslc_SetPageCur(&m_gui, E_PG_MAIN);
       SetTabHighlight(E_ELEM_TAB_MAIN);
     }
+    else if (nElemId == E_ELEM_BTN_ALERT) {
+      // Show alert popup, modal
+      gslc_ElemSetTxtStr(&m_gui, m_pElemAlertMsg, "Alert Message!");
+      gslc_PopupShow(&m_gui,E_PG_ALERT,true); // Use false for modeless
+    }
+    else if (nElemId == E_ELEM_ALERT_OK) {
+      GSLC_DEBUG_PRINT("INFO: Alert popup selected OK\n", "");
+      // Dispose of alert
+      gslc_PopupHide(&m_gui);
+    }
+    else if (nElemId == E_ELEM_ALERT_CANCEL) {
+      GSLC_DEBUG_PRINT("INFO: Alert popup selected Cancel\n", "");
+      // Dispose of alert
+      gslc_PopupHide(&m_gui);
+    }
   }
   return true;
 }
@@ -129,57 +152,58 @@ bool InitOverlays()
 {
   gslc_tsElemRef*  pElemRef = NULL;
 
-  gslc_PageAdd(&m_gui, E_PG_GLOBAL, m_asGlbElem, MAX_ELEM_PG_GLOBAL, m_asGlbElemRef, MAX_ELEM_PG_GLOBAL);
+  gslc_PageAdd(&m_gui, E_PG_BASE, m_asGlbElem, MAX_ELEM_PG_BASE, m_asGlbElemRef, MAX_ELEM_PG_BASE);
   gslc_PageAdd(&m_gui, E_PG_MAIN, m_asMainElem, MAX_ELEM_PG_MAIN, m_asMainElemRef, MAX_ELEM_PG_MAIN);
   gslc_PageAdd(&m_gui, E_PG_CONFIG, m_asConfigElem, MAX_ELEM_PG_CONFIG, m_asConfigElemRef, MAX_ELEM_PG_CONFIG);
+  gslc_PageAdd(&m_gui, E_PG_ALERT, m_asAlertElem, MAX_ELEM_PG_ALERT, m_asAlertElemRef, MAX_ELEM_PG_ALERT);
 
   // Background flat color
   gslc_SetBkgndColor(&m_gui,GSLC_COL_BLACK);
 
   // Note that the current page defaults to the first page added, which in the
-  // above sequence is E_PG_GLOBAL. Therefore, we should explicitly ensure
+  // above sequence is E_PG_BASE. Therefore, we should explicitly ensure
   // that the main page is the current page.
   gslc_SetPageCur(&m_gui, E_PG_MAIN);
-  // Now mark the E_PG_GLOBAL as a "global" page which means that it's elements
+  // Now mark the E_PG_BASE as a "base" page which means that it's elements
   // are always visible. This is useful for common page elements.
-  gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);
+  gslc_SetPageBase(&m_gui, E_PG_BASE);
 
   // -----------------------------------
-  // PAGE: GLOBAL
+  // PAGE: BASE
   // Create title
-  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 10, 10, 100, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_BASE, (gslc_tsRect) { 10, 10, 100, 20 },
     (char*)"GUIslice Demo", 0, E_FONT_TITLE);
   gslc_ElemSetTxtAlign(&m_gui, pElemRef, GSLC_ALIGN_MID_LEFT);
   gslc_ElemSetFillEn(&m_gui, pElemRef, false);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
 
-  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_GLOBAL,
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_BASE,
     (gslc_tsRect) { 240, 5, 50, 25 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnCommon);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_RED_DK2, GSLC_COL_RED_DK4, GSLC_COL_RED_DK1);
 
-  pElemRef = gslc_ElemCreateLine(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, 0, 35, 320, 35);
+  pElemRef = gslc_ElemCreateLine(&m_gui, GSLC_ID_AUTO, E_PG_BASE, 0, 35, 320, 35);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLACK, GSLC_COL_GRAY, GSLC_COL_GRAY);
 
 
   // Create counter
-  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 110, 10, 50, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_BASE, (gslc_tsRect) { 110, 10, 50, 20 },
     (char*)"Count:", 0, E_FONT_TXT);
   static char mstr1[8] = "";
-  pElemRef = gslc_ElemCreateTxt(&m_gui, E_ELEM_TXT_COUNT, E_PG_GLOBAL, (gslc_tsRect) { 170, 10, 50, 20 },
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_ELEM_TXT_COUNT, E_PG_BASE, (gslc_tsRect) { 170, 10, 50, 20 },
     mstr1, sizeof(mstr1), E_FONT_TXT);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_PURPLE);
   m_pElemCnt = pElemRef; // Save for quick access
 
 
   // Create Tab label buttons, start with main with framed highlight
-  m_pElemTabMain = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_MAIN, E_PG_GLOBAL,
+  m_pElemTabMain = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_MAIN, E_PG_BASE,
     (gslc_tsRect) { 30, 50, 50, 20 }, (char*)"Main", 0, E_FONT_BTN, &CbBtnCommon);
-  m_pElemTabConfig = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_CONFIG, E_PG_GLOBAL,
+  m_pElemTabConfig = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_TAB_CONFIG, E_PG_BASE,
     (gslc_tsRect) { 90, 50, 50, 20 }, (char*)"Extra", 0, E_FONT_BTN, &CbBtnCommon);
   SetTabHighlight(E_ELEM_TAB_MAIN);
 
   // Create tab box
-  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_GLOBAL, (gslc_tsRect) { 20, 70, 280, 150 });
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_BASE, (gslc_tsRect) { 20, 70, 200, 150 });
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
 
   // -----------------------------------
@@ -195,14 +219,14 @@ bool InitOverlays()
 
   // Checkbox element
   pElemRef = gslc_ElemXCheckboxCreate(&m_gui, E_ELEM_CHECK1, E_PG_MAIN, &m_asXCheck[0],
-    (gslc_tsRect) { 200, 120, 30, 30 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
+    (gslc_tsRect) { 100, 160, 30, 30 }, false, GSLCX_CHECKBOX_STYLE_X, GSLC_COL_BLUE_LT2, false);
 
   // -----------------------------------
   // PAGE: CONFIG
 
   // Create Dummy button
-  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_CALC, E_PG_CONFIG,
-    (gslc_tsRect) { 60, 170, 50, 20 }, (char*)"Calc", 0, E_FONT_BTN, &CbBtnCommon);
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_ALERT, E_PG_CONFIG,
+    (gslc_tsRect) { 60, 170, 50, 20 }, (char*)"Alert", 0, E_FONT_BTN, &CbBtnCommon);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GREEN_DK2, GSLC_COL_GREEN_DK4, GSLC_COL_GREEN_DK1);
 
   // Create a few labels & checkboxes
@@ -224,6 +248,32 @@ bool InitOverlays()
   pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_CONFIG, (gslc_tsRect) { 100, nPosY, 50, 10 },
     (char*)"Data 3", 0, E_FONT_TXT);
   nPosY += nSpaceY;
+
+  // -----------------------------------
+  // PAGE: POPUP Confirm
+
+  // Create alert box
+  pElemRef = gslc_ElemCreateBox(&m_gui, GSLC_ID_AUTO, E_PG_ALERT, (gslc_tsRect) { 160 - 90, 120 - 30, 2 * 90, 90 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_LT2, GSLC_COL_GRAY_DK3, GSLC_COL_GRAY_DK3);
+
+  // Alert message
+  static char m_strAlertMsg[20] = "alert";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_ALERT, (gslc_tsRect) { 160 - 80, 120 - 20, 2 * 80, 40 },
+    m_strAlertMsg, sizeof(m_strAlertMsg), E_FONT_TXT);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_RED_LT1);
+  m_pElemAlertMsg = pElemRef; // Save for quick access
+
+  // Create OK button
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_ALERT_OK, E_PG_ALERT,
+    (gslc_tsRect) { 160 - 40 - 30, 120 + 30, 2 * 30, 2 * 10 }, (char*)"OK", 0, E_FONT_BTN, &CbBtnCommon);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK2, GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
+
+  // Create Cancel button
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_ALERT_CANCEL, E_PG_ALERT,
+    (gslc_tsRect) { 160 + 40 - 30, 120 + 30, 2 * 30, 2 * 10 }, (char*)"Cancel", 0, E_FONT_BTN, &CbBtnCommon);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK2, GSLC_COL_BLUE_DK4, GSLC_COL_BLUE_DK1);
+
+
 
   return true;
 }
@@ -284,8 +334,8 @@ int main( int argc, char* args[] )
     gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,((m_nCount/200)%100));
 
     // We can change or disable the global page as needed:
-    //   gslc_SetPageGlobal(&m_gui, E_PG_GLOBAL);    // Set to E_PG_GLOBAL
-    //   gslc_SetPageGlobal(&m_gui, GSLC_PAGE_NONE); // Disable
+    //   gslc_SetPageBase(&m_gui, E_PG_BASE);    // Set to E_PG_BASE
+    //   gslc_SetPageBase(&m_gui, GSLC_PAGE_NONE); // Disable
 
     // Periodically call GUIslice update function
     gslc_Update(&m_gui);

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -513,13 +513,6 @@ void gslc_Quit(gslc_tsGui* pGui)
 // Main polling loop for GUIslice
 void gslc_Update(gslc_tsGui* pGui)
 {
-  // Ensure that at least the "current" page has been defined
-  // FIXME: Not sure that this check is required; perhaps it
-  // was used to prevent early calls to PageRedrawGo()?
-  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
-    return; // No page added yet
-  }
-
   // The touch handling logic is used by both the touchscreen
   // handler as well as the GPIO/pin/keyboard input controller
   #if !defined(DRV_TOUCH_NONE)
@@ -1758,10 +1751,6 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
   gslc_tsElemRef*   pElemRef = NULL;
   gslc_tsCollect*   pCollect = NULL;
 
-  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
-    return; // No page added yet
-  }
-
   bool  bRedrawFullPage = false;  // Does entire page require redraw?
   gslc_tsPage*  pPage = NULL;
 
@@ -1788,6 +1777,8 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
         // still warrant full page redraw.
         if (pGui->bRedrawPartialEn) {
           // Is the element transparent?
+          // FIXME: Instead of forcing full page redraw, consider
+          // using clipping region for partial redraw
           if (!(pElem->nFeatures & GSLC_ELEM_FEA_FILL_EN)) {
             bRedrawFullPage = true;
           }
@@ -1821,10 +1812,6 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
 //   are rendered.
 void gslc_PageRedrawGo(gslc_tsGui* pGui)
 {
-  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
-    return; // No page added yet
-  }
-
   // Update any page redraw status that may be required
   // - Note that this routine handles cases where an element
   //   marked as requiring update is semi-transparent which can
@@ -3376,6 +3363,8 @@ void gslc_TrackInput(gslc_tsGui* pGui,gslc_tsPage* pPage,gslc_teInputRawEvent eI
   // - For now, use the top enabled page in the stack
   for (int nStack = 0; nStack < GSLC_STACK__MAX; nStack++) {
     if (pGui->pPageStack[nStack]) {
+      // TODO: Check for "bActive" flag, in case we have
+      // disabled touch events for this page in the stack
       pFocusPage = pGui->pPageStack[nStack];
     }
   }

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -176,7 +176,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   pGui->nTouchLastY           = 0;
   pGui->nTouchLastPress       = 0;
 
-  pGui->pfuncXEvent           = NULL;
+  //pGui->pfuncXEvent           = NULL; // UNUSED
   pGui->pfuncPinPoll          = NULL;
 
   pGui->asInputMap            = NULL;
@@ -1620,8 +1620,7 @@ void gslc_PageAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* psElem,uint16_t 
 
   gslc_tsPage*  pPage = &pGui->asPage[pGui->nPageCnt];
 
-  // TODO: Create proper PageReset()
-  pPage->pfuncXEvent      = NULL;
+  //pPage->pfuncXEvent      = NULL; // UNUSED
 
   // Initialize pPage->sCollect
   gslc_CollectReset(&pPage->sCollect,psElem,nMaxElem,psElemRef,nMaxElemRef);
@@ -1968,6 +1967,7 @@ gslc_tsElemRef* gslc_PageFindElemById(gslc_tsGui* pGui,int16_t nPageId,int16_t n
   return pElemRef;
 }
 
+/* UNUSED
 void gslc_PageSetEventFunc(gslc_tsGui* pGui,gslc_tsPage* pPage,GSLC_CB_EVENT funcCb)
 {
   if ((pPage == NULL) || (funcCb == NULL)) {
@@ -1977,6 +1977,7 @@ void gslc_PageSetEventFunc(gslc_tsGui* pGui,gslc_tsPage* pPage,GSLC_CB_EVENT fun
   }
   pPage->pfuncXEvent       = funcCb;
 }
+*/
 
 
 // TODO: Create a PageStackFocusStep()
@@ -3071,7 +3072,7 @@ void gslc_ElemSetStyleFrom(gslc_tsGui* pGui,gslc_tsElemRef* pElemRefSrc,gslc_tsE
 
   // pXData
 
-  pElemDest->pfuncXEvent      = pElemSrc->pfuncXEvent;
+  //pElemDest->pfuncXEvent      = pElemSrc->pfuncXEvent; // UNUSED
   pElemDest->pfuncXDraw       = pElemSrc->pfuncXDraw;
   pElemDest->pfuncXTouch      = pElemSrc->pfuncXTouch;
   pElemDest->pfuncXTick       = pElemSrc->pfuncXTick;
@@ -3079,6 +3080,7 @@ void gslc_ElemSetStyleFrom(gslc_tsGui* pGui,gslc_tsElemRef* pElemRefSrc,gslc_tsE
   gslc_ElemSetRedraw(pGui,pElemRefDest,GSLC_REDRAW_FULL);
 }
 
+/* UNUSED
 void gslc_ElemSetEventFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_EVENT funcCb)
 {
   if ((pElemRef == NULL) || (funcCb == NULL)) {;
@@ -3089,6 +3091,7 @@ void gslc_ElemSetEventFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_EVE
   gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
   pElem->pfuncXEvent       = funcCb;
 }
+*/
 
 
 void gslc_ElemSetDrawFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_DRAW funcCb)
@@ -4119,7 +4122,7 @@ void gslc_ResetElem(gslc_tsElem* pElem)
   pElem->pTxtFont         = NULL;
 
   pElem->pXData           = NULL;
-  pElem->pfuncXEvent      = NULL;
+  pElem->pfuncXEvent      = NULL; // UNUSED
   pElem->pfuncXDraw       = NULL;
   pElem->pfuncXTouch      = NULL;
   pElem->pfuncXTick       = NULL;
@@ -4258,7 +4261,7 @@ void gslc_CollectReset(gslc_tsCollect* pCollect,gslc_tsElem* asElem,uint16_t nEl
 
   pCollect->nElemAutoIdNext   = GSLC_ID_AUTO_BASE;
 
-  pCollect->pfuncXEvent       = NULL;
+  //pCollect->pfuncXEvent       = NULL; // UNUSED
 
   // Save the pointer to the element array
   pCollect->asElem = asElem;
@@ -4469,6 +4472,7 @@ void gslc_CollectSetParent(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsElem
 }
 #endif
 
+/* UNUSED
 void gslc_CollectSetEventFunc(gslc_tsGui* pGui,gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb)
 {
   if ((pCollect == NULL) || (funcCb == NULL)) {
@@ -4478,6 +4482,7 @@ void gslc_CollectSetEventFunc(gslc_tsGui* pGui,gslc_tsCollect* pCollect,GSLC_CB_
   }
   pCollect->pfuncXEvent       = funcCb;
 }
+*/
 
 // ============================================================================
 

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -1959,6 +1959,18 @@ void gslc_PageSetEventFunc(gslc_tsGui* pGui,gslc_tsPage* pPage,GSLC_CB_EVENT fun
 }
 
 
+// TODO: Create a PageStackFocusStep()
+// - The functionality would track which page is currently focused
+//   and instead of looping around on the page, the next enabled
+//   page in the stack would be traversed.
+// - Wrapping at the bottom of the stack would create the GSLC_IND_NONE
+//   state.
+// - Without this enhancement, GPIO / keyboard controls will only
+//   operate on the top-most page in the stack, which prevents the
+//   ability to navigate tab select controls if they are provided
+//   by a lower layer in the stack.
+
+
 int16_t gslc_PageFocusStep(gslc_tsGui* pGui, gslc_tsPage* pPage, bool bNext)
 {
 #if !(GSLC_FEATURE_INPUT)
@@ -3364,9 +3376,10 @@ void gslc_TrackInput(gslc_tsGui* pGui,gslc_tsPage* pPage,gslc_teInputRawEvent eI
   // - For now, use the top enabled page in the stack
   for (int nStack = 0; nStack < GSLC_STACK__MAX; nStack++) {
     if (pGui->pPageStack[nStack]) {
-      // TODO: Check for "bActive" flag, in case we have
-      // disabled touch events for this page in the stack
-      pFocusPage = pGui->pPageStack[nStack];
+      // Ensure the page layer is active (receiving touch events)
+      if (pGui->abPageStackActive[nStack]) {
+        pFocusPage = pGui->pPageStack[nStack];
+      }
     }
   }
   if (!pFocusPage) {

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -1703,35 +1703,39 @@ void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive)
   pGui->abPageStackActive[nStackPos] = bActive;
 }
 
+void gslc_SetPageBase(gslc_tsGui* pGui, int16_t nPageId)
+{
+  gslc_SetStackPage(pGui, GSLC_STACK_BASE, nPageId);
+}
+
 void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId)
 {
   gslc_SetStackPage(pGui, GSLC_STACK_CUR, nPageId);
 }
 
-void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId)
+void gslc_SetPageOverlay(gslc_tsGui* pGui,int16_t nPageId)
 {
-  gslc_SetStackPage(pGui, GSLC_STACK_GLB, nPageId);
+  gslc_SetStackPage(pGui, GSLC_STACK_OVERLAY, nPageId);
 }
-
 
 void gslc_PopupShow(gslc_tsGui* pGui, int16_t nPageId, bool bModal)
 {
-  gslc_SetStackPage(pGui, GSLC_STACK_OVR, nPageId);
+  gslc_SetStackPage(pGui, GSLC_STACK_OVERLAY, nPageId);
   // If modal dialog selected, then deactive other pages in stack
   // If modeless dialog selected, then don't deactive other pages in stack
   if (bModal) {
     gslc_SetStackState(pGui, GSLC_STACK_CUR, false);
-    gslc_SetStackState(pGui, GSLC_STACK_GLB, false);
+    gslc_SetStackState(pGui, GSLC_STACK_BASE, false);
   }
 }
 
 void gslc_PopupHide(gslc_tsGui* pGui)
 {
-  gslc_SetStackPage(pGui, GSLC_STACK_OVR, GSLC_PAGE_NONE);
+  gslc_SetStackPage(pGui, GSLC_STACK_OVERLAY, GSLC_PAGE_NONE);
   // Ensure other pages in stack are activated
   // - This is done in case they were deactivated due to a modal popup
   gslc_SetStackState(pGui, GSLC_STACK_CUR, true);
-  gslc_SetStackState(pGui, GSLC_STACK_GLB, true);
+  gslc_SetStackState(pGui, GSLC_STACK_BASE, true);
 }
 
 

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -152,8 +152,6 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
 
   pGui->pGlbPage        = NULL;
   pGui->pCurPage        = NULL;
-  pGui->pGlbPageCollect = NULL;
-  pGui->pCurPageCollect = NULL;
 
   // Initialize collection of fonts with user-supplied pointer
   pGui->asFont      = asFont;
@@ -1701,9 +1699,6 @@ void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId)
   // Save a reference to the selected page
   pGui->pCurPage = pPage;
 
-  // Save a reference to the selected page's element collection
-  pGui->pCurPageCollect = &pPage->sCollect;
-
   #if defined(DEBUG_LOG)
   GSLC_DEBUG_PRINT("INFO: Changed current to page %u\n",nPageId);
   #endif
@@ -1725,7 +1720,7 @@ void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId)
   if (nPageId == GSLC_PAGE_NONE) {
     // Disable the global page
     pGui->pGlbPage = NULL;
-    pGui->pGlbPageCollect = NULL;
+    //xxx pGui->pGlbPageCollect = NULL;
 
 #if defined(DEBUG_LOG)
     GSLC_DEBUG_PRINT("INFO: Disabled global page%s\n", "");
@@ -1745,7 +1740,7 @@ void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId)
     pGui->pGlbPage = pPage;
 
     // Save a reference to the selected page's element collection
-    pGui->pGlbPageCollect = &pPage->sCollect;
+    //xxx pGui->pGlbPageCollect = &pPage->sCollect;
 
 #if defined(DEBUG_LOG)
     GSLC_DEBUG_PRINT("INFO: Changed global to page %u\n", nPageId);
@@ -1802,6 +1797,7 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
   }
 
   bool  bRedrawFullPage = false;  // Does entire page require redraw?
+  gslc_tsPage*  pPage = NULL;
 
   // Only work on current page
   // But do this in two passes:
@@ -1811,15 +1807,14 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
     // Select the page collection to process
     if (nPageMode == 0) {
       // If no global page exists, proceed to next pass
-      if (!pGui->pGlbPage) {
+      pPage = pGui->pGlbPage;
+      if (!pPage) {
         continue;
       }
-      else {
-        pCollect = pGui->pGlbPageCollect;
-      }
     } else {
-      pCollect = pGui->pCurPageCollect;
+      pPage = pGui->pCurPage;
     }
+    pCollect = &pPage->sCollect;
 
     for (nInd=0;nInd<pCollect->nElemRefCnt;nInd++) {
       pElemRef = &pCollect->asElemRef[nInd];

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -151,7 +151,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   pGui->asPage          = asPage;
 
   for (nInd = 0; nInd < GSLC_STACK__MAX; nInd++) {
-    pGui->pPageStack[nInd] = NULL;
+    pGui->apPageStack[nInd] = NULL;
     pGui->abPageStackActive[nInd] = true;
   }
   pGui->bScreenNeedRedraw  = true;
@@ -1648,7 +1648,7 @@ void gslc_PageAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* psElem,uint16_t 
 
 int gslc_GetPageCur(gslc_tsGui* pGui)
 {
-  gslc_tsPage* pStackPage = pGui->pPageStack[GSLC_STACK_CUR];
+  gslc_tsPage* pStackPage = pGui->apPageStack[GSLC_STACK_CUR];
   if (pStackPage == NULL) {
     return GSLC_PAGE_NONE;
   }
@@ -1658,7 +1658,7 @@ int gslc_GetPageCur(gslc_tsGui* pGui)
 void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
 {
   int16_t nPageSaved = GSLC_PAGE_NONE;
-  gslc_tsPage* pStackPage = pGui->pPageStack[nStackPos];
+  gslc_tsPage* pStackPage = pGui->apPageStack[nStackPos];
   if (pStackPage != NULL) {
     nPageSaved = pStackPage->nPageId;
   }
@@ -1681,7 +1681,7 @@ void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
   }
 
   // Save a reference to the selected page
-  pGui->pPageStack[nStackPos] = pPage;
+  pGui->apPageStack[nStackPos] = pPage;
 
   #if defined(DEBUG_LOG)
   GSLC_DEBUG_PRINT("INFO: Changed PageStack[%u] to page %u\n",nStackPos,nPageId);
@@ -1696,7 +1696,7 @@ void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
 
 void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive)
 {
-  gslc_tsPage* pStackPage = pGui->pPageStack[nStackPos];
+  gslc_tsPage* pStackPage = pGui->apPageStack[nStackPos];
   if (pStackPage == NULL) {
     // TODO: Error
     return;
@@ -1778,7 +1778,7 @@ void gslc_PageRedrawCalc(gslc_tsGui* pGui)
   // Work on each enabled page in the stack
   for (nStackPage=0;nStackPage<GSLC_STACK__MAX;nStackPage++) {
     // Select the page collection to process
-    pPage = pGui->pPageStack[nStackPage];
+    pPage = pGui->apPageStack[nStackPage];
     if (!pPage) {
       // If this stack page is not enabled, skip to next stack page
       continue;
@@ -1866,7 +1866,7 @@ void gslc_PageRedrawGo(gslc_tsGui* pGui)
   // Issue page redraw events to all pages in stack
   // - Start from bottom page in stack first
   for (int nStackPage = 0; nStackPage < GSLC_STACK__MAX; nStackPage++) {
-    gslc_tsPage* pStackPage = pGui->pPageStack[nStackPage];
+    gslc_tsPage* pStackPage = pGui->apPageStack[nStackPage];
     if (!pStackPage) {
       continue;
     }
@@ -3395,10 +3395,10 @@ void gslc_TrackInput(gslc_tsGui* pGui,gslc_tsPage* pPage,gslc_teInputRawEvent eI
   // Determine the page to accept focus
   // - For now, use the top enabled page in the stack
   for (int nStack = 0; nStack < GSLC_STACK__MAX; nStack++) {
-    if (pGui->pPageStack[nStack]) {
+    if (pGui->apPageStack[nStack]) {
       // Ensure the page layer is active (receiving touch events)
       if (pGui->abPageStackActive[nStack]) {
-        pFocusPage = pGui->pPageStack[nStack];
+        pFocusPage = pGui->apPageStack[nStack];
       }
     }
   }
@@ -3565,7 +3565,7 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
 
   // Generate touch page event for any enabled pages in the stack
   for (unsigned nStack = 0; nStack < GSLC_STACK__MAX; nStack++) {
-    gslc_tsPage* pStackPage = pGui->pPageStack[nStack];
+    gslc_tsPage* pStackPage = pGui->apPageStack[nStack];
     if (pStackPage) {
       // Ensure the page layer is active (receiving touch events)
       if (pGui->abPageStackActive[nStack]) {

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -153,6 +153,8 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
   for (nInd = 0; nInd < GSLC_STACK__MAX; nInd++) {
     pGui->pPageStack[nInd] = NULL;
   }
+  pGui->bScreenNeedRedraw  = true;
+  pGui->bScreenNeedFlip    = false;
 
   // Initialize collection of fonts with user-supplied pointer
   pGui->asFont      = asFont;
@@ -1625,8 +1627,6 @@ void gslc_PageAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* psElem,uint16_t 
   gslc_tsPage*  pPage = &pGui->asPage[pGui->nPageCnt];
 
   // TODO: Create proper PageReset()
-  pPage->bPageNeedRedraw  = true;
-  pPage->bPageNeedFlip    = false;
   pPage->pfuncXEvent      = NULL;
 
   // Initialize pPage->sCollect
@@ -1764,24 +1764,20 @@ void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId)
 // requires a redraw.
 void gslc_PageRedrawSet(gslc_tsGui* pGui,bool bRedraw)
 {
-  // FIXME: Support other pages in stack
-  gslc_tsPage* pStackPage = pGui->pPageStack[GSLC_STACK_CUR];
-  if (pStackPage == NULL) {
-    return; // No page added yet
+  if (pGui == NULL) {
+    return;
   }
 
-  pStackPage->bPageNeedRedraw = bRedraw;
+  pGui->bScreenNeedRedraw = bRedraw;
 }
 
 bool gslc_PageRedrawGet(gslc_tsGui* pGui)
 {
-  // FIXME: Support other pages in stack
-  gslc_tsPage* pStackPage = pGui->pPageStack[GSLC_STACK_CUR];
-  if (pStackPage == NULL) {
-    return false; // No page added yet
+  if (pGui == NULL) {
+    return false;
   }
 
-  return pStackPage->bPageNeedRedraw;
+  return pGui->bScreenNeedRedraw;
 }
 
 // Check the redraw flag on all elements on the current page and update
@@ -1927,12 +1923,11 @@ void gslc_PageRedrawGo(gslc_tsGui* pGui)
 
 void gslc_PageFlipSet(gslc_tsGui* pGui,bool bNeeded)
 {
-  gslc_tsPage* pStackPage = pGui->pPageStack[GSLC_STACK_CUR];
-  if (pStackPage == NULL) {
-    return; // No page added yet
+  if (pGui == NULL) {
+    return;
   }
 
-  pStackPage->bPageNeedFlip = bNeeded;
+  pGui->bScreenNeedFlip = bNeeded;
 
   // To assist in debug of drawing primitives, support immediate
   // rendering of the current display. Note that this only works
@@ -1944,22 +1939,20 @@ void gslc_PageFlipSet(gslc_tsGui* pGui,bool bNeeded)
 
 bool gslc_PageFlipGet(gslc_tsGui* pGui)
 {
-  gslc_tsPage* pStackPage = pGui->pPageStack[GSLC_STACK_CUR];
-  if (pStackPage == NULL) {
-    return false; // No page added yet
+  if (pGui == NULL) {
+    return false;
   }
 
-  return pStackPage->bPageNeedFlip;
+  return pGui->bScreenNeedFlip;
 }
 
 void gslc_PageFlipGo(gslc_tsGui* pGui)
 {
-  gslc_tsPage* pStackPage = pGui->pPageStack[GSLC_STACK_CUR];
-  if (pStackPage == NULL) {
-    return; // No page added yet
+  if (pGui == NULL) {
+    return;
   }
 
-  if (pStackPage->bPageNeedFlip) {
+  if (pGui->bScreenNeedFlip) {
     gslc_DrvPageFlipNow(pGui);
 
     // Indicate that page flip is no longer required

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -152,6 +152,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
 
   for (nInd = 0; nInd < GSLC_STACK__MAX; nInd++) {
     pGui->pPageStack[nInd] = NULL;
+    pGui->abPageStackActive[nInd] = true;
   }
   pGui->bScreenNeedRedraw  = true;
   pGui->bScreenNeedFlip    = false;
@@ -1658,7 +1659,7 @@ void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
 {
   int16_t nPageSaved = GSLC_PAGE_NONE;
   gslc_tsPage* pStackPage = pGui->pPageStack[nStackPos];
-  if (pStackPage == NULL) {
+  if (pStackPage != NULL) {
     nPageSaved = pStackPage->nPageId;
   }
 
@@ -1693,14 +1694,14 @@ void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
 }
 
 
-void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bVisible, bool bActive)
+void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive)
 {
   gslc_tsPage* pStackPage = pGui->pPageStack[nStackPos];
   if (pStackPage == NULL) {
     // TODO: Error
     return;
   }
-  // TODO
+  pGui->abPageStackActive[nStackPos] = bActive;
 }
 
 void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId)
@@ -3533,8 +3534,11 @@ void gslc_TrackTouch(gslc_tsGui* pGui,gslc_tsPage* pPage,int16_t nX,int16_t nY,u
   for (unsigned nStack = 0; nStack < GSLC_STACK__MAX; nStack++) {
     gslc_tsPage* pStackPage = pGui->pPageStack[nStack];
     if (pStackPage) {
-      sEvent = gslc_EventCreate(pGui, GSLC_EVT_TOUCH, 0, (void*)pStackPage, pvData);
-      gslc_PageEvent(pGui, sEvent);
+      // Ensure the page layer is active (receiving touch events)
+      if (pGui->abPageStackActive[nStack]) {
+        sEvent = gslc_EventCreate(pGui, GSLC_EVT_TOUCH, 0, (void*)pStackPage, pvData);
+        gslc_PageEvent(pGui, sEvent);
+      }
     }
   }
 

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -1715,6 +1715,26 @@ void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId)
 }
 
 
+void gslc_PopupShow(gslc_tsGui* pGui, int16_t nPageId, bool bModal)
+{
+  gslc_SetStackPage(pGui, GSLC_STACK_OVR, nPageId);
+  if (bModal) {
+    // Deactivate other pages in stack
+    gslc_SetStackState(pGui, GSLC_STACK_CUR, false);
+    gslc_SetStackState(pGui, GSLC_STACK_GLB, false);
+  }
+}
+
+void gslc_PopupHide(gslc_tsGui* pGui)
+{
+  gslc_SetStackPage(pGui, GSLC_STACK_OVR, GSLC_PAGE_NONE);
+  // Ensure other pages in stack are activated
+  // - This is done in case they were deactivated due to a modal popup
+  gslc_SetStackState(pGui, GSLC_STACK_CUR, true);
+  gslc_SetStackState(pGui, GSLC_STACK_GLB, true);
+}
+
+
 // Adjust the flag that indicates whether the entire page
 // requires a redraw.
 void gslc_PageRedrawSet(gslc_tsGui* pGui,bool bRedraw)

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -1674,7 +1674,7 @@ void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
     // Find the page
     pPage = gslc_PageFindById(pGui, nPageId);
     if (pPage == NULL) {
-      GSLC_DEBUG_PRINT("ERROR: SetPageInStack() can't find page (ID=%d)\n", nPageId);
+      GSLC_DEBUG_PRINT("ERROR: SetStackPage() can't find page (ID=%d)\n", nPageId);
       return;
     }
   }
@@ -1717,8 +1717,9 @@ void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId)
 void gslc_PopupShow(gslc_tsGui* pGui, int16_t nPageId, bool bModal)
 {
   gslc_SetStackPage(pGui, GSLC_STACK_OVR, nPageId);
+  // If modal dialog selected, then deactive other pages in stack
+  // If modeless dialog selected, then don't deactive other pages in stack
   if (bModal) {
-    // Deactivate other pages in stack
     gslc_SetStackState(pGui, GSLC_STACK_CUR, false);
     gslc_SetStackState(pGui, GSLC_STACK_GLB, false);
   }

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -748,6 +748,7 @@ typedef struct {
   uint8_t             nPageCnt;         ///< Current page index
 
   gslc_tsPage*        pPageStack[GSLC_STACK__MAX]; ///< Stack of pages
+  bool                abPageStackActive[GSLC_STACK__MAX]; ///< Whether page in stack can receive touch events
 
   // Redraw of screen (ie. across page stack)
   bool                bScreenNeedRedraw; ///< Screen requires a redraw
@@ -1405,12 +1406,11 @@ void gslc_SetStackPage(gslc_tsGui* pGui,uint8_t nStackPos,int16_t nPageId);
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  nStackPos:   Position to update in the page stack (0..GSLC_STACK__MAX-1)
-/// \param[in]  bVisible:    Indicate if page should be shown
 /// \param[in]  bActive:     Indicate if page should receive touch events
 ///
 /// \return none
 ///
-void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bVisible, bool bActive);
+void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive);
 
 
 ///

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -118,6 +118,7 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_PAGE_USER_BASE     = 0,      ///< Starting Page ID for user assignments
     // Internal usage
     GSLC_PAGE_NONE          = -2999,  ///< No Page ID has been assigned
+    GSLC_PAGE_GLOBAL        = -2998,  ///< The global page (always visible)
   } gslc_tePageId;
 
 
@@ -743,7 +744,9 @@ typedef struct {
   uint8_t             nPageMax;         ///< Maximum number of pages
   uint8_t             nPageCnt;         ///< Current page index
 
+  gslc_tsPage*        pGlbPage;         ///< Global page (optional)
   gslc_tsPage*        pCurPage;         ///< Currently active page
+  gslc_tsCollect*     pGlbPageCollect;  ///< Ptr to global page collection (optional)
   gslc_tsCollect*     pCurPageCollect;  ///< Ptr to active page collection
 
   // Callback functions
@@ -1390,6 +1393,17 @@ int gslc_GetPageCur(gslc_tsGui* pGui);
 /// \return none
 ///
 void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId);
+
+
+///
+/// Assigns a page to be globally visible
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nPageId:     Page ID to select as global or GSLC_PAGE_NONE to disable
+///
+/// \return none
+///
+void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId);
 
 
 ///

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -746,8 +746,6 @@ typedef struct {
 
   gslc_tsPage*        pGlbPage;         ///< Global page (optional)
   gslc_tsPage*        pCurPage;         ///< Currently active page
-  gslc_tsCollect*     pGlbPageCollect;  ///< Ptr to global page collection (optional)
-  gslc_tsCollect*     pCurPageCollect;  ///< Ptr to active page collection
 
   // Callback functions
   GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -118,7 +118,6 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_PAGE_USER_BASE     = 0,      ///< Starting Page ID for user assignments
     // Internal usage
     GSLC_PAGE_NONE          = -2999,  ///< No Page ID has been assigned
-    GSLC_PAGE_GLOBAL        = -2998,  ///< The global page (always visible)
   } gslc_tePageId;
 
   /// Define page stack
@@ -1387,6 +1386,31 @@ gslc_tsFont* gslc_FontGet(gslc_tsGui* pGui,int16_t nFontId);
 ///
 
 int gslc_GetPageCur(gslc_tsGui* pGui);
+
+
+///
+/// Assign a page to the page stack
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nStackPos:   Position to update in the page stack (0..GSLC_STACK__MAX-1)
+/// \param[in]  nPageId:     Page ID to select as current
+///
+/// \return none
+///
+void gslc_SetStackPage(gslc_tsGui* pGui,uint8_t nStackPos,int16_t nPageId);
+
+
+///
+/// Change the status of a page in a page stack
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nStackPos:   Position to update in the page stack (0..GSLC_STACK__MAX-1)
+/// \param[in]  bVisible:    Indicate if page should be shown
+/// \param[in]  bActive:     Indicate if page should receive touch events
+///
+/// \return none
+///
+void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bVisible, bool bActive);
 
 
 ///

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -122,9 +122,9 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
 
   /// Define page stack
   typedef enum {
-    GSLC_STACK_GLB = 0,                ///< Global page
+    GSLC_STACK_BASE = 0,               ///< Base page
     GSLC_STACK_CUR,                    ///< Current page
-    GSLC_STACK_OVR,                    ///< Overlay page (eg. popups)
+    GSLC_STACK_OVERLAY,                ///< Overlay page (eg. popups)
 
     GSLC_STACK__MAX                    ///< Defines maximum number of pages in stack
   } gslc_teStackPage;
@@ -1414,10 +1414,21 @@ void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive);
 
 
 ///
-/// Select a new page for display
+/// Assigns a page for the base layer in the page stack
 ///
 /// \param[in]  pGui:        Pointer to GUI
-/// \param[in]  nPageId:     Page ID to select as current
+/// \param[in]  nPageId:     Page ID to select (or GSLC_PAGE_NONE to disable)
+///
+/// \return none
+///
+void gslc_SetPageBase(gslc_tsGui* pGui, int16_t nPageId);
+
+
+///
+/// Select a page for the current layer in the page stack
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nPageId:     Page ID to select
 ///
 /// \return none
 ///
@@ -1425,18 +1436,19 @@ void gslc_SetPageCur(gslc_tsGui* pGui,int16_t nPageId);
 
 
 ///
-/// Assigns a page to be globally visible
+/// Select a page for the overlay layer in the page stack
 ///
 /// \param[in]  pGui:        Pointer to GUI
-/// \param[in]  nPageId:     Page ID to select as global or GSLC_PAGE_NONE to disable
+/// \param[in]  nPageId:     Page ID to select (or GSLC_PAGE_NONE to disable)
 ///
 /// \return none
 ///
-void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId);
+void gslc_SetPageOverlay(gslc_tsGui* pGui,int16_t nPageId);
 
 
 ///
 /// Show a popup dialog
+/// - Popup dialogs use the overlay layer in the page stack
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  nPageId:     Page ID to use as the popup dialog

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -1436,6 +1436,29 @@ void gslc_SetPageGlobal(gslc_tsGui* pGui, int16_t nPageId);
 
 
 ///
+/// Show a popup dialog
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nPageId:     Page ID to use as the popup dialog
+/// \param[in]  bModal:      If true, popup is modal (other layers won't accept touch).
+///                          If false, popup is modeless (other layers still accept touch)
+///
+/// \return none
+///
+void gslc_PopupShow(gslc_tsGui* pGui, int16_t nPageId, bool bModal);
+
+
+///
+/// Hides the currently active popup dialog
+///
+/// \param[in]  pGui:        Pointer to GUI
+///
+/// \return none
+///
+void gslc_PopupHide(gslc_tsGui* pGui);
+
+
+///
 /// Update the need-redraw status for the current page
 ///
 /// \param[in]  pGui:        Pointer to GUI

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -749,6 +749,7 @@ typedef struct {
 
   gslc_tsPage*        apPageStack[GSLC_STACK__MAX];       ///< Stack of pages
   bool                abPageStackActive[GSLC_STACK__MAX]; ///< Whether page in stack can receive touch events
+  bool                abPageStackDoDraw[GSLC_STACK__MAX]; ///< Whether page in stack is still actively drawn
 
   // Redraw of screen (ie. across page stack)
   bool                bScreenNeedRedraw; ///< Screen requires a redraw
@@ -1407,10 +1408,17 @@ void gslc_SetStackPage(gslc_tsGui* pGui,uint8_t nStackPos,int16_t nPageId);
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  nStackPos:   Position to update in the page stack (0..GSLC_STACK__MAX-1)
 /// \param[in]  bActive:     Indicate if page should receive touch events
+/// \param[in]  bDoDraw:     Indicate if page should continue to be redrawn. If pages in
+///                          the stack are overlapping and an element in a lower layer
+///                          continues to receive updates, then the element may "show through"
+///                          the layers above it. In such cases where pages in the stack
+///                          are overlapping and lower pages contain dynamically updating
+///                          elements, it may be best to disable redraw while the overlapping
+///                          page is visible (by setting bDoDraw to false).
 ///
 /// \return none
 ///
-void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive);
+void gslc_SetStackState(gslc_tsGui* pGui, uint8_t nStackPos, bool bActive, bool bDoDraw);
 
 
 ///

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -121,6 +121,14 @@ extern GSLC_CB_DEBUG_OUT g_pfDebugOut;
     GSLC_PAGE_GLOBAL        = -2998,  ///< The global page (always visible)
   } gslc_tePageId;
 
+  /// Define page stack
+  typedef enum {
+    GSLC_STACK_GLB = 0,                ///< Global page
+    GSLC_STACK_CUR,                    ///< Current page
+    GSLC_STACK_OVR,                    ///< Overlay page (eg. popups)
+
+    GSLC_STACK__MAX                    ///< Defines maximum number of pages in stack
+  } gslc_teStackPage;
 
   /// Group ID enumerations
   typedef enum {
@@ -744,8 +752,7 @@ typedef struct {
   uint8_t             nPageMax;         ///< Maximum number of pages
   uint8_t             nPageCnt;         ///< Current page index
 
-  gslc_tsPage*        pGlbPage;         ///< Global page (optional)
-  gslc_tsPage*        pCurPage;         ///< Currently active page
+  gslc_tsPage*        pPageStack[GSLC_STACK__MAX]; ///< Stack of pages
 
   // Callback functions
   GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -662,10 +662,6 @@ typedef struct {
 
   int16_t             nPageId;              ///< Page identifier
 
-  // Redraw
-  bool                bPageNeedRedraw;      ///< Page require a redraw
-  bool                bPageNeedFlip;        ///< Screen requires a page flip
-
   // Callback functions
   GSLC_CB_EVENT       pfuncXEvent;          ///< Callback func ptr for events
 
@@ -753,6 +749,10 @@ typedef struct {
   uint8_t             nPageCnt;         ///< Current page index
 
   gslc_tsPage*        pPageStack[GSLC_STACK__MAX]; ///< Stack of pages
+
+  // Redraw of screen (ie. across page stack)
+  bool                bScreenNeedRedraw; ///< Screen requires a redraw
+  bool                bScreenNeedFlip;   ///< Screen requires a page flip
 
   // Callback functions
   GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -743,11 +743,11 @@ typedef struct {
 
 
   // Pages
-  gslc_tsPage*        asPage;           ///< Array of pages
-  uint8_t             nPageMax;         ///< Maximum number of pages
-  uint8_t             nPageCnt;         ///< Current page index
+  gslc_tsPage*        asPage;           ///< Array of all pages defined in system
+  uint8_t             nPageMax;         ///< Maximum number of pages that can be defined
+  uint8_t             nPageCnt;         ///< Current number of pages defined
 
-  gslc_tsPage*        pPageStack[GSLC_STACK__MAX]; ///< Stack of pages
+  gslc_tsPage*        apPageStack[GSLC_STACK__MAX];       ///< Stack of pages
   bool                abPageStackActive[GSLC_STACK__MAX]; ///< Whether page in stack can receive touch events
 
   // Redraw of screen (ie. across page stack)

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -613,7 +613,7 @@ typedef struct gslc_tsElem {
   void*               pXData;           ///< Ptr to extended data structure
 
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for event tree (draw,touch,tick)
+  GSLC_CB_EVENT       pfuncXEvent;      ///< UNUSED: Callback func ptr for event tree (draw,touch,tick)
 
   GSLC_CB_DRAW        pfuncXDraw;       ///< Callback func ptr for custom drawing
   GSLC_CB_TOUCH       pfuncXTouch;      ///< Callback func ptr for touch
@@ -644,7 +644,7 @@ typedef struct {
   int16_t               nElemIndFocused;  ///< Element index currently in focus (eg. by keyboard/pin control), GSLC_IND_NONE for none
 
   // Callback functions
-  GSLC_CB_EVENT         pfuncXEvent;      ///< Callback func ptr for events
+  //GSLC_CB_EVENT         pfuncXEvent;      ///< UNUSED: Callback func ptr for events
 
 } gslc_tsCollect;
 
@@ -662,7 +662,7 @@ typedef struct {
   int16_t             nPageId;              ///< Page identifier
 
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;          ///< Callback func ptr for events
+  //GSLC_CB_EVENT       pfuncXEvent;          ///< UNUSED: Callback func ptr for events
 
 } gslc_tsPage;
 
@@ -755,7 +755,7 @@ typedef struct {
   bool                bScreenNeedFlip;   ///< Screen requires a page flip
 
   // Callback functions
-  GSLC_CB_EVENT       pfuncXEvent;      ///< Callback func ptr for events
+  //GSLC_CB_EVENT       pfuncXEvent;      ///< UNUSED: Callback func ptr for events
   GSLC_CB_PIN_POLL    pfuncPinPoll;     ///< Callback func ptr for pin polling
 
 
@@ -1937,6 +1937,7 @@ void gslc_ElemSetVisible(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bVisible
 ///
 bool gslc_ElemGetVisible(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
 
+/* UNUSED
 ///
 /// Assign the event callback function for a element
 ///
@@ -1947,6 +1948,7 @@ bool gslc_ElemGetVisible(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
 /// \return none
 ///
 void gslc_ElemSetEventFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_EVENT funcCb);
+*/
 
 
 ///
@@ -2788,6 +2790,7 @@ void gslc_ElemDraw(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId);
 ///
 bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent);
 
+/* UNUSED
 ///
 /// Assign the event callback function for a page
 ///
@@ -2797,8 +2800,8 @@ bool gslc_PageEvent(void* pvGui,gslc_tsEvent sEvent);
 ///
 /// \return none
 ///
-/// \todo Unused?
 void gslc_PageSetEventFunc(gslc_tsGui* pGui,gslc_tsPage* pPage,GSLC_CB_EVENT funcCb);
+*/
 
 ///
 /// Redraw all elements on the active page. Only the
@@ -3086,6 +3089,7 @@ void gslc_CollectSetParent(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsElem
 /// \defgroup _IntCollectEvt_ Internal: Element Collection Event Functions
 /// @{
 
+/* UNUSED
 ///
 /// Assign the event callback function for an element collection
 ///
@@ -3096,6 +3100,7 @@ void gslc_CollectSetParent(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsElem
 /// \return none
 ///
 void gslc_CollectSetEventFunc(gslc_tsGui* pGui,gslc_tsCollect* pCollect,GSLC_CB_EVENT funcCb);
+*/
 
 ///
 /// Common event handler function for an element collection

--- a/src/GUIslice_ex.c
+++ b/src/GUIslice_ex.c
@@ -776,7 +776,10 @@ gslc_tsElemRef* gslc_ElemXCheckboxFindChecked(gslc_tsGui* pGui,int16_t nGroupId)
   bool                bCurChecked;
   gslc_tsElemRef*     pFoundElemRef = NULL;
 
-  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
+  // Operate on current page
+  // TODO: Support other page layers
+  gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
+  if (pPage == NULL) {
     return NULL; // No page added yet
   }
 
@@ -785,10 +788,6 @@ gslc_tsElemRef* gslc_ElemXCheckboxFindChecked(gslc_tsGui* pGui,int16_t nGroupId)
     GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
     return NULL;
   }
-
-  // Operate on current page
-  // TODO: Support other page layers
-  gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
 
   gslc_tsCollect* pCollect = &pPage->sCollect;
   for (nCurInd=0;nCurInd<pCollect->nElemCnt;nCurInd++) {
@@ -901,13 +900,17 @@ void gslc_ElemXCheckboxSetStateHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bo
 // then also update the state of all other buttons in the group.
 void gslc_ElemXCheckboxSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bChecked)
 {
+  // Operate on current page
+  // TODO: Support other page layers
+  gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
+  if (pPage == NULL) {
+    return; // No page added yet
+  }
+
   if (pElemRef == NULL) {
     static const char GSLC_PMEM FUNCSTR[] = "ElemXCheckboxSetState";
     GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
     return;
-  }
-  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
-    return; // No page added yet
   }
 
   gslc_tsElem*        pElem = gslc_GetElemFromRef(pGui,pElemRef);
@@ -942,9 +945,6 @@ void gslc_ElemXCheckboxSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool b
     // We use the GUI pointer for access to other elements
     // NOTE: There is an assumption that we are calling ElemXCheckboxSetState
     //       on a checkbox on the current page.
-    // Operate on current page
-    // TODO: Support other page layers
-    gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
 
     gslc_tsCollect* pCollect = &pPage->sCollect;
     for (nCurInd=0;nCurInd<pCollect->nElemRefCnt;nCurInd++) {

--- a/src/GUIslice_ex.c
+++ b/src/GUIslice_ex.c
@@ -785,9 +785,15 @@ gslc_tsElemRef* gslc_ElemXCheckboxFindChecked(gslc_tsGui* pGui,int16_t nGroupId)
     GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
     return NULL;
   }
-  for (nCurInd=0;nCurInd<pGui->pCurPageCollect->nElemCnt;nCurInd++) {
+
+  // Operate on current page
+  // TODO: Support other page layers
+  gslc_tsPage* pPage = pGui->pCurPage;
+
+  gslc_tsCollect* pCollect = &pPage->sCollect;
+  for (nCurInd=0;nCurInd<pCollect->nElemCnt;nCurInd++) {
     // Fetch extended data
-    pCurElemRef   = &(pGui->pCurPageCollect->asElemRef[nCurInd]);
+    pCurElemRef   = &(pCollect->asElemRef[nCurInd]);
     pCurElem      = gslc_GetElemFromRef(pGui,pCurElemRef);
     nCurType      = pCurElem->nType;
     // Only want to proceed if it is a checkbox
@@ -936,9 +942,14 @@ void gslc_ElemXCheckboxSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool b
     // We use the GUI pointer for access to other elements
     // NOTE: There is an assumption that we are calling ElemXCheckboxSetState
     //       on a checkbox on the current page.
-    for (nCurInd=0;nCurInd<pGui->pCurPageCollect->nElemRefCnt;nCurInd++) {
+    // Operate on current page
+    // TODO: Support other page layers
+    gslc_tsPage* pPage = pGui->pCurPage;
+
+    gslc_tsCollect* pCollect = &pPage->sCollect;
+    for (nCurInd=0;nCurInd<pCollect->nElemRefCnt;nCurInd++) {
       // Fetch extended data
-      pCurElemRef   = &pGui->pCurPageCollect->asElemRef[nCurInd];
+      pCurElemRef   = &pCollect->asElemRef[nCurInd];
       pCurElem      = gslc_GetElemFromRef(pGui,pCurElemRef);
 
       // FIXME: Handle pCurElemRef->eElemFlags

--- a/src/GUIslice_ex.c
+++ b/src/GUIslice_ex.c
@@ -778,7 +778,7 @@ gslc_tsElemRef* gslc_ElemXCheckboxFindChecked(gslc_tsGui* pGui,int16_t nGroupId)
 
   // Operate on current page
   // TODO: Support other page layers
-  gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
+  gslc_tsPage* pPage = pGui->apPageStack[GSLC_STACK_CUR];
   if (pPage == NULL) {
     return NULL; // No page added yet
   }
@@ -902,7 +902,7 @@ void gslc_ElemXCheckboxSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool b
 {
   // Operate on current page
   // TODO: Support other page layers
-  gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
+  gslc_tsPage* pPage = pGui->apPageStack[GSLC_STACK_CUR];
   if (pPage == NULL) {
     return; // No page added yet
   }

--- a/src/GUIslice_ex.c
+++ b/src/GUIslice_ex.c
@@ -776,7 +776,7 @@ gslc_tsElemRef* gslc_ElemXCheckboxFindChecked(gslc_tsGui* pGui,int16_t nGroupId)
   bool                bCurChecked;
   gslc_tsElemRef*     pFoundElemRef = NULL;
 
-  if (pGui->pCurPage == NULL) {
+  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
     return NULL; // No page added yet
   }
 
@@ -788,7 +788,7 @@ gslc_tsElemRef* gslc_ElemXCheckboxFindChecked(gslc_tsGui* pGui,int16_t nGroupId)
 
   // Operate on current page
   // TODO: Support other page layers
-  gslc_tsPage* pPage = pGui->pCurPage;
+  gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
 
   gslc_tsCollect* pCollect = &pPage->sCollect;
   for (nCurInd=0;nCurInd<pCollect->nElemCnt;nCurInd++) {
@@ -906,7 +906,7 @@ void gslc_ElemXCheckboxSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool b
     GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
     return;
   }
-  if (pGui->pCurPage == NULL) {
+  if (pGui->pPageStack[GSLC_STACK_CUR] == NULL) {
     return; // No page added yet
   }
 
@@ -944,7 +944,7 @@ void gslc_ElemXCheckboxSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool b
     //       on a checkbox on the current page.
     // Operate on current page
     // TODO: Support other page layers
-    gslc_tsPage* pPage = pGui->pCurPage;
+    gslc_tsPage* pPage = pGui->pPageStack[GSLC_STACK_CUR];
 
     gslc_tsCollect* pCollect = &pPage->sCollect;
     for (nCurInd=0;nCurInd<pCollect->nElemRefCnt;nCurInd++) {

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.73"
+#define GUISLICE_VER "0.11.0.78"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.94"
+#define GUISLICE_VER "0.11.0.95"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.61"
+#define GUISLICE_VER "0.11.0.62"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.72"
+#define GUISLICE_VER "0.11.0.73"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.79"
+#define GUISLICE_VER "0.11.0.80"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.65"
+#define GUISLICE_VER "0.11.0.66"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.92"
+#define GUISLICE_VER "0.11.0.93"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.64"
+#define GUISLICE_VER "0.11.0.65"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.80"
+#define GUISLICE_VER "0.11.0.81"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.62"
+#define GUISLICE_VER "0.11.0.63"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.69"
+#define GUISLICE_VER "0.11.0.70"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.68"
+#define GUISLICE_VER "0.11.0.69"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.70"
+#define GUISLICE_VER "0.11.0.71"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.66"
+#define GUISLICE_VER "0.11.0.67"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.67"
+#define GUISLICE_VER "0.11.0.68"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.93"
+#define GUISLICE_VER "0.11.0.94"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.71"
+#define GUISLICE_VER "0.11.0.72"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.63"
+#define GUISLICE_VER "0.11.0.64"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.78"
+#define GUISLICE_VER "0.11.0.79"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.0.95"
+#define GUISLICE_VER "0.11.0.96"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
- Implement basic page stack functionality from #71 and #81 
- Add example ex24 to show tabbed dialog box, base layer and popup
- Add example ex25 to show popup
- Add `SetPageBase()`, `SetPageOverlay()` to complement `SetPageCur()`
- Add `PopupShow()` and `PopupHide()`
- Add `SetStackPage()` and `SetStackState()` to permit advanced controls over the page stack
- Further optimizations for redraw will come later
