### PR TITLE
Add XListbox element

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2798,6 +2798,7 @@ void gslc_ElemSetTxtStr(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,const char* pS
   if (strncmp(pElem->pStrBuf,pStr,pElem->nStrBufMax-1)) {
     strncpy(pElem->pStrBuf,pStr,pElem->nStrBufMax-1);
     pElem->pStrBuf[pElem->nStrBufMax-1] = '\0';  // Force termination
+    // TODO: Might want to change to GSLC_REDRAW_INC
     gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
   }
 }
@@ -2814,6 +2815,7 @@ void gslc_ElemSetTxtCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor c
       !gslc_ColorEqual(pElem->colElemTextGlow, colVal)) {
     pElem->colElemText      = colVal;
     pElem->colElemTextGlow  = colVal; // Default to same color for glowing state
+    // TODO: Might want to change to GSLC_REDRAW_INC
     gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
   }
 }
@@ -2939,7 +2941,6 @@ gslc_teRedrawType gslc_ElemGetRedraw(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
   return GSLC_REDRAW_NONE;
 }
 
-
 void gslc_ElemSetGlow(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bGlowing)
 {
   if ((pElemRef == NULL) || (pElemRef->pElem == NULL)) {
@@ -2952,7 +2953,7 @@ void gslc_ElemSetGlow(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bGlowing)
   gslc_SetElemRefFlag(pGui,pElemRef,GSLC_ELEMREF_GLOWING,(bGlowing)?GSLC_ELEMREF_GLOWING:0);
 
   if (bGlowing != bGlowingOld) {
-    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
   }
 }
 
@@ -3033,7 +3034,7 @@ void gslc_ElemSetGlowEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bGlowEn)
   } else {
     pElem->nFeatures &= ~GSLC_ELEM_FEA_GLOW_EN;
   }
-  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
 }
 
 bool gslc_ElemGetGlowEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
@@ -3060,7 +3061,7 @@ void gslc_ElemSetClickEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bClickEn
   } else {
     pElem->nFeatures &= ~GSLC_ELEM_FEA_CLICK_EN;
   }
-  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+  // No need to call ElemSetRedraw() as we aren't changing a visual characteristic
 }
 
 void gslc_ElemSetStyleFrom(gslc_tsGui* pGui,gslc_tsElemRef* pElemRefSrc,gslc_tsElemRef* pElemRefDest)

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2128,6 +2128,30 @@ gslc_tsElem* gslc_GetElemFromRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
   return pElem;
 }
 
+// For extended elements, fetch the extended data structure
+void* gslc_GetXDataFromRef(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nType, int16_t nLineNum)
+{
+  if (pElemRef == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pElemRef is NULL\n", nType, nLineNum);
+    return NULL;
+  }
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui, pElemRef);
+  if (pElem == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pElem is NULL\n", nType, nLineNum);
+    return NULL;
+  }
+  if (pElem->nType != nType) {
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) Elem type mismatch\n", nType, nLineNum);
+    return NULL;
+  }
+  void* pXData = pElem->pXData;
+  if (pXData == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pXData is NULL\n", nType, nLineNum);
+    return NULL;
+  }
+  return pXData;
+}
+
 
 // ------------------------------------------------------------------------
 // Element Creation Functions

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -2739,10 +2739,10 @@ uint8_t gslc_GetElemRefFlag(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,uint8_t nF
 void gslc_SetElemRefFlag(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,uint8_t nFlagMask,uint8_t nFlagVal);
 
 
-// Returns a pointer to an element from an element reference, copying
-// from FLASH to RAM if element is stored in PROGMEM. This function
-// enables all APIs to work with Elements irrespective of whether they
-// were created in RAM or Flash.
+/// Returns a pointer to an element from an element reference, copying
+/// from FLASH to RAM if element is stored in PROGMEM. This function
+/// enables all APIs to work with Elements irrespective of whether they
+/// were created in RAM or Flash.
 ///
 /// \param[in]  pGui:         Pointer to GUI
 /// \param[in]  pElemRef:     Pointer to Element Reference
@@ -2750,6 +2750,19 @@ void gslc_SetElemRefFlag(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,uint8_t nFlag
 /// \return Pointer to Element after ensuring that it is accessible from RAM
 ///
 gslc_tsElem* gslc_GetElemFromRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
+
+/// Returns a pointer to the data structure associated with an extended element.
+/// - Example usage:
+///   gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+///
+/// \param[in]  pGui:         Pointer to GUI
+/// \param[in]  pElemRef:     Pointer to Element Reference
+/// \param[in]  nType:        Expected type indicator (ie. GSLC_TYPEX_*)
+/// \param[in]  nLineNum:     Line number from calling function (ie. __LINE__)
+///
+/// \return Void pointer to extended data (pXData), or NULL if error. Needs to be typecasted accordingly.
+///
+void* gslc_GetXDataFromRef(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nType, int16_t nLineNum);
 
 
 ///

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.11"
+#define GUISLICE_VER "0.11.2.12"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.10"
+#define GUISLICE_VER "0.11.2.11"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.12"
+#define GUISLICE_VER "0.11.2.14"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2"
+#define GUISLICE_VER "0.11.2.10"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XCheckbox.c
+++ b/src/elem/XCheckbox.c
@@ -58,17 +58,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //
 // - This file extends the core GUIslice functionality with
 //   additional widget types
-// - After adding any widgets to GUIslice_ex, a unique
-//   enumeration (GSLC_TYPEX_*) should be added to "GUIslice.h"
 //
-//   TODO: Consider whether we should remove the need to update
-//         these enumerations in "GUIslice.h"; we could instead
-//         define a single "GSLC_TYPEX" in GUIslice.h but then
-//         allow "GUIslice_ex.h" to create a new set of unique
-//         enumerations. This way extended elements could be created
-//         in GUIslice_ex and no changes at all would be required
-//         in GUIslice.
-
 // ----------------------------------------------------------------------------
 
 // ============================================================================

--- a/src/elem/XGauge.c
+++ b/src/elem/XGauge.c
@@ -60,17 +60,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //
 // - This file extends the core GUIslice functionality with
 //   additional widget types
-// - After adding any widgets to GUIslice_ex, a unique
-//   enumeration (GSLC_TYPEX_*) should be added to "GUIslice.h"
 //
-//   TODO: Consider whether we should remove the need to update
-//         these enumerations in "GUIslice.h"; we could instead
-//         define a single "GSLC_TYPEX" in GUIslice.h but then
-//         allow "GUIslice_ex.h" to create a new set of unique
-//         enumerations. This way extended elements could be created
-//         in GUIslice_ex and no changes at all would be required
-//         in GUIslice.
-
 // ----------------------------------------------------------------------------
 
 

--- a/src/elem/XGraph.c
+++ b/src/elem/XGraph.c
@@ -58,17 +58,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //
 // - This file extends the core GUIslice functionality with
 //   additional widget types
-// - After adding any widgets to GUIslice_ex, a unique
-//   enumeration (GSLC_TYPEX_*) should be added to "GUIslice.h"
 //
-//   TODO: Consider whether we should remove the need to update
-//         these enumerations in "GUIslice.h"; we could instead
-//         define a single "GSLC_TYPEX" in GUIslice.h but then
-//         allow "GUIslice_ex.h" to create a new set of unique
-//         enumerations. This way extended elements could be created
-//         in GUIslice_ex and no changes at all would be required
-//         in GUIslice.
-
 // ----------------------------------------------------------------------------
 
 // ============================================================================

--- a/src/elem/XListbox.c
+++ b/src/elem/XListbox.c
@@ -1,0 +1,788 @@
+// =======================================================================
+// GUIslice library (extensions)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file GUIslice_ex.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XListbox.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+
+// ----------------------------------------------------------------------------
+
+// TODO: Combine with GUIslice MAX_STR
+// Defines the maximum length of a listbox item
+#define XLISTBOX_MAX_STR        20
+
+// ============================================================================
+// Extended Element: Listbox
+// - A Listbox control
+// ============================================================================
+
+/*
+// Basic debug functionality
+void debug_ElemXListboxDump(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef)
+{
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui, pElemRef);
+  gslc_tsXListbox*  pListbox = (gslc_tsXListbox*)(pElem->pXData);
+
+  char acTxt[40 + 1];
+  GSLC_DEBUG_PRINT("Xlistbox:Dump (nBufPos=%d nItemCnt=%d)\n", pListbox->nBufItemsPos,pListbox->nItemCnt);
+  for (unsigned nInd = 0; nInd < pListbox->nBufItemsPos; nInd++) {
+    char ch = pListbox->pBufItems[nInd];
+    if (ch == 0) {
+      snprintf(acTxt, 40,"[%2u] = %02X = [NULL]", nInd, ch);
+    }
+    else {
+      snprintf(acTxt, 40,"[%2u] = %02X = [%c]", nInd, ch, ch);
+    }
+    GSLC_DEBUG_PRINT("XListbox:Dump: %s\n", acTxt);
+  }
+}
+*/
+
+
+// Recalculate listbox item sizing if enabled
+bool gslc_ElemXListboxRecalcSize(gslc_tsXListbox* pListbox,gslc_tsRect rElem)
+{
+  int16_t nElem;
+  int16_t nElemInner;
+  int16_t nItemOuter;
+  int16_t nItemWOld;
+  bool bNeedRedraw = false;
+
+  // If number of rows was auto-sized based on content, then calculate now
+  if (pListbox->nRows == XLISTBOX_SIZE_AUTO) {
+    if (pListbox->nItemCnt == 0) {
+      pListbox->nRows = 1; // Force at least one row
+    } else {
+      pListbox->nRows = ((pListbox->nItemCnt + 1) / pListbox->nCols);
+    }
+  }
+
+  // NOTE: In the nElemInner calculation, we add nItemGap to account
+  // for the fact that the last column does not include a "gap" after it.
+  if (pListbox->bItemAutoSizeW) {
+    nItemWOld = pListbox->nItemW;
+    nElem = rElem.w;
+    nElemInner = nElem - (2 * pListbox->nMarginW) + pListbox->nItemGap;
+    nItemOuter = nElemInner / pListbox->nCols;
+    pListbox->nItemW = nItemOuter - pListbox->nItemGap;
+    if (pListbox->nItemW != nItemWOld) {
+      bNeedRedraw = true;
+    }
+  }
+  if (pListbox->bItemAutoSizeH) {
+    nItemWOld = pListbox->nItemH;
+    nElem = rElem.h;
+    nElemInner = nElem - (2 * pListbox->nMarginH) + pListbox->nItemGap;
+    nItemOuter = nElemInner / pListbox->nRows;
+    pListbox->nItemH = nItemOuter - pListbox->nItemGap;
+    if (pListbox->nItemH != nItemWOld) {
+      bNeedRedraw = true;
+    }
+  }
+
+  // Clear Need Recalc flag
+  pListbox->bNeedRecalc = false;
+
+  return bNeedRedraw;
+}
+
+void gslc_ElemXListboxSetSize(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nRows, int8_t nCols)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->nRows = nRows;
+  pListbox->nCols = nCols;
+  pListbox->bNeedRecalc = true;
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+}
+
+
+
+void gslc_ElemXListboxSetMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->nMarginW = nMarginW;
+  pListbox->nMarginH = nMarginH;
+  pListbox->bNeedRecalc = true;
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXListboxItemsSetTxtMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->nItemMarginW = nMarginW;
+  pListbox->nItemMarginH = nMarginH;
+  pListbox->bNeedRecalc = true;
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+}
+
+
+void gslc_ElemXListboxItemsSetSize(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemW, int16_t nItemH)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->nItemW = nItemW;
+  pListbox->nItemH = nItemH;
+  // Determine if auto-sizing requested
+  pListbox->bItemAutoSizeW = (nItemW == XLISTBOX_SIZE_AUTO) ? true : false;
+  pListbox->bItemAutoSizeH = (nItemH == XLISTBOX_SIZE_AUTO) ? true : false;
+
+  pListbox->bNeedRecalc = true;
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXListboxItemsSetGap(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nGap, gslc_tsColor colGap)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->nItemGap = nGap;
+  pListbox->colGap = colGap;
+  pListbox->bNeedRecalc = true;
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+}
+
+
+void gslc_ElemXListboxReset(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->nBufItemsPos = 0;
+  pListbox->nItemCnt = 0;
+  pListbox->nItemSel = XLISTBOX_SEL_NONE;
+  pListbox->bNeedRecalc = true;
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+}
+
+
+bool gslc_ElemXListboxAddItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, const char* pStrItem)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return false;
+
+  int8_t      nStrItemLen;
+  char*       pBuf = NULL;
+  uint16_t    nBufItemsPos = pListbox->nBufItemsPos;
+  uint16_t    nBufItemsMax = pListbox->nBufItemsMax;
+
+  nStrItemLen = strlen(pStrItem);
+
+  if (nStrItemLen == 0) {
+    // Nothing to add
+    return false;
+  }
+
+  // Ensure we won't overrun the buffer, including the terminator
+  if (nBufItemsPos + nStrItemLen + 1 > nBufItemsMax) {
+    // Proceed with truncation
+    nStrItemLen = nBufItemsMax - pListbox->nBufItemsPos - 1;
+    GSLC_DEBUG_PRINT("ERROR: ElemXListboxAddItem() buffer too small\n", "");
+  }
+
+  // If the truncation left nothing to add, skip out now
+  if (nStrItemLen <= 0) {
+    return false;
+  }
+
+  pBuf = pListbox->pBufItems + nBufItemsPos;
+  strncpy(pBuf, pStrItem, nStrItemLen);
+  pListbox->nBufItemsPos += nStrItemLen;
+
+  // Ensure terminator added
+  pBuf += nStrItemLen;
+  *pBuf = 0;
+  pListbox->nBufItemsPos++;
+
+  pListbox->nItemCnt++;
+
+  //GSLC_DEBUG_PRINT("Xlistbox:Add\n", "");
+  //debug_ElemXListboxDump(pGui, pElemRef);
+
+  // Inidicate sizing may need update
+  pListbox->bNeedRecalc = true;
+
+  // Mark as needing full redraw
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+  return true;
+}
+
+bool gslc_ElemXListboxGetItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemSel, char* pStrItem, uint8_t nStrItemLen)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return false;
+
+  // Ensure user provided valid string
+  if ((pStrItem == NULL) || (nStrItemLen == 0)) {
+    // ERROR
+    return false;
+  }
+  uint16_t   nBufPos = 0;
+  uint16_t   nItemInd = 0;
+  uint8_t*   pBuf = NULL;
+  bool       bFound = false;
+  while (1) {
+    if (nItemInd == nItemSel) {
+      bFound = true;
+      break;
+    }
+    if (nBufPos >= pListbox->nBufItemsMax) {
+      break;
+    }
+    if (pListbox->pBufItems[nBufPos] == 0) {
+      nItemInd++;
+    }
+    nBufPos++;
+  }
+  if (bFound) {
+    pBuf = &(pListbox->pBufItems[nBufPos]);
+    strncpy(pStrItem, (char*)pBuf, nStrItemLen);
+    // Ensure null terminated in case the buffer
+    // was smaller than the item source
+    pStrItem[nStrItemLen - 1] = 0;
+    return true;
+  } else {
+    // If no item was found, return an empty string (NULL)
+    pStrItem[0] = 0;
+    return false;
+  }
+}
+
+
+int16_t gslc_ElemXListboxGetItemCnt(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return 0;
+
+  return pListbox->nItemCnt;
+}
+
+
+// Create a Listbox element and add it to the GUI element list
+// - Defines default styling for the element
+// - Defines callback for redraw and touch
+gslc_tsElemRef* gslc_ElemXListboxCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXListbox* pXData,gslc_tsRect rElem,int16_t nFontId,uint8_t* pBufItems,uint16_t nBufItemsMax,int16_t nItemDefault)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXListboxCreate";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_LISTBOX,rElem,NULL,0,nFontId);
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_CLICK_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_GLOW_EN;
+
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+  pXData->pBufItems       = pBufItems;
+  pXData->nBufItemsMax    = nBufItemsMax;
+  pXData->nBufItemsPos    = 0;
+  pXData->nItemCnt        = 0;
+  pXData->nItemSel        = nItemDefault;
+  pXData->nItemTop        = 0;
+  pXData->pfuncXSel       = NULL;
+  pXData->nCols           = 1;
+  pXData->nRows           = XLISTBOX_SIZE_AUTO;     // Auto-calculated from content
+  pXData->bNeedRecalc     = true;                   // Force auto-sizing
+  pXData->nMarginW        = 5;
+  pXData->nMarginH        = 5;
+  pXData->bItemAutoSizeW  = true;                   // Force auto-sizing
+  pXData->bItemAutoSizeH  = false;
+  pXData->nItemW          = XLISTBOX_SIZE_AUTO;     // Auto-sized
+  pXData->nItemH          = 30;
+  pXData->nItemGap        = 2;
+  pXData->colGap          = GSLC_COL_BLACK;
+  pXData->nItemMarginW    = 5;
+  pXData->nItemMarginH    = 5;
+  pXData->nRedrawSelOld   = XLISTBOX_SEL_NONE;
+  sElem.pXData            = (void*)(pXData);
+  // Specify the custom drawing callback
+  sElem.pfuncXDraw        = &gslc_ElemXListboxDraw;
+  // Specify the custom touch tracking callback
+  sElem.pfuncXTouch       = &gslc_ElemXListboxTouch;
+
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_WHITE;
+
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+
+// Redraw the Listbox
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+bool gslc_ElemXListboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXListboxDraw";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return false;
+  }
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui  = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui,pElemRef);
+
+  // Fetch the element's extended data structure
+  gslc_tsXListbox* pListbox;
+  pListbox = (gslc_tsXListbox*)(pElem->pXData);
+  if (pListbox == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: ElemXListboxDraw(%s) pXData is NULL\n","");
+    return false;
+  }
+
+  //bool            bGlow     = (pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN) && gslc_ElemGetGlow(pGui,pElemRef);
+  int8_t          nItemSel  = pListbox->nItemSel;
+
+
+  gslc_tsRect rElemRect;
+  if (pElem->nFeatures & GSLC_ELEM_FEA_FRAME_EN) {
+    rElemRect = gslc_ExpandRect(pElem->rElem, -1, -1);
+    if (eRedraw == GSLC_REDRAW_FULL) {
+      gslc_DrawFrameRect(pGui, pElem->rElem, pElem->colElemFrame);
+    }
+  } else {
+    rElemRect = pElem->rElem;
+  }
+
+  // If full redraw and gap is enabled:
+  // - Clear background with gap color, as list items
+  //   will be overdrawn in colBg color
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    if (pListbox->nItemGap > 0) {
+      gslc_DrawFillRect(pGui, rElemRect, pListbox->colGap);
+    }
+  }
+
+  // Determine if we need to recalculate the item sizing
+  if (pListbox->bNeedRecalc) {
+    gslc_ElemXListboxRecalcSize(pListbox, rElemRect);
+  }
+
+  int16_t nX0, nY0;
+  nX0 = rElemRect.x;
+  nY0 = rElemRect.y;
+
+  int8_t        nRows = pListbox->nRows;
+  int8_t        nCols = pListbox->nCols;
+  gslc_tsRect   rItemRect;
+  int16_t       nItemBaseX, nItemBaseY;
+  int16_t       nItemX, nItemY;
+  int16_t       nItemW, nItemH;
+  int16_t       nTxtPixX;
+  int16_t       nTxtPixY;
+  bool          bItemSel;
+  gslc_tsColor  colFill, colTxt;
+
+  // Error check
+  if (nCols == 0) {
+    return false;
+  }
+
+  // Determine top-left coordinate of list matrix
+  nItemBaseX = nX0 + pListbox->nMarginW;
+  nItemBaseY = nY0 + pListbox->nMarginH;
+  char acStr[XLISTBOX_MAX_STR+1] = "";
+
+
+  // Loop through the items in the list
+  int8_t nItemTop = pListbox->nItemTop;
+  int8_t nItemCnt = pListbox->nItemCnt;
+  int8_t nItemInd;
+
+  // Note that nItemTop is always pointing to an
+  // item index at the start of a row
+
+  // Determine the list indices to display in the visible window due to scrolling
+  int8_t nDispIndMax = (nRows * nCols);
+
+  for (int8_t nDispInd = 0; nDispInd < nDispIndMax; nDispInd++) {
+
+    // Calculate the item index based on the display index
+    nItemInd = nItemTop + nDispInd;
+
+    // Did we go past the end of our list?
+    if (nItemInd >= nItemCnt) {
+      break;
+    }
+
+    // Fetch the list item
+    bool bOk = gslc_ElemXListboxGetItem(pGui, pElemRef, nItemInd, acStr, XLISTBOX_MAX_STR);
+    if (!bOk) {
+      // TODO: Erorr handling
+      break;
+    }
+
+    int8_t    nItemIndX, nItemIndY;
+    int16_t   nItemOuterW, nItemOuterH;
+
+    // Convert linear count into row & column
+    nItemIndY = nDispInd / nCols; // Round down
+    nItemIndX = nDispInd % nCols;
+
+    // Calculate total spacing between items (including gap)
+    nItemOuterW = pListbox->nItemW + pListbox->nItemGap;
+    nItemOuterH = pListbox->nItemH + pListbox->nItemGap;
+
+    // Determine top-left corner of each item
+    nItemW = pListbox->nItemW;
+    nItemH = pListbox->nItemH;
+    nItemY = nItemBaseY + (nItemIndY * nItemOuterH);
+    nItemX = nItemBaseX + (nItemIndX * nItemOuterW);
+
+    // Create rect for item
+    rItemRect = (gslc_tsRect) { nItemX, nItemY, nItemW, nItemH };
+
+    // Create coordinate for text
+    nTxtPixX = nItemX + pListbox->nItemMarginW;
+    nTxtPixY = nItemY + pListbox->nItemMarginH;
+
+    // Is the item selected?
+    bItemSel = (nItemInd == nItemSel) ? true : false;
+
+    // Determine the color based on state
+    colFill = (bItemSel) ? pElem->colElemFillGlow : pElem->colElemFill;
+    colTxt = (bItemSel) ? pElem->colElemTextGlow : pElem->colElemText;
+
+    bool bDoRedraw = false;
+    if (eRedraw == GSLC_REDRAW_FULL) {
+      bDoRedraw = true;
+    } else if (eRedraw == GSLC_REDRAW_INC) {
+      if (nItemInd == pListbox->nRedrawSelOld) {
+        bDoRedraw = true;
+      } else if (nItemInd == nItemSel) {
+        bDoRedraw = true;
+      }
+    }
+    // Draw the list item
+    if (bDoRedraw) {
+      gslc_DrawFillRect(pGui, rItemRect, colFill);
+      gslc_DrvDrawTxt(pGui, nTxtPixX, nTxtPixY, pElem->pTxtFont, acStr, pElem->eTxtFlags, colTxt, colFill);
+    }
+
+
+  }
+
+  // Save the last selected item
+  pListbox->nRedrawSelOld = nItemSel;
+
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  // Mark page as needing flip
+  gslc_PageFlipSet(pGui,true);
+
+  return true;
+}
+
+bool gslc_ElemXListboxTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, int16_t nRelX, int16_t nRelY)
+{
+  #if defined(DRV_TOUCH_NONE)
+  return false;
+  #else
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXListboxTouch";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return false;
+  }
+  gslc_tsGui*           pGui = NULL;
+  gslc_tsElemRef*       pElemRef = NULL;
+  gslc_tsElem*          pElem = NULL;
+  gslc_tsXListbox*      pListbox = NULL;
+
+  // Typecast the parameters to match the GUI
+  pGui = (gslc_tsGui*)(pvGui);
+  pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  pElem = gslc_GetElemFromRef(pGui, pElemRef);
+  pListbox = (gslc_tsXListbox*)(pElem->pXData);
+
+  //bool    bGlowingOld = gslc_ElemGetGlow(pGui, pElemRef);
+  bool    bTouchInside = false;
+  bool    bUpdateSel = false;
+  bool    bIndexed = false;
+
+  switch (eTouch) {
+
+  case GSLC_TOUCH_DOWN_IN:
+    // Start glowing as must be over it
+    gslc_ElemSetGlow(pGui, pElemRef, true);
+    bUpdateSel = true;
+    bTouchInside = true;
+    break;
+
+  case GSLC_TOUCH_MOVE_IN:
+    gslc_ElemSetGlow(pGui, pElemRef, true);
+    bUpdateSel = true;
+    bTouchInside = true;
+    break;
+  case GSLC_TOUCH_MOVE_OUT:
+    gslc_ElemSetGlow(pGui, pElemRef, false);
+    bUpdateSel = true;
+    break;
+
+  case GSLC_TOUCH_UP_IN:
+    // End glow
+    gslc_ElemSetGlow(pGui, pElemRef, false);
+    bTouchInside = true;
+    break;
+  case GSLC_TOUCH_UP_OUT:
+    // End glow
+    gslc_ElemSetGlow(pGui, pElemRef, false);
+    bUpdateSel = true; // TODO: Determine if this is correct
+    break;
+
+  case GSLC_TOUCH_SET_REL:
+  case GSLC_TOUCH_SET_ABS:
+    //bIndexed = true;
+    //gslc_ElemSetGlow(pGui,pElemRef,true);
+    //bUpdateSel = true;
+    break;
+
+  default:
+    return false;
+    break;
+  }
+
+  uint8_t nCols = pListbox->nCols;
+
+  // If we need to update the Listbox selection, calculate the value
+  // and perform the update
+  if (bUpdateSel) {
+    int16_t nItemSelOld = pListbox->nItemSel;
+    int16_t nItemSel = XLISTBOX_SEL_NONE;
+
+    if (bIndexed) {
+      // The selection is changed by direct control (eg. keyboard)
+      // instead of touch coordinates
+
+
+      // FIXME: Change the following to be either absolute or relative
+      // value assignment instead of inc/dec. Then the user code can
+      // define what the magnitude and direction should be.
+
+      if (eTouch == GSLC_TOUCH_SET_REL) {
+        // Overload the "nRelY" parameter
+        nItemSel = nItemSelOld + nRelY;
+      } else if (eTouch == GSLC_TOUCH_SET_ABS) {
+        // Overload the "nRelY" parameter
+        nItemSel = nRelY;
+      }
+      gslc_ElemXListboxSetSel(pGui, pElemRef, nItemSel);
+    }
+    else {
+      // Determine which item we are tracking
+      int16_t nItemOuterW, nItemOuterH;
+      int16_t nDispR, nDispC;
+      int16_t nItemR, nItemC;
+      if (bTouchInside) {
+        // Get position relative to top-left list matrix cell
+        nRelX -= pListbox->nMarginW;
+        nRelY -= pListbox->nMarginH;
+        // Determine spacing between matrix cells
+        nItemOuterW = pListbox->nItemW + pListbox->nItemGap;
+        nItemOuterH = pListbox->nItemH + pListbox->nItemGap;
+
+        // Determine which matrix cell we are in
+        nDispC = nRelX / nItemOuterW;
+        nDispR = nRelY / nItemOuterH;
+
+        // Map the display cell to the list cell (adjusted for scrolling)
+        // - Note that nItemTop is always pointing to an
+        //   item index at the start of a row
+        nItemC = nDispC;
+        nItemR = pListbox->nItemTop + nDispR;
+
+        // Now we have identified the cell within the list matrix
+        if (nItemR >= 0) {
+          if ((nItemC >= 0) && (nItemC < nCols)) {
+            nItemSel = nItemR * nCols + nItemC;
+            if (nItemSel >= pListbox->nItemCnt) {
+              // Out of range, so disable
+              nItemSel = XLISTBOX_SEL_NONE;
+            }
+            // Now check for touch in gap region
+            // - First find offset from top-left of matrix cell
+            nRelX = nRelX % nItemOuterW;
+            nRelY = nRelY % nItemOuterH;
+            // If we are in the gap region, disable
+            if (nRelX > pListbox->nItemW) {
+              nItemSel = XLISTBOX_SEL_NONE;
+            }
+            if (nRelY > pListbox->nItemH) {
+              nItemSel = XLISTBOX_SEL_NONE;
+            }
+
+          }
+        }
+      }
+
+      // Update the Listbox selection
+      if (nItemSel != nItemSelOld) {
+        // Update the selection
+        gslc_ElemXListboxSetSel(pGui, pElemRef, nItemSel);
+        // If any selection callback is defined, call it now
+        if (pListbox->pfuncXSel != NULL) {
+          (*pListbox->pfuncXSel)((void*)(pGui),(void*)(pElemRef),nItemSel);
+        }
+        // Redraw the element
+        // - Note that ElemXListboxSetSel() above will also request redraw
+        gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_INC);
+      }
+    }
+
+  }
+
+  return true;
+  
+  #endif // DRV_TOUCH_NONE
+}
+
+int16_t gslc_ElemXListboxGetSel(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return XLISTBOX_SEL_NONE;
+
+  return pListbox->nItemSel;
+}
+
+bool gslc_ElemXListboxSetSel(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef, int16_t nItemSel)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return false;
+
+  bool bOk = false;
+  if (nItemSel == XLISTBOX_SEL_NONE) { bOk = true; }
+  if ((nItemSel >= 0) && (nItemSel < pListbox->nItemCnt)) { bOk = true; }
+  if (bOk) {
+    pListbox->nItemSel = nItemSel;
+    gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_INC);
+  }
+  return bOk;
+}
+
+bool gslc_ElemXListboxSetScrollPos(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nScrollPos)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return false;
+
+  bool bOk = false;
+  if ((nScrollPos >= 0) && (nScrollPos < pListbox->nItemCnt)) {
+    bOk = true;
+  }
+
+  int16_t nCols = pListbox->nCols;
+  int16_t nItemCnt = pListbox->nItemCnt;
+
+  // Error handling: in case position out of bounds
+  if (nScrollPos >= nItemCnt) {
+    nScrollPos = (nItemCnt > 0) ? nItemCnt - 1 : 0;
+  }
+
+  // Adjust the top item index to the start of its row
+  // - This is done because we may have multiple columns
+  //   per row. This ensures nItemTop points to the list
+  //   index at the start of a row.
+  nScrollPos = (nScrollPos / nCols) * nCols;
+  pListbox->nItemTop = nScrollPos;
+
+  // Need to update all rows in display
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
+  return bOk;
+}
+
+
+// Assign the selection callback function for a Listbox
+void gslc_ElemXListboxSetSelFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_XLISTBOX_SEL funcCb)
+{
+  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
+  if (!pListbox) return;
+
+  pListbox->pfuncXSel = funcCb;
+}
+
+// ============================================================================

--- a/src/elem/XListbox.c
+++ b/src/elem/XListbox.c
@@ -251,7 +251,8 @@ bool gslc_ElemXListboxAddItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, const 
     return false;
   }
 
-  pBuf = pListbox->pBufItems + nBufItemsPos;
+  // Treat this section of the buffer as [char]
+  pBuf = (char*)pListbox->pBufItems + nBufItemsPos;
   strncpy(pBuf, pStrItem, nStrItemLen);
   pListbox->nBufItemsPos += nStrItemLen;
 
@@ -583,7 +584,6 @@ bool gslc_ElemXListboxTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, i
   switch (eTouch) {
 
   case GSLC_TOUCH_DOWN_IN:
-    GSLC_DEBUG_PRINT("DBG: %d,%d DownIn\n", nRelX,nRelY); //xxx
     // Start glowing as must be over it
     gslc_ElemSetGlow(pGui, pElemRef, true);
     // User pressed inside elem: start selection
@@ -591,20 +591,17 @@ bool gslc_ElemXListboxTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, i
     break;
 
   case GSLC_TOUCH_MOVE_IN:
-    GSLC_DEBUG_PRINT("DBG: %d,%d MoveIn\n", nRelX,nRelY); //xxx
     gslc_ElemSetGlow(pGui, pElemRef, true);
     // Track changes in selection
     bSelTrack = true;
     break;
   case GSLC_TOUCH_MOVE_OUT:
-    GSLC_DEBUG_PRINT("DBG: %d,%d MoveOut\n", nRelX,nRelY); //xxx
     gslc_ElemSetGlow(pGui, pElemRef, false);
     // User has dragged to outside elem: deselect
     bSelTrack = true;
     break;
 
   case GSLC_TOUCH_UP_IN:
-    GSLC_DEBUG_PRINT("DBG: %d,%d UpIn\n", nRelX,nRelY); //xxx
     // End glow
     gslc_ElemSetGlow(pGui, pElemRef, false);
     // User released inside elem.
@@ -614,7 +611,6 @@ bool gslc_ElemXListboxTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, i
     bSelSave = true;
     break;
   case GSLC_TOUCH_UP_OUT:
-    GSLC_DEBUG_PRINT("DBG: %d,%d UpOut\n", nRelX,nRelY); //xxx
     // End glow
     gslc_ElemSetGlow(pGui, pElemRef, false);
     // User released outside elem: leave selection as-is

--- a/src/elem/XListbox.h
+++ b/src/elem/XListbox.h
@@ -1,0 +1,315 @@
+#ifndef _GUISLICE_EX_XLISTBOX_H_
+#define _GUISLICE_EX_XLISTBOX_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: Listbox control
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XListbox.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+// ============================================================================
+// Extended Element: Listbox
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_LISTBOX GSLC_TYPE_BASE_EXTEND + 10
+
+// Define constants specific to the control
+#define XLISTBOX_SEL_NONE       -1  // Indicator for "no selection"
+#define XLISTBOX_SIZE_AUTO      -1  // Indicator for "auto-size"
+
+/// Callback function for Listbox feedback
+typedef bool (*GSLC_CB_XLISTBOX_SEL)(void* pvGui,void* pvElem,int16_t nSel);
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+/// Extended data for Listbox element
+typedef struct {
+
+  // Config
+  uint8_t*        pBufItems;      ///< Buffer containing items
+  uint16_t        nBufItemsMax;   ///< Max size of buffer containing items
+  uint16_t        nBufItemsPos;   ///< Current buffer position
+  int16_t         nItemCnt;       ///< Number of items in the list
+
+  // Style config
+  int8_t          nCols;          ///< Number of columns
+  int8_t          nRows;          ///< Number of columns (or XLSITBOX_SIZE_AUTO to calculate)
+  bool            bNeedRecalc;    ///< Determine if sizing may need recalc
+  int8_t          nMarginW;       ///< Margin inside main listbox area (X offset)
+  int8_t          nMarginH;       ///< Margin inside main listbox area (Y offset)
+  int16_t         nItemW;         ///< Width of listbox item
+  int16_t         nItemH;         ///< Height of listbox item
+  int8_t          nItemGap;       ///< Gap between listbox items
+  gslc_tsColor    colGap;         ///< Gap color
+  int8_t          nItemMarginW;   ///< Text margin inside listbox items (X offset)
+  int8_t          nItemMarginH;   ///< Text margin inside listbox items (Y offset)
+  bool            bItemAutoSizeW; ///< Enable auto-sizing of items (in width)
+  bool            bItemAutoSizeH; ///< Enable auto-sizing of items (in height)
+
+  // State
+  int16_t         nItemSel;       ///< Currently selected item (XLISTBOX_SEL_NONE for none)
+  int16_t         nRedrawSelOld;  ///< Old selected item to redraw (XLISTBOX_SEL_NONE for none)
+  int8_t          nItemTop;       ///< Item to show at top of list after scrolling (0 is default)
+
+  // Callbacks
+  GSLC_CB_XLISTBOX_SEL pfuncXSel; ///< Callback func ptr for selection update
+
+} gslc_tsXListbox;
+
+
+///
+/// Create a Listbox Element
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  nElemId:       Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:         Page ID to attach element to
+/// \param[in]  pXData:        Ptr to extended element data structure
+/// \param[in]  rElem:         Rectangle coordinates defining checkbox size
+/// \param[in]  nFontId:       Font ID for item display
+/// \param[in]  pBufItems:     Pointer to buffer that will contain list of items
+/// \param[in]  nBufItemsMax:  Max size of buffer for list of items (pBufItems)
+/// \param[in]  nSelDefault:   Default item to select
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXListboxCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXListbox* pXData, gslc_tsRect rElem, int16_t nFontId, uint8_t* pBufItems,
+  uint16_t nBufItemsMax, int16_t nSelDefault);
+
+
+///
+/// Configure the number of rows & columns to display in the listbox
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  nRows:         Number of rows (>= 1, or XLISTBOX_SIZE_AUTO to base on content)
+/// \param[in]  nCols:         Number of columns (>= 1)
+///
+/// \return none
+///
+void gslc_ElemXListboxSetSize(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nRows, int8_t nCols);
+
+
+///
+/// Configure the margin inside the listbox
+/// - Defines the region bewteen the element rect and the inner listbox items
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  nMaginW:       Set the margin (horizontal) inside the listbox (0 for none)
+/// \param[in]  nMaginH:       Set the margin (horizontal) inside the listbox (0 for none)
+///
+/// \return none
+///
+void gslc_ElemXListboxSetMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH);
+
+///
+/// Configure the text margin inside the listbox items
+/// - Defines the region bewteen the listbox item and the text labels
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  nMaginW:       Set the margin (horizontal) inside the item (0 for none)
+/// \param[in]  nMaginH:       Set the margin (horizontal) inside the item (0 for none)
+///
+/// \return none
+///
+void gslc_ElemXListboxItemsSetTxtMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH);
+
+///
+/// Configure the size of the listbox items
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  nItemW:        Set the width of a listbox item (or -1 to auto-size)
+/// \param[in]  nItemH:        Set the height of a listbox item
+///
+/// \return none
+///
+void gslc_ElemXListboxItemsSetSize(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemW, int16_t nItemH);
+
+///
+/// Configure the gap between listbox items
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  nGap:          Set the gap between listbox items (0 for none)
+/// \param[in]  colGap:        Set the color of the gap between listbox items
+///
+/// \return none
+///
+void gslc_ElemXListboxItemsSetGap(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nGap, gslc_tsColor colGap);
+
+
+///
+/// Empty the listbox of all items
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+///
+/// \return none
+///
+void gslc_ElemXListboxReset(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef);
+
+
+///
+/// Add an item to the listbox
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  pStrItem:      String to use when creating the listbox item
+///
+/// \return true if OK, false if fail (eg. insufficient buffer storage)
+///
+bool gslc_ElemXListboxAddItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, const char* pStrItem);
+
+///
+/// Get the indexed listbox item
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+/// \param[in]  nItemSel:      Item index to fetch
+/// \param[out] pStrItem:      Ptr to the string buffer to receive the item
+/// \param[in]  nStrItemLen:   Maximum buffer length of pStrItem
+///
+/// \return true if success, false if fail (eg. can't locate item)
+///
+bool gslc_ElemXListboxGetItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemSel, char* pStrItem, uint8_t nStrItemLen);
+
+
+///
+/// Get the number of items in the listbox
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pElemRef:      Ptr to Element Reference to update
+///
+/// \return Number of items
+///
+int16_t gslc_ElemXListboxGetItemCnt(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef);
+
+///
+/// Draw a Listbox element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXListboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+///
+/// Handle touch events to Listbox element
+/// - Called from gslc_ElemSendEventTouch()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element ref (typecast to gslc_tsElemRef*)
+/// \param[in]  eTouch:      Touch event type
+/// \param[in]  nRelX:       Touch X coord relative to element
+/// \param[in]  nRelY:       Touch Y coord relative to element
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXListboxTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16_t nRelX,int16_t nRelY);
+
+
+///
+/// Get a Listbox element's current selection
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+///
+/// \return Current Listbox selection (or -1 if none)
+///
+int16_t gslc_ElemXListboxGetSel(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
+
+
+///
+/// Set a Listbox element's current selection
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nItemSel:    Listbox item to select (or -1 for none)
+///
+/// \return true if success, false if fail
+///
+bool gslc_ElemXListboxSetSel(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemSel);
+
+///
+/// Set the Listbox scroll position
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nScrollPos:  Scroll the listbox so that the nScrollPos item is at the top (0 default)
+///
+/// \return true if success, false if fail
+///
+bool gslc_ElemXListboxSetScrollPos(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nScrollPos);
+
+
+///
+/// Assign the selection callback function for a Listbox
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  funcCb:      Function pointer to selection routine (or NULL for none)
+///
+/// \return none
+///
+void gslc_ElemXListboxSetSelFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_XLISTBOX_SEL funcCb);
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XLISTBOX_H_
+

--- a/src/elem/XListbox.h
+++ b/src/elem/XListbox.h
@@ -43,6 +43,8 @@ extern "C" {
 
 // ============================================================================
 // Extended Element: Listbox
+// - NOTE: The XListbox element is in beta development.
+//         Therefore, its API is subject to change.
 // ============================================================================
 
 // Define unique identifier for extended element type
@@ -52,6 +54,7 @@ extern "C" {
 // Define constants specific to the control
 #define XLISTBOX_SEL_NONE       -1  // Indicator for "no selection"
 #define XLISTBOX_SIZE_AUTO      -1  // Indicator for "auto-size"
+#define XLISTBOX_BUF_OH_R        2  // Listbox buffer overhead per row
 
 /// Callback function for Listbox feedback
 typedef bool (*GSLC_CB_XLISTBOX_SEL)(void* pvGui,void* pvElem,int16_t nSel);
@@ -85,9 +88,10 @@ typedef struct {
   bool            bItemAutoSizeH; ///< Enable auto-sizing of items (in height)
 
   // State
-  int16_t         nItemSel;       ///< Currently selected item (XLISTBOX_SEL_NONE for none)
-  int16_t         nRedrawSelOld;  ///< Old selected item to redraw (XLISTBOX_SEL_NONE for none)
-  int8_t          nItemTop;       ///< Item to show at top of list after scrolling (0 is default)
+  int16_t         nItemCurSel;      ///< Currently selected item (XLISTBOX_SEL_NONE for none)
+  int16_t         nItemCurSelLast;  ///< Old selected item to redraw (XLISTBOX_SEL_NONE for none)
+  int16_t         nItemSavedSel;    ///< Persistent selected item (ie. saved selection)
+  int16_t         nItemTop;         ///< Item to show at top of list after scrolling (0 is default)
 
   // Callbacks
   GSLC_CB_XLISTBOX_SEL pfuncXSel; ///< Callback func ptr for selection update
@@ -206,13 +210,13 @@ bool gslc_ElemXListboxAddItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, const 
 ///
 /// \param[in]  pGui:          Pointer to GUI
 /// \param[in]  pElemRef:      Ptr to Element Reference to update
-/// \param[in]  nItemSel:      Item index to fetch
+/// \param[in]  nItemCurSel:      Item index to fetch
 /// \param[out] pStrItem:      Ptr to the string buffer to receive the item
 /// \param[in]  nStrItemLen:   Maximum buffer length of pStrItem
 ///
 /// \return true if success, false if fail (eg. can't locate item)
 ///
-bool gslc_ElemXListboxGetItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemSel, char* pStrItem, uint8_t nStrItemLen);
+bool gslc_ElemXListboxGetItem(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemCurSel, char* pStrItem, uint8_t nStrItemLen);
 
 
 ///
@@ -268,11 +272,11 @@ int16_t gslc_ElemXListboxGetSel(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElemRef:    Pointer to Element reference
-/// \param[in]  nItemSel:    Listbox item to select (or -1 for none)
+/// \param[in]  nItemCurSel:    Listbox item to select (or -1 for none)
 ///
 /// \return true if success, false if fail
 ///
-bool gslc_ElemXListboxSetSel(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemSel);
+bool gslc_ElemXListboxSetSel(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemCurSel);
 
 ///
 /// Set the Listbox scroll position

--- a/src/elem/XSelNum.c
+++ b/src/elem/XSelNum.c
@@ -58,17 +58,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //
 // - This file extends the core GUIslice functionality with
 //   additional widget types
-// - After adding any widgets to GUIslice_ex, a unique
-//   enumeration (GSLC_TYPEX_*) should be added to "GUIslice.h"
 //
-//   TODO: Consider whether we should remove the need to update
-//         these enumerations in "GUIslice.h"; we could instead
-//         define a single "GSLC_TYPEX" in GUIslice.h but then
-//         allow "GUIslice_ex.h" to create a new set of unique
-//         enumerations. This way extended elements could be created
-//         in GUIslice_ex and no changes at all would be required
-//         in GUIslice.
-
 // ----------------------------------------------------------------------------
 
 

--- a/src/elem/XSlider.c
+++ b/src/elem/XSlider.c
@@ -58,17 +58,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //
 // - This file extends the core GUIslice functionality with
 //   additional widget types
-// - After adding any widgets to GUIslice_ex, a unique
-//   enumeration (GSLC_TYPEX_*) should be added to "GUIslice.h"
 //
-//   TODO: Consider whether we should remove the need to update
-//         these enumerations in "GUIslice.h"; we could instead
-//         define a single "GSLC_TYPEX" in GUIslice.h but then
-//         allow "GUIslice_ex.h" to create a new set of unique
-//         enumerations. This way extended elements could be created
-//         in GUIslice_ex and no changes at all would be required
-//         in GUIslice.
-
 // ----------------------------------------------------------------------------
 
 

--- a/src/elem/XTextbox.c
+++ b/src/elem/XTextbox.c
@@ -58,17 +58,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //
 // - This file extends the core GUIslice functionality with
 //   additional widget types
-// - After adding any widgets to GUIslice_ex, a unique
-//   enumeration (GSLC_TYPEX_*) should be added to "GUIslice.h"
 //
-//   TODO: Consider whether we should remove the need to update
-//         these enumerations in "GUIslice.h"; we could instead
-//         define a single "GSLC_TYPEX" in GUIslice.h but then
-//         allow "GUIslice_ex.h" to create a new set of unique
-//         enumerations. This way extended elements could be created
-//         in GUIslice_ex and no changes at all would be required
-//         in GUIslice.
-
 // ----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
This PR adds support for the **XListbox** element per #46 

Summary of features:
- Single-column and multi-column lists
- Dynamic list population at runtime (reset or add)
- Integration with vertical scrollbars
- Single listbox item selection with toggle
- Selection callback function
- Auto-sizing of listbox items based on row and column counts
- Optimized list item memory storage (only single byte overhead per item)

Example sketches to follow.