### PR TITLE
Add XSpinner element

### DIFF
--- a/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
+++ b/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
@@ -1,0 +1,256 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 32 (Arduino):
+//   - Multiple page handling
+//   - Background image
+//   - XSpinner compound elements
+//
+//   - NOTE: The XSpinner compound element requires GSLC_FEATURE_COMPOUND enabled
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. Therefore, it may not
+//     run on Arduino devices with limited memory. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+// - To support a larger number of GUI elements, it is recommended to
+//   use a CPU that provides more than 2KB of SRAM (eg. ATmega2560).
+//
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Ensure optional compound element feature is enabled in the configuration
+#if !(GSLC_FEATURE_COMPOUND)
+  #error "Config: GSLC_FEATURE_COMPOUND required for this example but not enabled. Please update GUIslice_config."
+#endif
+
+// Include any extended elements
+#include "elem/XGauge.h"
+#include "elem/XSpinner.h"
+
+// Defines for resources
+#define IMG_BKGND       "back1_24.bmp"
+
+// Enumerations for pages, elements, fonts, images
+enum {E_PG_MAIN,E_PG_EXTRA};
+enum {E_ELEM_BTN_QUIT,E_ELEM_BTN_EXTRA,E_ELEM_BTN_BACK,
+      E_ELEM_TXT_COUNT,E_ELEM_PROGRESS,
+      E_ELEM_COMP1,E_ELEM_COMP2,E_ELEM_COMP3};
+enum {E_FONT_BTN,E_FONT_TXT,E_FONT_TITLE};
+
+bool      m_bQuit = false;
+
+// Free-running counter for display
+unsigned  m_nCount = 0;
+
+// Instantiate the GUI
+#define MAX_PAGE                2
+#define MAX_FONT                3
+
+// Define the maximum number of elements per page
+#define MAX_ELEM_PG_MAIN        9                 // # Elems total on Main page
+#define MAX_ELEM_PG_EXTRA       7                 // # Elems total on Extra page
+#define MAX_ELEM_PG_MAIN_RAM    MAX_ELEM_PG_MAIN  // # Elems in RAM
+#define MAX_ELEM_PG_EXTRA_RAM   MAX_ELEM_PG_EXTRA // # Elems in RAM
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asMainElem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asExtraElem[MAX_ELEM_PG_EXTRA_RAM];
+gslc_tsElemRef              m_asExtraElemRef[MAX_ELEM_PG_EXTRA];
+
+gslc_tsXGauge               m_sXGauge;
+gslc_tsXSpinner              m_sXSpinner[3];
+
+
+#define MAX_STR             8
+
+  // Save some element pointers for quick access
+  gslc_tsElemRef*  m_pElemCnt = NULL;
+  gslc_tsElemRef*  m_pElemProgress = NULL;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+// Button callbacks
+// - Show example of common callback function
+bool CbBtnCommon(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+  int16_t nElemId = pElem->nId;
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    if (nElemId == E_ELEM_BTN_QUIT) {
+      m_bQuit = true;
+    } else if (nElemId == E_ELEM_BTN_EXTRA) {
+      gslc_SetPageCur(&m_gui,E_PG_EXTRA);
+    } else if (nElemId == E_ELEM_BTN_BACK) {
+      gslc_SetPageCur(&m_gui,E_PG_MAIN);
+    }
+  }
+  return true;
+}
+
+
+// Create the default elements on each page
+bool InitOverlays()
+{
+  gslc_tsElemRef*  pElemRef = NULL;
+
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asMainElem,MAX_ELEM_PG_MAIN_RAM,m_asMainElemRef,MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui,E_PG_EXTRA,m_asExtraElem,MAX_ELEM_PG_EXTRA_RAM,m_asExtraElemRef,MAX_ELEM_PG_EXTRA);
+
+  // -----------------------------------
+  // Background
+  // - Background image from SD card disabled, uncomment to enable
+  // - Ensure that GSLC_SD_EN is set to 1 in GUIslice_config.h
+  //static const char m_strImgBkgnd[] = IMG_BKGND;
+  //gslc_SetBkgndImage(&m_gui,gslc_GetImageFromSD(m_strImgBkgnd,GSLC_IMGREF_FMT_BMP24));
+
+  // -----------------------------------
+  // PAGE: MAIN
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,50,280,150});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create title
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){10,10,310,40},
+    (char*)"GUIslice Demo",0,E_FONT_TITLE);
+  gslc_ElemSetTxtAlign(&m_gui,pElemRef,GSLC_ALIGN_MID_MID);
+  gslc_ElemSetFillEn(&m_gui,pElemRef,false);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_WHITE);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_QUIT,E_PG_MAIN,
+    (gslc_tsRect){100,140,50,20},(char*)"Quit",0,E_FONT_BTN,&CbBtnCommon);
+
+
+  // Create Extra button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_EXTRA,E_PG_MAIN,
+    (gslc_tsRect){170,140,50,20},(char*)"Extra",0,E_FONT_BTN,&CbBtnCommon);
+
+  // Create counter
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){40,60,50,10},
+    (char*)"Count:",0,E_FONT_TXT);
+  static char mstr1[8] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_ELEM_TXT_COUNT,E_PG_MAIN,(gslc_tsRect){100,60,50,10},
+    mstr1,sizeof(mstr1),E_FONT_TXT);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_YELLOW);
+  m_pElemCnt = pElemRef; // Save for quick access
+
+
+  // Create progress bar
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){40,80,50,10},
+    (char*)"Progress:",0,E_FONT_TXT);
+  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
+    0,100,0,GSLC_COL_GREEN,false);
+  m_pElemProgress = pElemRef; // Save for quick access
+
+
+  // Add compound element
+  pElemRef = gslc_ElemXSpinnerCreate(&m_gui,E_ELEM_COMP1,E_PG_MAIN,&m_sXSpinner[0],
+    (gslc_tsRect){160,60,120,50},E_FONT_BTN);
+
+  // -----------------------------------
+  // PAGE: EXTRA
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui,GSLC_ID_AUTO,E_PG_EXTRA,(gslc_tsRect){40,40,240,160});
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
+
+  // Create Back button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,E_ELEM_BTN_BACK,E_PG_EXTRA,
+    (gslc_tsRect){50,170,50,20},(char*)"Back",0,E_FONT_BTN,&CbBtnCommon);
+
+
+  // Create a few labels
+  int16_t    nPosY = 50;
+  int16_t    nSpaceY = 20;
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_EXTRA,(gslc_tsRect){60,nPosY,50,10},
+    (char*)"Data 1",0,E_FONT_TXT); nPosY += nSpaceY;
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_EXTRA,(gslc_tsRect){60,nPosY,50,10},
+    (char*)"Data 2",0,E_FONT_TXT); nPosY += nSpaceY;
+  pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_EXTRA,(gslc_tsRect){60,nPosY,50,10},
+    (char*)"Data 3",0,E_FONT_TXT); nPosY += nSpaceY;
+
+  // Add compound element
+  pElemRef = gslc_ElemXSpinnerCreate(&m_gui,E_ELEM_COMP2,E_PG_EXTRA,&m_sXSpinner[1],
+    (gslc_tsRect){130,60,120,50},E_FONT_BTN);
+
+  pElemRef = gslc_ElemXSpinnerCreate(&m_gui,E_ELEM_COMP3,E_PG_EXTRA,&m_sXSpinner[2],
+    (gslc_tsRect){130,120,120,50},E_FONT_BTN);
+
+
+  return true;
+}
+
+
+void setup()
+{
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  // Initialize
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,NULL,1)) { return; }
+  if (!gslc_FontAdd(&m_gui,E_FONT_TXT,GSLC_FONTREF_PTR,NULL,1)) { return; }
+  if (!gslc_FontAdd(&m_gui,E_FONT_TITLE,GSLC_FONTREF_PTR,NULL,1)) { return; }
+
+  // Create page elements
+  InitOverlays();
+
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+}
+
+void loop()
+{
+  char              acTxt[MAX_STR];
+
+  // Save some element references for easy access
+  gslc_tsElemRef*  pElemCnt        = gslc_PageFindElemById(&m_gui,E_PG_MAIN,E_ELEM_TXT_COUNT);
+  gslc_tsElemRef*  pElemProgress   = gslc_PageFindElemById(&m_gui,E_PG_MAIN,E_ELEM_PROGRESS);
+
+  m_nCount++;
+
+  // Perform drawing updates
+  // - Note: we can make the updates conditional on the active
+  //   page by checking gslc_GetPageCur() first.
+
+  snprintf(acTxt,MAX_STR,"%u",m_nCount);
+  gslc_ElemSetTxtStr(&m_gui,pElemCnt,acTxt);
+
+  gslc_ElemXGaugeUpdate(&m_gui,pElemProgress,((m_nCount/2)%100));
+
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // Slow down updates
+  delay(100);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) { }
+  }
+}
+
+

--- a/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
+++ b/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
@@ -1,6 +1,6 @@
 //
-// GUIslice Library Examples
-// - Calvin Hass
+// GUIslice Library Example
+// - Paul Conti, Calvin Hass
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 // - Example 32 (Arduino):
@@ -9,6 +9,7 @@
 //   - XSpinner compound elements
 //
 //   - NOTE: The XSpinner compound element requires GSLC_FEATURE_COMPOUND enabled
+//
 //   - NOTE: This is the simple version of the example without
 //     optimizing for memory consumption. Therefore, it may not
 //     run on Arduino devices with limited memory. A "minimal"

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2060,7 +2060,8 @@ int16_t gslc_PageFocusStep(gslc_tsGui* pGui, gslc_tsPage* pPage, bool bNext)
 
 int gslc_ElemGetId(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
 {
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return GSLC_ID_NONE;
   return pElem->nId;
 }
 
@@ -2124,6 +2125,21 @@ gslc_tsElem* gslc_GetElemFromRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
   } else {
     // SRC_ELEMREF_SRC_RAM
     // No copy required
+  }
+  return pElem;
+}
+
+// Fetch element from reference, with debug
+gslc_tsElem* gslc_GetElemFromRefD(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nLineNum)
+{
+  if (pElemRef == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: GetElemFromRefD(Line %d) pElemRef is NULL\n", nLineNum);
+    return NULL;
+  }
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui, pElemRef);
+  if (pElem == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: GetElemFromRefD(Line %d) pElem is NULL\n", nLineNum);
+    return NULL;
   }
   return pElem;
 }
@@ -2477,13 +2493,8 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
     return true;
   }
 
-  if ((pGui == NULL) || (pElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemDrawByRef";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return false;
-  }
-
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return false;
 
   // --------------------------------------------------------------------------
   // Handle visibility
@@ -2693,12 +2704,9 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
 
 void gslc_ElemSetFillEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFillEn)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetFillEn";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   if (bFillEn) {
     pElem->nFeatures |= GSLC_ELEM_FEA_FILL_EN;
   } else {
@@ -2710,12 +2718,9 @@ void gslc_ElemSetFillEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFillEn)
 
 void gslc_ElemSetFrameEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFrameEn)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetFrameEn";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   if (bFrameEn) {
     pElem->nFeatures |= GSLC_ELEM_FEA_FRAME_EN;
   } else {
@@ -2727,12 +2732,9 @@ void gslc_ElemSetFrameEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFrameEn
 
 void gslc_ElemSetCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colFrame,gslc_tsColor colFill,gslc_tsColor colFillGlow)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetCol";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->colElemFrame     = colFrame;
   pElem->colElemFill      = colFill;
   pElem->colElemFillGlow  = colFillGlow;
@@ -2741,12 +2743,9 @@ void gslc_ElemSetCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colF
 
 void gslc_ElemSetGlowCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colFrameGlow,gslc_tsColor colFillGlow,gslc_tsColor colTxtGlow)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetGlowCol";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->colElemFrameGlow   = colFrameGlow;
   pElem->colElemFillGlow    = colFillGlow;
   pElem->colElemTextGlow    = colTxtGlow;
@@ -2755,59 +2754,43 @@ void gslc_ElemSetGlowCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor 
 
 void gslc_ElemSetGroup(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int nGroupId)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetGroup";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->nGroup           = nGroupId;
 }
 
 int gslc_ElemGetGroup(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemGetGroup";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return GSLC_GROUP_ID_NONE;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return GSLC_GROUP_ID_NONE;
+
   return pElem->nGroup;
 }
 
 
 void gslc_ElemSetTxtAlign(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,unsigned nAlign)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTxtAlign";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->eTxtAlign        = nAlign;
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetTxtMargin(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,unsigned nMargin)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTxtMargin";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->nTxtMargin        = nMargin;
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetTxtStr(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,const char* pStr)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTxtStr";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
 
   // Check for read-only status (in case the string was
   // defined in Flash/PROGMEM)
@@ -2829,12 +2812,9 @@ void gslc_ElemSetTxtStr(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,const char* pS
 
 void gslc_ElemSetTxtCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colVal)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTxtCol";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   if (!gslc_ColorEqual(pElem->colElemText, colVal) ||
       !gslc_ColorEqual(pElem->colElemTextGlow, colVal)) {
     pElem->colElemText      = colVal;
@@ -2846,12 +2826,9 @@ void gslc_ElemSetTxtCol(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor c
 
 void gslc_ElemSetTxtMem(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teTxtFlags eFlags)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTxtMem";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   if (GSLC_LOCAL_STR) {
     if ((eFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_PROG) {
       // ERROR: Unsupported mode
@@ -2867,12 +2844,8 @@ void gslc_ElemSetTxtMem(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teTxtFlag
 
 void gslc_ElemSetTxtEnc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teTxtFlags eFlags)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTxtEnc";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
 
   gslc_teTxtFlags eFlagsCur = pElem->eTxtFlags;
   pElem->eTxtFlags = (eFlagsCur & ~GSLC_TXT_ENC) | (eFlags & GSLC_TXT_ENC);
@@ -2880,12 +2853,9 @@ void gslc_ElemSetTxtEnc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teTxtFlag
 
 void gslc_ElemUpdateFont(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int nFontId)
 {
-  if ((pGui == NULL) || (pElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemUpdateFont";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->pTxtFont = gslc_FontGet(pGui,nFontId);
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
@@ -2993,11 +2963,9 @@ bool gslc_ElemGetGlow(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
 
 void gslc_ElemSetVisible(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bVisible)
 {
-  if ((pElemRef == NULL) || (pElemRef->pElem == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetVisible";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   bool bVisibleOld = gslc_ElemGetVisible(pGui,pElemRef);
   gslc_SetElemRefFlag(pGui,pElemRef,GSLC_ELEMREF_VISIBLE,(bVisible)?GSLC_ELEMREF_VISIBLE:0);
 
@@ -3025,7 +2993,6 @@ void gslc_ElemSetVisible(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bVisible
     //       redraw during the element-hide operation and
     //       avoid the overdrawing behavior.
 
-    gslc_tsElem* pElem = gslc_GetElemFromRef(pGui, pElemRef);
     gslc_tsRect rRect = pElem->rElem;
     gslc_SetClipRect(pGui, &rRect);
     gslc_PageRedrawSet(pGui, true);
@@ -3047,12 +3014,9 @@ bool gslc_ElemGetVisible(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
 
 void gslc_ElemSetGlowEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bGlowEn)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetGlowEn";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   if (bGlowEn) {
     pElem->nFeatures |= GSLC_ELEM_FEA_GLOW_EN;
   } else {
@@ -3063,23 +3027,17 @@ void gslc_ElemSetGlowEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bGlowEn)
 
 bool gslc_ElemGetGlowEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemGetGlowEn";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return false;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return false;
+
   return pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN;
 }
 
 void gslc_ElemSetClickEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bClickEn)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetClickEn";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   if (bClickEn) {
     pElem->nFeatures |= GSLC_ELEM_FEA_CLICK_EN;
   } else {
@@ -3090,13 +3048,9 @@ void gslc_ElemSetClickEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bClickEn
 
 void gslc_ElemSetStyleFrom(gslc_tsGui* pGui,gslc_tsElemRef* pElemRefSrc,gslc_tsElemRef* pElemRefDest)
 {
-  if ((pElemRefSrc == NULL) || (pElemRefDest == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetStyleFrom";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElemSrc  = gslc_GetElemFromRef(pGui,pElemRefSrc);
-  gslc_tsElem*  pElemDest = gslc_GetElemFromRef(pGui,pElemRefDest);
+  gslc_tsElem* pElemSrc = gslc_GetElemFromRefD(pGui, pElemRefSrc, __LINE__);
+  gslc_tsElem* pElemDest = gslc_GetElemFromRefD(pGui, pElemRefDest, __LINE__);
+  if ((!pElemSrc) || (!pElemDest)) return;
 
   // TODO: Check ElemRef SRC type for compatibility
 
@@ -3143,12 +3097,9 @@ void gslc_ElemSetStyleFrom(gslc_tsGui* pGui,gslc_tsElemRef* pElemRefSrc,gslc_tsE
 /* UNUSED
 void gslc_ElemSetEventFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_EVENT funcCb)
 {
-  if ((pElemRef == NULL) || (funcCb == NULL)) {;
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetEventFunc";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->pfuncXEvent       = funcCb;
 }
 */
@@ -3156,35 +3107,26 @@ void gslc_ElemSetEventFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_EVE
 
 void gslc_ElemSetDrawFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_DRAW funcCb)
 {
-  if ((pElemRef == NULL) || (funcCb == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetDrawFunc";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem* pElem    = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->pfuncXDraw     = funcCb;
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
 
 void gslc_ElemSetTickFunc(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,GSLC_CB_TICK funcCb)
 {
-  if ((pElemRef == NULL) || (funcCb == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetTickFunc";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-  gslc_tsElem* pElem      = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
   pElem->pfuncXTick       = funcCb;
 }
 
 bool gslc_ElemOwnsCoord(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nX,int16_t nY,bool bOnlyClickEn)
 {
-  if (pElemRef == NULL) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemOwnsCoord";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return false;
-  }
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return false;
+
   if (bOnlyClickEn && !(pElem->nFeatures & GSLC_ELEM_FEA_CLICK_EN) ) {
     return false;
   }
@@ -3441,19 +3383,11 @@ bool gslc_CollectTouchCompound(void* pvGui, void* pvElemRef, gslc_teTouch eTouch
   return false;
   #else
 
-  if ((pvGui == NULL) || (pvElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "CollectTouchCompound";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
-    return false;
-  }
-  gslc_tsGui*           pGui = NULL;
-  gslc_tsElemRef*       pElemRef = NULL;
-  gslc_tsElem*          pElem = NULL;
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return false;
 
-  // Typecast the parameters to match the GUI
-  pGui = (gslc_tsGui*)(pvGui);
-  pElemRef = (gslc_tsElemRef*)(pvElemRef);
-  pElem = gslc_GetElemFromRef(pGui, pElemRef);
 
   // Handle any compound element operations
   switch (eTouch) {
@@ -4170,13 +4104,8 @@ bool gslc_SetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
 void gslc_ElemSetImage(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsImgRef sImgRef,
   gslc_tsImgRef sImgRefSel)
 {
-  if ((pGui == NULL) || (pElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemSetImage";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return;
-  }
-
-  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
 
   // Update the normal and glowing images
   gslc_DrvSetElemImageNorm(pGui,pElem,sImgRef);

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -486,6 +486,9 @@ typedef bool (*GSLC_CB_TICK)(void* pvGui,void* pvElemRef);
 /// Callback function for pin polling
 typedef bool (*GSLC_CB_PIN_POLL)(void* pvGui,int16_t* pnPinInd,int16_t* pnPinVal);
 
+/// Callback function for element input ready
+typedef bool (*GSLC_CB_INPUT)(void* pvGui,void* pvElemRef);
+
 // -----------------------------------------------------------------------
 // Structures
 // -----------------------------------------------------------------------

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -3158,6 +3158,19 @@ bool gslc_CollectEvent(void* pvGui,gslc_tsEvent sEvent);
 ///
 void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTouch* pEventTouch);
 
+/// Handle dispatch of touch (up,down,move) events to compound elements sub elements
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+/// \param[in]  eTouch:      Touch event type
+/// \param[in]  nRelX:       Touch X coord relative to element
+/// \param[in]  nRelY:       Touch Y coord relative to element
+/// \param[in]  pCollect:    Collection containing sub elements
+///
+/// \return true if success, false otherwise
+///
+bool gslc_CollectTouchCompound(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, int16_t nRelX, int16_t nRelY, gslc_tsCollect* pCollect);
+
 
 /// Handle direct input events within the element collection
 ///
@@ -3168,6 +3181,7 @@ void gslc_CollectTouch(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTou
 /// \return none
 ///
 void gslc_CollectInput(gslc_tsGui* pGui,gslc_tsCollect* pCollect,gslc_tsEventTouch* pEventTouch);
+
 
 
 // ------------------------------------------------------------------------

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -2749,7 +2749,21 @@ void gslc_SetElemRefFlag(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,uint8_t nFlag
 ///
 /// \return Pointer to Element after ensuring that it is accessible from RAM
 ///
-gslc_tsElem* gslc_GetElemFromRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
+// TODO: Mark this as public API
+gslc_tsElem* gslc_GetElemFromRef(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef);
+
+
+/// Returns a pointer to an element from an element reference.
+/// This is a wrapper for GetElemFromRef() including debug checking
+/// for invalid pointers.
+///
+/// \param[in]  pGui:         Pointer to GUI
+/// \param[in]  pElemRef:     Pointer to Element Reference
+/// \param[in]  nLineNum:     Line number from calling function (ie. __LINE__)
+///
+/// \return Pointer to Element after ensuring that it is accessible from RAM
+///
+gslc_tsElem* gslc_GetElemFromRefD(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nLineNum);
 
 /// Returns a pointer to the data structure associated with an extended element.
 /// - Example usage:

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.34"
+#define GUISLICE_VER "0.11.2.36"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.25"
+#define GUISLICE_VER "0.11.2.26"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.20"
+#define GUISLICE_VER "0.11.2.25"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XSelNum.c
+++ b/src/elem/XSelNum.c
@@ -143,13 +143,17 @@ gslc_tsElemRef* gslc_ElemXSelNumCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t 
   int16_t nOffsetX = rElem.x;
   int16_t nOffsetY = rElem.y;
 
+  gslc_tsRect rSubElem;
+
+  rSubElem = (gslc_tsRect) { nOffsetX+40,nOffsetY+10,30,30 };
+  rSubElem = gslc_ExpandRect(rSubElem, -1, -1);
   #if (GSLC_LOCAL_STR)
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SELNUM_ID_BTN_INC,GSLC_PAGE_NONE,
-    (gslc_tsRect){nOffsetX+40,nOffsetY+10,30,30},"+",0,nFontId,&gslc_ElemXSelNumClick);
+    rSubElem,"+",0,nFontId,&gslc_ElemXSelNumClick);
   #else
   strncpy(pXData->acElemTxt[0],"+",SELNUM_STR_LEN-1);
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SELNUM_ID_BTN_INC,GSLC_PAGE_NONE,
-    (gslc_tsRect){nOffsetX+40,nOffsetY+10,30,30},pXData->acElemTxt[0],SELNUM_STR_LEN,
+    rSubElem,pXData->acElemTxt[0],SELNUM_STR_LEN,
     nFontId,&gslc_ElemXSelNumClick);
   #endif
   gslc_ElemSetCol(pGui,pElemRefTmp,(gslc_tsColor){0,0,192},(gslc_tsColor){0,0,128},(gslc_tsColor){0,0,224});
@@ -157,13 +161,15 @@ gslc_tsElemRef* gslc_ElemXSelNumCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t 
   pElemTmp = gslc_GetElemFromRef(pGui,pElemRefTmp);
   gslc_CollectElemAdd(pGui,&pXData->sCollect,pElemTmp,GSLC_ELEMREF_DEFAULT);
 
+  rSubElem = (gslc_tsRect) { nOffsetX+80,nOffsetY+10,30,30 };
+  rSubElem = gslc_ExpandRect(rSubElem, -1, -1);
   #if (GSLC_LOCAL_STR)
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SELNUM_ID_BTN_DEC,GSLC_PAGE_NONE,
-    (gslc_tsRect){nOffsetX+80,nOffsetY+10,30,30},"-",0,nFontId,&gslc_ElemXSelNumClick);
+    rSubElem,"-",0,nFontId,&gslc_ElemXSelNumClick);
   #else
   strncpy(pXData->acElemTxt[1],"-",SELNUM_STR_LEN-1);
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SELNUM_ID_BTN_DEC,GSLC_PAGE_NONE,
-    (gslc_tsRect){nOffsetX+80,nOffsetY+10,30,30},pXData->acElemTxt[1],SELNUM_STR_LEN,
+    rSubElem,pXData->acElemTxt[1],SELNUM_STR_LEN,
     nFontId,&gslc_ElemXSelNumClick);
   #endif
   gslc_ElemSetCol(pGui,pElemRefTmp,(gslc_tsColor){0,0,192},(gslc_tsColor){0,0,128},(gslc_tsColor){0,0,224});
@@ -171,13 +177,15 @@ gslc_tsElemRef* gslc_ElemXSelNumCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t 
   pElemTmp = gslc_GetElemFromRef(pGui,pElemRefTmp);
   gslc_CollectElemAdd(pGui,&pXData->sCollect,pElemTmp,GSLC_ELEMREF_DEFAULT);
 
+  rSubElem = (gslc_tsRect) { nOffsetX+10,nOffsetY+10,20,30 };
+  rSubElem = gslc_ExpandRect(rSubElem, -1, -1);
   #if (GSLC_LOCAL_STR)
   pElemRefTmp = gslc_ElemCreateTxt(pGui,SELNUM_ID_TXT,GSLC_PAGE_NONE,
-    (gslc_tsRect){nOffsetX+10,nOffsetY+10,20,30},"0",0,nFontId);
+    rSubElem,"0",0,nFontId);
   #else
   strncpy(pXData->acElemTxt[2],"0",SELNUM_STR_LEN-1);
   pElemRefTmp = gslc_ElemCreateTxt(pGui,SELNUM_ID_TXT,GSLC_PAGE_NONE,
-    (gslc_tsRect){nOffsetX+10,nOffsetY+10,20,30},pXData->acElemTxt[2],SELNUM_STR_LEN,nFontId);
+    rSubElem,pXData->acElemTxt[2],SELNUM_STR_LEN,nFontId);
   #endif
   pElemTmp = gslc_GetElemFromRef(pGui,pElemRefTmp);
   gslc_CollectElemAdd(pGui,&pXData->sCollect,pElemTmp,GSLC_ELEMREF_DEFAULT);
@@ -213,25 +221,13 @@ gslc_tsElemRef* gslc_ElemXSelNumCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t 
 //   and then redraw the sub-element collection.
 bool gslc_ElemXSelNumDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
 {
-  if ((pvGui == NULL) || (pvElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemXSelNumDraw";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return false;
-  }
-  // Typecast the parameters to match the GUI and element types
-  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
-  gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
-  gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXSelNum* pSelNum = (gslc_tsXSelNum*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_SELNUM, __LINE__);
+  if (!pSelNum) return false;
 
   bool bGlow = (pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN) && gslc_ElemGetGlow(pGui,pElemRef);
-
-  // Fetch the element's extended data structure
-  gslc_tsXSelNum* pSelNum;
-  pSelNum = (gslc_tsXSelNum*)(pElem->pXData);
-  if (pSelNum == NULL) {
-    GSLC_DEBUG_PRINT("ERROR: ElemXSelNumDraw(%s) pXData is NULL\n","");
-    return false;
-  }
 
   // Draw the compound element fill (background)
   // - Should only need to do this in full redraw
@@ -251,7 +247,9 @@ bool gslc_ElemXSelNumDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
   //   of type box.
   // - We don't need to show any glowing of the compound element
 
-  gslc_DrawFrameRect(pGui,pElem->rElem,(bGlow)?pElem->colElemFrameGlow:pElem->colElemFrame);
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    gslc_DrawFrameRect(pGui, pElem->rElem, (bGlow) ? pElem->colElemFrameGlow : pElem->colElemFrame);
+  }
 
   // Clear the redraw flag
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
@@ -311,15 +309,10 @@ bool gslc_ElemXSelNumClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16
   return false;
 #else
 
-  if ((pvGui == NULL) || (pvElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemXSelNumClick";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return false;
-  }
-  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
-  gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
-  gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
-
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return false;
 
   // Fetch the parent of the clicked element which is the compound
   // element itself. This enables us to access the extra control data.
@@ -349,14 +342,14 @@ bool gslc_ElemXSelNumClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16
 
     if (nSubElemId == SELNUM_ID_BTN_INC) {
       // Increment button
-      if (nCounter<100) {
+      if (nCounter < 100) {
         nCounter++;
       }
       gslc_ElemXSelNumSetCounter(pGui,pSelNum,nCounter);
 
     } else if (nSubElemId == SELNUM_ID_BTN_DEC) {
       // Decrement button
-      if (nCounter>0) {
+      if (nCounter > 0) {
         nCounter--;
       }
       gslc_ElemXSelNumSetCounter(pGui,pSelNum,nCounter);
@@ -378,22 +371,6 @@ bool gslc_ElemXSelNumTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16
   gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
   gslc_tsXSelNum* pSelNum = (gslc_tsXSelNum*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_SELNUM, __LINE__);
   if (!pSelNum) return false;
-
-  // Handle any compound element operations
-  switch(eTouch) {
-    case GSLC_TOUCH_DOWN_IN:
-    case GSLC_TOUCH_MOVE_IN:
-      gslc_ElemSetGlow(pGui,pElemRef,true);
-      break;
-    case GSLC_TOUCH_MOVE_OUT:
-    case GSLC_TOUCH_UP_IN:
-    case GSLC_TOUCH_UP_OUT:
-    default:
-      gslc_ElemSetGlow(pGui,pElemRef,false);
-      break;
-  }
-
-  // Handle any sub-element operations
 
   // Get Collection
   gslc_tsCollect* pCollect = &pSelNum->sCollect;

--- a/src/elem/XSpinner.c
+++ b/src/elem/XSpinner.c
@@ -1,0 +1,394 @@
+// =======================================================================
+// GUIslice library (extensions)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XSpinner.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XSpinner.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+#if (GSLC_FEATURE_COMPOUND)
+// ============================================================================
+// Extended Element: Spinner
+// - Spinner element demonstrates a simple up/down counter
+// - This is a compound element containing two buttons and
+//   a text area to represent the current value
+// ============================================================================
+
+// Private sub Element ID definitions
+static const int16_t  SPINNER_ID_BTN_INC = 100;
+static const int16_t  SPINNER_ID_BTN_DEC = 101;
+static const int16_t  SPINNER_ID_TXT     = 102;
+
+// Create a compound element
+// - For now just two buttons and a text area
+gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXSpinner* pXData,gslc_tsRect rElem,int8_t nFontId)
+{
+
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXSpinnerCreate";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem sElem;
+
+
+  // Initialize composite element
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_SPINNER,rElem,NULL,0,GSLC_FONT_NONE);
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_CLICK_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_GLOW_EN;  // Don't need to glow outer element
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+
+  pXData->nCounter      = 0;
+
+  // Determine the maximum number of elements that we can store
+  // in the sub-element array. We do this at run-time with sizeof()
+  // instead of using #define to avoid polluting the global namespace.
+  int16_t nSubElemMax = sizeof(pXData->asElem) / sizeof(pXData->asElem[0]);
+
+  // NOTE: The count parameters in CollectReset() must match the size of
+  //       the asElem[] array. It is used for bounds checking when we
+  //       add new elements.
+  // NOTE: We only use RAM for subelement storage
+  gslc_CollectReset(&pXData->sCollect,pXData->asElem,nSubElemMax,pXData->asElemRef,nSubElemMax);
+
+
+  sElem.pXData            = (void*)(pXData);
+  // Specify the custom drawing callback
+  sElem.pfuncXDraw        = &gslc_ElemXSpinnerDraw;
+  // Specify the custom touch tracking callback
+  sElem.pfuncXTouch       = &gslc_ElemXSpinnerTouch;
+
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_WHITE;
+
+
+  // Now create the sub elements
+  // - Ensure page is set to GSLC_PAGE_NONE so that
+  //   we create the element struct but not add it to a specific page.
+  // - When we create an element with GSLC_PAGE_NONE it is
+  //   saved in the GUI's temporary element storage.
+  // - When we have finished creating / styling the element, we then
+  //   copy it into the permanent sub-element storage
+
+  // - The element IDs assigned to the sub-elements are
+  //   arbitrary (with local scope in the compound element),
+  //   so they don't need to be unique globally across the GUI.
+  gslc_tsElemRef* pElemRefTmp   = NULL;
+  gslc_tsElem*    pElemTmp      = NULL;
+  gslc_tsElemRef* pElemRef      = NULL;
+
+  // Determine offset coordinate of compound element so that we can
+  // specify relative positioning during the sub-element Create() operations.
+  int16_t nOffsetX = rElem.x;
+  int16_t nOffsetY = rElem.y;
+
+  #if (GSLC_LOCAL_STR)
+  pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SPINNER_ID_BTN_INC,GSLC_PAGE_NONE,
+    (gslc_tsRect){nOffsetX+40,nOffsetY+10,30,30},"\030",0,nFontId,&gslc_ElemXSpinnerClick);
+  #else
+  strncpy(pXData->acElemTxt[0],"\030",SPINNER_STR_LEN-1);
+  pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SPINNER_ID_BTN_INC,GSLC_PAGE_NONE,
+    (gslc_tsRect){nOffsetX+40,nOffsetY+10,30,30},pXData->acElemTxt[0],SPINNER_STR_LEN,
+    nFontId,&gslc_ElemXSpinnerClick);
+  #endif
+  gslc_ElemSetCol(pGui,pElemRefTmp,(gslc_tsColor){0,0,192},(gslc_tsColor){0,0,128},(gslc_tsColor){0,0,224});
+  gslc_ElemSetTxtCol(pGui,pElemRefTmp,GSLC_COL_WHITE);
+  pElemTmp = gslc_GetElemFromRef(pGui,pElemRefTmp);
+  gslc_CollectElemAdd(pGui,&pXData->sCollect,pElemTmp,GSLC_ELEMREF_DEFAULT);
+
+  #if (GSLC_LOCAL_STR)
+  pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SPINNER_ID_BTN_DEC,GSLC_PAGE_NONE,
+    (gslc_tsRect){nOffsetX+80,nOffsetY+10,30,30},"\031",0,nFontId,&gslc_ElemXSpinnerClick);
+  #else
+  strncpy(pXData->acElemTxt[1],"\031",SPINNER_STR_LEN-1);
+  pElemRefTmp = gslc_ElemCreateBtnTxt(pGui,SPINNER_ID_BTN_DEC,GSLC_PAGE_NONE,
+    (gslc_tsRect){nOffsetX+80,nOffsetY+10,30,30},pXData->acElemTxt[1],SPINNER_STR_LEN,
+    nFontId,&gslc_ElemXSpinnerClick);
+  #endif
+  gslc_ElemSetCol(pGui,pElemRefTmp,(gslc_tsColor){0,0,192},(gslc_tsColor){0,0,128},(gslc_tsColor){0,0,224});
+  gslc_ElemSetTxtCol(pGui,pElemRefTmp,GSLC_COL_WHITE);
+  pElemTmp = gslc_GetElemFromRef(pGui,pElemRefTmp);
+  gslc_CollectElemAdd(pGui,&pXData->sCollect,pElemTmp,GSLC_ELEMREF_DEFAULT);
+
+  #if (GSLC_LOCAL_STR)
+  pElemRefTmp = gslc_ElemCreateTxt(pGui,SPINNER_ID_TXT,GSLC_PAGE_NONE,
+    (gslc_tsRect){nOffsetX+10,nOffsetY+10,20,30},"0",0,nFontId);
+  #else
+  strncpy(pXData->acElemTxt[2],"0",SPINNER_STR_LEN-1);
+  pElemRefTmp = gslc_ElemCreateTxt(pGui,SPINNER_ID_TXT,GSLC_PAGE_NONE,
+    (gslc_tsRect){nOffsetX+10,nOffsetY+10,20,30},pXData->acElemTxt[2],SPINNER_STR_LEN,nFontId);
+  #endif
+  pElemTmp = gslc_GetElemFromRef(pGui,pElemRefTmp);
+  gslc_CollectElemAdd(pGui,&pXData->sCollect,pElemTmp,GSLC_ELEMREF_DEFAULT);
+
+
+  // Now proceed to add the compound element to the page
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+
+    // Now propagate the parent relationship to enable a cascade
+    // of redrawing from low-level elements to the top
+    gslc_CollectSetParent(pGui,&pXData->sCollect,pElemRef);
+
+    return pElemRef;
+  } else {
+    GSLC_DEBUG_PRINT("ERROR: ElemXSpinnerCreate(%s) Compound elements inside compound elements not supported\n","");
+    return NULL;
+
+    // TODO: For now, disable compound elements within
+    // compound elements. If we want to enable this, we
+    // would probably use the temporary element reference
+    // the GUI.
+    // Save as temporary element for further processing
+    //pGui->sElemTmp = sElem;   // Need fixing
+    //return &(pGui->sElemTmp); // Need fixing
+  }
+
+}
+
+
+// Redraw the compound element
+// - When drawing a compound element, we clear the background
+//   and then redraw the sub-element collection.
+bool gslc_ElemXSpinnerDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXSpinner* pSpinner = (gslc_tsXSpinner*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_SPINNER, __LINE__);
+  if (!pSpinner) return false;
+
+  bool bGlow = (pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN) && gslc_ElemGetGlow(pGui,pElemRef);
+
+  // Draw the compound element fill (background)
+  // - Should only need to do this in full redraw
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    gslc_DrawFillRect(pGui,pElem->rElem,(bGlow)?pElem->colElemFillGlow:pElem->colElemFill);
+  }
+
+  // Draw the sub-elements
+  // - For now, force redraw of entire compound element
+  gslc_tsCollect* pCollect = &pSpinner->sCollect;
+
+  gslc_tsEvent  sEvent = gslc_EventCreate(pGui,GSLC_EVT_DRAW,GSLC_EVTSUB_DRAW_FORCE,(void*)(pCollect),NULL);
+  gslc_CollectEvent(pGui,sEvent);
+
+  // Optionally, draw a frame around the compound element
+  // - This could instead be done by creating a sub-element
+  //   of type box.
+  // - We don't need to show any glowing of the compound element
+
+  gslc_DrawFrameRect(pGui,pElem->rElem,(bGlow)?pElem->colElemFrameGlow:pElem->colElemFrame);
+
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  // Mark page as needing flip
+  gslc_PageFlipSet(pGui,true);
+
+  return true;
+}
+
+// Fetch the current value of the element's counter
+int gslc_ElemXSpinnerGetCounter(gslc_tsGui* pGui,gslc_tsXSpinner* pSpinner)
+{
+  if ((pGui == NULL) || (pSpinner == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXSpinnerGetCounter";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return 0;
+  }
+  return pSpinner->nCounter;
+}
+
+
+void gslc_ElemXSpinnerSetCounter(gslc_tsGui* pGui,gslc_tsXSpinner* pSpinner,int16_t nCount)
+{
+  if (pSpinner == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXSpinnerSetCounter";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  pSpinner->nCounter = nCount;
+
+  // Determine new counter text
+  // FIXME: Consider replacing the printf() with an optimized function to
+  //        conserve RAM. Potentially leverage GSLC_DEBUG_PRINT().
+  char  acStrNew[GSLC_LOCAL_STR_LEN];
+  snprintf(acStrNew,GSLC_LOCAL_STR_LEN,"%hd",pSpinner->nCounter);
+
+  // Update the element
+  gslc_tsElemRef* pElemRef = gslc_CollectFindElemById(pGui,&pSpinner->sCollect,SPINNER_ID_TXT);
+  gslc_ElemSetTxtStr(pGui,pElemRef,acStrNew);
+
+}
+
+
+// Handle the compound element main functionality
+// - This routine is called by gslc_ElemEvent() to handle
+//   any click events that resulted from the touch tracking process.
+// - The code here will generally represent the core
+//   functionality of the compound element and any communication
+//   between sub-elements.
+// - pvElemRef is a void pointer to the element ref being tracked. From
+//   the pElemRefParent member we can get the parent/compound element
+//   data structures.
+bool gslc_ElemXSpinnerClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+#if defined(DRV_TOUCH_NONE)
+  return false;
+#else
+
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXSpinnerClick";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return false;
+  }
+  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
+
+
+  // Fetch the parent of the clicked element which is the compound
+  // element itself. This enables us to access the extra control data.
+  gslc_tsElemRef*    pElemRefParent = pElem->pElemRefParent;
+  if (pElemRefParent == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: ElemXSpinnerClick(%s) parent ElemRef ptr NULL\n","");
+    return false;
+  }
+
+  gslc_tsElem*    pElemParent = gslc_GetElemFromRef(pGui,pElemRefParent);
+  gslc_tsXSpinner* pSpinner     = (gslc_tsXSpinner*)(pElemParent->pXData);
+  if (pSpinner == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: ElemXSpinnerClick() element (ID=%d) has NULL pXData\n",pElem->nId);
+    return false;
+  }
+
+  // Begin the core compound element functionality
+  int nCounter  = pSpinner->nCounter;
+
+  // Handle the various button presses
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+
+    // Get the tracked element ID
+    gslc_tsElemRef* pElemRefTracked = pSpinner->sCollect.pElemRefTracked;
+    gslc_tsElem*    pElemTracked    = gslc_GetElemFromRef(pGui,pElemRefTracked);
+    int nSubElemId = pElemTracked->nId;
+
+    if (nSubElemId == SPINNER_ID_BTN_INC) {
+      // Increment button
+      if (nCounter<100) {
+        nCounter++;
+      }
+      gslc_ElemXSpinnerSetCounter(pGui,pSpinner,nCounter);
+
+    } else if (nSubElemId == SPINNER_ID_BTN_DEC) {
+      // Decrement button
+      if (nCounter>0) {
+        nCounter--;
+      }
+      gslc_ElemXSpinnerSetCounter(pGui,pSpinner,nCounter);
+
+    }
+  } // eTouch
+
+  return true;
+#endif // !DRV_TOUCH_NONE
+}
+
+bool gslc_ElemXSpinnerTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16_t nRelX,int16_t nRelY)
+{
+#if defined(DRV_TOUCH_NONE)
+  return false;
+#else
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsXSpinner* pSpinner = (gslc_tsXSpinner*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_SPINNER, __LINE__);
+  if (!pSpinner) return false;
+
+  // Handle any compound element operations
+  switch(eTouch) {
+    case GSLC_TOUCH_DOWN_IN:
+    case GSLC_TOUCH_MOVE_IN:
+      gslc_ElemSetGlow(pGui,pElemRef,true);
+      break;
+    case GSLC_TOUCH_MOVE_OUT:
+    case GSLC_TOUCH_UP_IN:
+    case GSLC_TOUCH_UP_OUT:
+    default:
+      gslc_ElemSetGlow(pGui,pElemRef,false);
+      break;
+  }
+
+  // Handle any sub-element operations
+
+  // Get Collection
+  gslc_tsCollect* pCollect = &pSpinner->sCollect;
+
+  return gslc_CollectTouchCompound(pvGui, pvElemRef, eTouch, nRelX, nRelY, pCollect);
+  #endif // !DRV_TOUCH_NONE
+}
+#endif // GSLC_FEATURE_COMPOUND
+
+
+// ============================================================================

--- a/src/elem/XSpinner.c
+++ b/src/elem/XSpinner.c
@@ -174,17 +174,17 @@ gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui, int16_t nElemId, int16
   int16_t nOffsetX = rElem.x;
   int16_t nOffsetY = rElem.y;
 
+  gslc_tsRect rSubElem;
+
+  rSubElem = (gslc_tsRect) { nOffsetX+nTxtBoxW, nOffsetY, nButtonSz, nButtonSz };
+  rSubElem = gslc_ExpandRect(rSubElem, -1, -1);
   #if (GSLC_LOCAL_STR)
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui, SPINNER_ID_BTN_INC, GSLC_PAGE_NONE,
-    (gslc_tsRect) {
-    nOffsetX + nTxtBoxW, nOffsetY, nButtonSz, nButtonSz
-  }, "\030", 0, nFontId, &gslc_ElemXSpinnerClick);
+    rSubElem, "\030", 0, nFontId, &gslc_ElemXSpinnerClick);
   #else
   strncpy(pXData->acElemTxt[0], "\030", SPINNER_STR_LEN - 1);
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui, SPINNER_ID_BTN_INC, GSLC_PAGE_NONE,
-    (gslc_tsRect) {
-    nOffsetX + nTxtBoxW, nOffsetY, nButtonSz, nButtonSz
-  }, pXData->acElemTxt[0], SPINNER_STR_LEN,
+    rSubElem, pXData->acElemTxt[0], SPINNER_STR_LEN,
       nFontId, &gslc_ElemXSpinnerClick);
   #endif
   gslc_ElemSetCol(pGui, pElemRefTmp, (gslc_tsColor) { 0, 0, 192 }, (gslc_tsColor) { 0, 0, 128 }, (gslc_tsColor) { 0, 0, 224 });
@@ -192,17 +192,15 @@ gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui, int16_t nElemId, int16
   pElemTmp = gslc_GetElemFromRef(pGui, pElemRefTmp);
   gslc_CollectElemAdd(pGui, &pXData->sCollect, pElemTmp, GSLC_ELEMREF_DEFAULT);
 
+  rSubElem = (gslc_tsRect) { nOffsetX+nTxtBoxW+nButtonSz, nOffsetY, nButtonSz, nButtonSz };
+  rSubElem = gslc_ExpandRect(rSubElem, -1, -1);
   #if (GSLC_LOCAL_STR)
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui, SPINNER_ID_BTN_DEC, GSLC_PAGE_NONE,
-    (gslc_tsRect) {
-    nOffsetX + nTxtBoxW + nButtonSz, nOffsetY, nButtonSz, nButtonSz
-  }, "\031", 0, nFontId, &gslc_ElemXSpinnerClick);
+    rSubElem, "\031", 0, nFontId, &gslc_ElemXSpinnerClick);
   #else
   strncpy(pXData->acElemTxt[1], "\031", SPINNER_STR_LEN - 1);
   pElemRefTmp = gslc_ElemCreateBtnTxt(pGui, SPINNER_ID_BTN_DEC, GSLC_PAGE_NONE,
-    (gslc_tsRect) {
-    nOffsetX + nTxtBoxW + nButtonSz, nOffsetY, nButtonSz, nButtonSz
-  }, pXData->acElemTxt[1], SPINNER_STR_LEN,
+    rSubElem, pXData->acElemTxt[1], SPINNER_STR_LEN,
       nFontId, &gslc_ElemXSpinnerClick);
   #endif
   gslc_ElemSetCol(pGui, pElemRefTmp, (gslc_tsColor) { 0, 0, 192 }, (gslc_tsColor) { 0, 0, 128 }, (gslc_tsColor) { 0, 0, 224 });
@@ -210,17 +208,15 @@ gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui, int16_t nElemId, int16
   pElemTmp = gslc_GetElemFromRef(pGui, pElemRefTmp);
   gslc_CollectElemAdd(pGui, &pXData->sCollect, pElemTmp, GSLC_ELEMREF_DEFAULT);
 
+  rSubElem = (gslc_tsRect) { nOffsetX, nOffsetY, nTxtBoxW, nButtonSz };
+  rSubElem = gslc_ExpandRect(rSubElem, -1, -1);
   #if (GSLC_LOCAL_STR)
   pElemRefTmp = gslc_ElemCreateTxt(pGui, SPINNER_ID_TXT, GSLC_PAGE_NONE,
-    (gslc_tsRect) {
-    nOffsetX, nOffsetY, nTxtBoxW, nButtonSz
-  }, (char*)acTxtNum, 0, nFontId);
+    rSubElem, (char*)acTxtNum, 0, nFontId);
   #else
   strncpy(pXData->acElemTxt[2], acTxtNum, SPINNER_STR_LEN - 1);
   pElemRefTmp = gslc_ElemCreateTxt(pGui, SPINNER_ID_TXT, GSLC_PAGE_NONE,
-    (gslc_tsRect) {
-    nOffsetX, nOffsetY, nTxtBoxW, nButtonSz
-  }, pXData->acElemTxt[2], SPINNER_STR_LEN, nFontId);
+    rSubElem, pXData->acElemTxt[2], SPINNER_STR_LEN, nFontId);
   #endif
   gslc_ElemSetTxtAlign(pGui, pElemRefTmp, GSLC_ALIGN_MID_MID);
   pElemTmp = gslc_GetElemFromRef(pGui, pElemRefTmp);
@@ -288,7 +284,9 @@ bool gslc_ElemXSpinnerDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
   //   of type box.
   // - We don't need to show any glowing of the compound element
 
-  gslc_DrawFrameRect(pGui,pElem->rElem,(bGlow)?pElem->colElemFrameGlow:pElem->colElemFrame);
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    gslc_DrawFrameRect(pGui, pElem->rElem, (bGlow) ? pElem->colElemFrameGlow : pElem->colElemFrame);
+  }
 
   // Clear the redraw flag
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
@@ -418,26 +416,11 @@ bool gslc_ElemXSpinnerTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int1
   gslc_tsXSpinner* pSpinner = (gslc_tsXSpinner*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_SPINNER, __LINE__);
   if (!pSpinner) return false;
 
-  // Handle any compound element operations
-  switch(eTouch) {
-    case GSLC_TOUCH_DOWN_IN:
-    case GSLC_TOUCH_MOVE_IN:
-      gslc_ElemSetGlow(pGui,pElemRef,true);
-      break;
-    case GSLC_TOUCH_MOVE_OUT:
-    case GSLC_TOUCH_UP_IN:
-    case GSLC_TOUCH_UP_OUT:
-    default:
-      gslc_ElemSetGlow(pGui,pElemRef,false);
-      break;
-  }
-
-  // Handle any sub-element operations
-
   // Get Collection
   gslc_tsCollect* pCollect = &pSpinner->sCollect;
 
   return gslc_CollectTouchCompound(pvGui, pvElemRef, eTouch, nRelX, nRelY, pCollect);
+
   #endif // !DRV_TOUCH_NONE
 }
 #endif // GSLC_FEATURE_COMPOUND

--- a/src/elem/XSpinner.c
+++ b/src/elem/XSpinner.c
@@ -299,15 +299,10 @@ bool gslc_ElemXSpinnerClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int1
   return false;
 #else
 
-  if ((pvGui == NULL) || (pvElemRef == NULL)) {
-    static const char GSLC_PMEM FUNCSTR[] = "ElemXSpinnerClick";
-    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
-    return false;
-  }
-  gslc_tsGui*     pGui      = (gslc_tsGui*)(pvGui);
-  gslc_tsElemRef* pElemRef  = (gslc_tsElemRef*)(pvElemRef);
-  gslc_tsElem*    pElem     = gslc_GetElemFromRef(pGui,pElemRef);
-
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return false;
 
   // Fetch the parent of the clicked element which is the compound
   // element itself. This enables us to access the extra control data.

--- a/src/elem/XSpinner.h
+++ b/src/elem/XSpinner.h
@@ -5,8 +5,8 @@
 
 
 // =======================================================================
-// GUIslice library extension: Select Number (Spinner) control
-// - Calvin Hass
+// GUIslice library extension: Spinner (number selection) control
+// - Extension by Paul Conti, Calvin Hass
 // - https://www.impulseadventure.com/elec/guislice-gui.html
 // - https://github.com/ImpulseAdventure/GUIslice
 // =======================================================================
@@ -54,7 +54,11 @@ extern "C" {
 // - Select any number above GSLC_TYPE_BASE_EXTEND
 #define  GSLC_TYPEX_SPINNER GSLC_TYPE_BASE_EXTEND + 15
 
-#define SPINNER_STR_LEN  6
+// Define the max number of sub-elements in compound element
+#define XSPINNER_COMP_CNT 3
+
+// Define the max string length to allocate for dynamic text elements
+#define XSPINNER_STR_LEN  6
 
 // Extended element data structures
 // - These data structures are maintained in the gslc_tsElem
@@ -71,16 +75,14 @@ typedef struct {
   gslc_tsElemRef*     pElemRef;       ///< Save our ElemRef for the callback
 
   // Internal sub-element members
-  gslc_tsCollect      sCollect;       ///< Collection management for sub-elements
-  gslc_tsElemRef      asElemRef[4];   ///< Storage for sub-element references
-  gslc_tsElem         asElem[4];      ///< Storage for sub-elements
+  gslc_tsCollect      sCollect;                      ///< Collection management for sub-elements
+  gslc_tsElemRef      asElemRef[XSPINNER_COMP_CNT];   ///< Storage for sub-element references
+  gslc_tsElem         asElem[XSPINNER_COMP_CNT];      ///< Storage for sub-elements
 
-  #if (GSLC_LOCAL_STR == 0)
-  // If elements don't provide their own internal string buffer, then
-  // we need to provide storage here in the extended data of the compound
-  // element. For now, simply provide a fixed-length memory buffer.
-  char                acElemTxt[4][SPINNER_STR_LEN]; ///< Storage for strings
-  #endif
+  // Provide storage for any dynamic text elements
+  // Simple example here uses fixed-length character array
+  char                acElemTxt[1][XSPINNER_STR_LEN]; ///< Storage for strings
+
 } gslc_tsXSpinner;
 
 
@@ -173,6 +175,7 @@ bool gslc_ElemXSpinnerClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int1
 /// \return true if success, false otherwise
 ///
 bool gslc_ElemXSpinnerTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16_t nRelX,int16_t nRelY);
+
 #endif // GLSC_COMPOUND
 
 // ============================================================================

--- a/src/elem/XSpinner.h
+++ b/src/elem/XSpinner.h
@@ -63,7 +63,12 @@ extern "C" {
 typedef struct {
 
   // Core functionality for Spinner
-  int16_t             nCounter;       ///< Counter for demo purposes
+  int16_t             nMin;           ///< Minimum control value
+  int16_t             nMax;           ///< Maximum control value
+  int16_t             nIncr;          ///< Increment by value
+  int16_t             nCounter;       ///< Current value
+  GSLC_CB_INPUT       pfuncXInput;    ///< Callback func ptr for input ready
+  gslc_tsElemRef*     pElemRef;       ///< Save our ElemRef for the callback
 
   // Internal sub-element members
   gslc_tsCollect      sCollect;       ///< Collection management for sub-elements
@@ -88,13 +93,21 @@ typedef struct {
 /// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
 /// \param[in]  nPage:       Page ID to attach element to
 /// \param[in]  pXData:      Ptr to extended element data structure
-/// \param[in]  rElem:       Rectangle coordinates defining element size
+/// \param[in]  nX0:         X Spinner Starting Coordinate 
+/// \param[in]  nY0:         Y Spinner Starting Coordinate 
+/// \param[in]  nMin:        Minimum value of Spinner
+/// \param[in]  nMax:        Maximum value of Spinner
+/// \param[in]  nVal:        Starting value of Spinner
+/// \param[in]  nIncr:       Increment Spinner by this value
 /// \param[in]  nFontId:     Font ID to use for drawing the element
+/// \param[in]  nButtonSz:   Size of individual buttons
+/// \param[in]  cbInput:     Callback for touch events
 ///
 /// \return Pointer to Element or NULL if failure
 ///
-gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
-  gslc_tsXSpinner* pXData,gslc_tsRect rElem,int8_t nFontId);
+gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage, gslc_tsXSpinner* pXData,
+  int16_t nX0, int16_t nY0, int16_t nMin, int16_t nMax, int16_t nVal, int16_t nIncr,
+  int8_t nFontId, int8_t nButtonSz, GSLC_CB_INPUT cbInput);
 
 
 ///

--- a/src/elem/XSpinner.h
+++ b/src/elem/XSpinner.h
@@ -1,0 +1,177 @@
+#ifndef _GUISLICE_EX_XSPINNER_H_
+#define _GUISLICE_EX_XSPINNER_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: Select Number (Spinner) control
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XSpinner.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+
+#if (GSLC_FEATURE_COMPOUND)
+// ============================================================================
+// Extended Element: Spinner (Number Selector)
+// - Demonstration of a compound element consisting of
+//   a counter text field along with an increment and
+//   decrement button.
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_SPINNER GSLC_TYPE_BASE_EXTEND + 15
+
+#define SPINNER_STR_LEN  6
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+/// Extended data for Spinner element
+typedef struct {
+
+  // Core functionality for Spinner
+  int16_t             nCounter;       ///< Counter for demo purposes
+
+  // Internal sub-element members
+  gslc_tsCollect      sCollect;       ///< Collection management for sub-elements
+  gslc_tsElemRef      asElemRef[4];   ///< Storage for sub-element references
+  gslc_tsElem         asElem[4];      ///< Storage for sub-elements
+
+  #if (GSLC_LOCAL_STR == 0)
+  // If elements don't provide their own internal string buffer, then
+  // we need to provide storage here in the extended data of the compound
+  // element. For now, simply provide a fixed-length memory buffer.
+  char                acElemTxt[4][SPINNER_STR_LEN]; ///< Storage for strings
+  #endif
+} gslc_tsXSpinner;
+
+
+
+
+///
+/// Create a Spinner Element
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining element size
+/// \param[in]  nFontId:     Font ID to use for drawing the element
+///
+/// \return Pointer to Element or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXSpinnerCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXSpinner* pXData,gslc_tsRect rElem,int8_t nFontId);
+
+
+///
+/// Draw a Spinner element on the screen
+/// - Called during redraw
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXSpinnerDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+
+///
+/// Get the current counter associated with Spinner
+///
+/// \param[in]  pGui:        Ptr to GUI
+/// \param[in]  pSpinner:     Ptr to Element
+///
+/// \return Current counter value
+///
+int gslc_ElemXSpinnerGetCounter(gslc_tsGui* pGui,gslc_tsXSpinner* pSpinner);
+
+
+///
+/// Set the current counter associated with Spinner
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pSpinner:     Ptr to Element
+/// \param[in]  nCount:      New counter value
+///
+/// \return none
+///
+void gslc_ElemXSpinnerSetCounter(gslc_tsGui* pGui,gslc_tsXSpinner* pSpinner,int16_t nCount);
+
+
+///
+/// Handle a click event within the Spinner
+/// - This is called internally by the Spinner touch handler
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+/// \param[in]  eTouch:      Touch event type
+/// \param[in]  nX:          Touch X coord
+/// \param[in]  nY:          Touch Y coord
+///
+/// \return none
+///
+bool gslc_ElemXSpinnerClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int16_t nY);
+
+///
+/// Handle touch (up,down,move) events to Spinner element
+/// - Called from gslc_ElemSendEventTouch()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+/// \param[in]  eTouch:      Touch event type
+/// \param[in]  nRelX:       Touch X coord relative to element
+/// \param[in]  nRelY:       Touch Y coord relative to element
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXSpinnerTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16_t nRelX,int16_t nRelY);
+#endif // GLSC_COMPOUND
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XSPINNER_H_
+


### PR DESCRIPTION
XSpinner is a number selector (up/down) compound control
- XSpinner based on @Pconti31 enhancements to XSelNum (range, increment, sizing, update callback)
- Include example `ex33_ard_spinner`

Additional changes:
- Simplified error handling with common `GetElemFromRefD`
- Add `CollectTouchCompound` helper for compound elements
- Optimized compound element redraw
- Compound elements: disabled propagation of redraw from sub-elements to parent
