### PR TITLE
Support for ESP32 + 4wire touch

### DIFF
--- a/configs/esp-tftespi-default-simple.h
+++ b/configs/esp-tftespi-default-simple.h
@@ -138,8 +138,13 @@ extern "C" {
   //     ADATOUCH_PIN_XP      // "X+": Can be a digital pin
 
   // Pin connections from diag_ard_touch_detect:
-  #define ADATOUCH_PIN_YP     13
-  #define ADATOUCH_PIN_XM     12
+  // NOTE: The following will need to be adjusted to match your touch overlay
+  //       This example pin selection is based on a mcufriend-type UNO shield (ILI9341)
+  //       with 8-bit parallel interface pin-sharing with the TFT control signals
+  //       hand-wired to an ESP32. For this particular example, the following
+  //       TFT_eSPI User_Setup was selected: Setup14_ILI9341_Parallel.h.
+  #define ADATOUCH_PIN_YP     4
+  #define ADATOUCH_PIN_XM     15
   #define ADATOUCH_PIN_YM     14
   #define ADATOUCH_PIN_XP     27
 
@@ -151,11 +156,10 @@ extern "C" {
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
   // Calibration settings from diag_ard_touch_calib:
-  #define ADATOUCH_X_MIN    100
-  #define ADATOUCH_X_MAX    900
-  #define ADATOUCH_Y_MIN    150
-  #define ADATOUCH_Y_MAX    900
-  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_X_MIN    924
+  #define ADATOUCH_X_MAX    211
+  #define ADATOUCH_Y_MIN    966
+  #define ADATOUCH_Y_MAX    145
   #define ADATOUCH_REMAP_YX 0
 
   // Touch overlay resistance value

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.53"
+#define GUISLICE_VER "0.11.2.54"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.2.54"
+#define GUISLICE_VER "0.11.3.2"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
Add workarounds for 4-wire **Adafruit_TouchScreen** with ESP32 & TFT_eSPI per #130 
- `GUIslice_drv_tft_espi.cpp` can be modified to alter the default workaround enables
- Workaround modes provided:
  - `FIX_4WIRE_Z`
  - `FIX_4WIRE_PIN_STATE`
  - `FIX_4WIRE_ADC_10` (only active on ESP32)
  - `FIX_4WIRE_FORCE_CS` (disabled by default)
