### PR TITLE
Add support for rounded buttons / rects

### DIFF
--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -176,6 +176,7 @@ typedef enum {
 
 /// Element features type
 #define GSLC_ELEM_FEA_VALID     0x80      ///< Element record is valid
+#define GSLC_ELEM_FEA_ROUND_EN  0x10      ///< Element is drawn with a rounded profile
 #define GSLC_ELEM_FEA_CLICK_EN  0x08      ///< Element accepts touch presses
 #define GSLC_ELEM_FEA_GLOW_EN   0x04      ///< Element supports glowing state
 #define GSLC_ELEM_FEA_FRAME_EN  0x02      ///< Element is drawn with a frame
@@ -732,6 +733,8 @@ typedef struct {
   gslc_tsFont*        asFont;           ///< Collection of loaded fonts
   uint8_t             nFontMax;         ///< Maximum number of fonts to allocate
   uint8_t             nFontCnt;         ///< Number of fonts allocated
+
+  uint8_t             nRoundRadius;     ///< Radius for rounded elements
 
 #if (GSLC_FEATURE_COMPOUND)
   gslc_tsElem         sElemTmp;         ///< Temporary element
@@ -1742,6 +1745,17 @@ void gslc_ElemSetFillEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFillEn);
 /// \return none
 ///
 void gslc_ElemSetFrameEn(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFrameEn);
+
+///
+/// Set the rounded frame/fill state for an Element
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  bRoundEn:    True if rounded, false otherwise
+///
+/// \return none
+///
+void gslc_ElemSetRoundEn(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, bool bRoundEn);
 
 ///
 /// Update the common color selection for an Element
@@ -2876,6 +2890,16 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
 ///
 void gslc_ElemDraw(gslc_tsGui* pGui,int16_t nPageId,int16_t nElemId);
 
+///
+/// Set the global rounded radius
+/// - Used for rounded rectangles
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nRadius:     Radius for rounded elements
+///
+/// \return none
+///
+void gslc_SetRoundRadius(gslc_tsGui* pGui, uint8_t nRadius);
 
 // ------------------------------------------------------------------------
 /// @}

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -864,6 +864,16 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   return true;
 }
 
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.fillRoundRect(rRect.x,rRect.y,rRect.w,rRect.h,nRadius,nColRaw);
+  return true;
+}
+
+
 bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 {
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
@@ -901,6 +911,16 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 #endif
   return true;
 }
+
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  m_disp.drawRoundRect(rRect.x,rRect.y,rRect.w,rRect.h,nRadius,nColRaw);
+  return true;
+}
+
 
 
 bool gslc_DrvDrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -89,19 +89,21 @@ extern "C" {
 //   gslc_DrvDrawPoint()
 // =======================================================================
 
-#define DRV_HAS_DRAW_POINT          1 ///< Support gslc_DrvDrawPoint()
+#define DRV_HAS_DRAW_POINT             1 ///< Support gslc_DrvDrawPoint()
 
-#define DRV_HAS_DRAW_POINTS         0 ///< Support gslc_DrvDrawPoints()
-#define DRV_HAS_DRAW_LINE           1 ///< Support gslc_DrvDrawLine()
-#define DRV_HAS_DRAW_RECT_FRAME     1 ///< Support gslc_DrvDrawFrameRect()
-#define DRV_HAS_DRAW_RECT_FILL      1 ///< Support gslc_DrvDrawFillRect()
-#define DRV_HAS_DRAW_CIRCLE_FRAME   1 ///< Support gslc_DrvDrawFrameCircle()
-#define DRV_HAS_DRAW_CIRCLE_FILL    1 ///< Support gslc_DrvDrawFillCircle()
-#define DRV_HAS_DRAW_TRI_FRAME      1 ///< Support gslc_DrvDrawFrameTriangle()
-#define DRV_HAS_DRAW_TRI_FILL       1 ///< Support gslc_DrvDrawFillTriangle()
-#define DRV_HAS_DRAW_TEXT           1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_POINTS            0 ///< Support gslc_DrvDrawPoints()
+#define DRV_HAS_DRAW_LINE              1 ///< Support gslc_DrvDrawLine()
+#define DRV_HAS_DRAW_RECT_FRAME        1 ///< Support gslc_DrvDrawFrameRect()
+#define DRV_HAS_DRAW_RECT_FILL         1 ///< Support gslc_DrvDrawFillRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FRAME  1 ///< Support gslc_DrvDrawFrameRoundRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FILL   1 ///< Support gslc_DrvDrawFillRoundRect()
+#define DRV_HAS_DRAW_CIRCLE_FRAME      1 ///< Support gslc_DrvDrawFrameCircle()
+#define DRV_HAS_DRAW_CIRCLE_FILL       1 ///< Support gslc_DrvDrawFillCircle()
+#define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
+#define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
+#define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
 
-#define DRV_OVERRIDE_TXT_ALIGN      0 ///< Driver provides text alignment
+#define DRV_OVERRIDE_TXT_ALIGN         0 ///< Driver provides text alignment
 
 // =======================================================================
 // Driver-specific members
@@ -397,6 +399,33 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 /// \return true if success, false if error
 ///
 bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol);
+
+
+///
+/// Draw a framed rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to frame
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to fill
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
 
 
 ///

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -397,6 +397,16 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   return true;
 }
 
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.fillRoundRect(rRect.x,rRect.y,rRect.w,rRect.h,nRadius,nColRaw);
+  return true;
+}
+
+
 bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 {
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
@@ -434,6 +444,16 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 #endif
   return true;
 }
+
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  m_disp.drawRoundRect(rRect.x,rRect.y,rRect.w,rRect.h,nRadius,nColRaw);
+  return true;
+}
+
 
 
 bool gslc_DrvDrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)

--- a/src/GUIslice_drv_m5stack.h
+++ b/src/GUIslice_drv_m5stack.h
@@ -67,19 +67,21 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 //   gslc_DrvDrawPoint()
 // =======================================================================
 
-#define DRV_HAS_DRAW_POINT          1 ///< Support gslc_DrvDrawPoint()
+#define DRV_HAS_DRAW_POINT             1 ///< Support gslc_DrvDrawPoint()
 
-#define DRV_HAS_DRAW_POINTS         0 ///< Support gslc_DrvDrawPoints()
-#define DRV_HAS_DRAW_LINE           1 ///< Support gslc_DrvDrawLine()
-#define DRV_HAS_DRAW_RECT_FRAME     1 ///< Support gslc_DrvDrawFrameRect()
-#define DRV_HAS_DRAW_RECT_FILL      1 ///< Support gslc_DrvDrawFillRect()
-#define DRV_HAS_DRAW_CIRCLE_FRAME   1 ///< Support gslc_DrvDrawFrameCircle()
-#define DRV_HAS_DRAW_CIRCLE_FILL    1 ///< Support gslc_DrvDrawFillCircle()
-#define DRV_HAS_DRAW_TRI_FRAME      1 ///< Support gslc_DrvDrawFrameTriangle()
-#define DRV_HAS_DRAW_TRI_FILL       1 ///< Support gslc_DrvDrawFillTriangle()
-#define DRV_HAS_DRAW_TEXT           1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_POINTS            0 ///< Support gslc_DrvDrawPoints()
+#define DRV_HAS_DRAW_LINE              1 ///< Support gslc_DrvDrawLine()
+#define DRV_HAS_DRAW_RECT_FRAME        1 ///< Support gslc_DrvDrawFrameRect()
+#define DRV_HAS_DRAW_RECT_FILL         1 ///< Support gslc_DrvDrawFillRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FRAME  1 ///< Support gslc_DrvDrawFrameRoundRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FILL   1 ///< Support gslc_DrvDrawFillRoundRect()
+#define DRV_HAS_DRAW_CIRCLE_FRAME      1 ///< Support gslc_DrvDrawFrameCircle()
+#define DRV_HAS_DRAW_CIRCLE_FILL       1 ///< Support gslc_DrvDrawFillCircle()
+#define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
+#define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
+#define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
 
-#define DRV_OVERRIDE_TXT_ALIGN      1 ///< Driver provides text alignment
+#define DRV_OVERRIDE_TXT_ALIGN         1 ///< Driver provides text alignment
 
 // =======================================================================
 // Driver-specific members
@@ -394,6 +396,33 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 /// \return true if success, false if error
 ///
 bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol);
+
+
+///
+/// Draw a framed rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to frame
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to fill
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
 
 
 ///

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -514,6 +514,16 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   return true;
 }
 
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.fillRoundRect(rRect.x,rRect.y,rRect.w,rRect.h,nRadius,nColRaw);
+  return true;
+}
+
+
 bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 {
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
@@ -551,6 +561,16 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 #endif
   return true;
 }
+
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  m_disp.drawRoundRect(rRect.x,rRect.y,rRect.w,rRect.h,nRadius,nColRaw);
+  return true;
+}
+
 
 
 bool gslc_DrvDrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -87,19 +87,21 @@ extern "C" {
 //   gslc_DrvDrawPoint()
 // =======================================================================
 
-#define DRV_HAS_DRAW_POINT          1 ///< Support gslc_DrvDrawPoint()
+#define DRV_HAS_DRAW_POINT             1 ///< Support gslc_DrvDrawPoint()
 
-#define DRV_HAS_DRAW_POINTS         0 ///< Support gslc_DrvDrawPoints()
-#define DRV_HAS_DRAW_LINE           1 ///< Support gslc_DrvDrawLine()
-#define DRV_HAS_DRAW_RECT_FRAME     1 ///< Support gslc_DrvDrawFrameRect()
-#define DRV_HAS_DRAW_RECT_FILL      1 ///< Support gslc_DrvDrawFillRect()
-#define DRV_HAS_DRAW_CIRCLE_FRAME   1 ///< Support gslc_DrvDrawFrameCircle()
-#define DRV_HAS_DRAW_CIRCLE_FILL    1 ///< Support gslc_DrvDrawFillCircle()
-#define DRV_HAS_DRAW_TRI_FRAME      1 ///< Support gslc_DrvDrawFrameTriangle()
-#define DRV_HAS_DRAW_TRI_FILL       1 ///< Support gslc_DrvDrawFillTriangle()
-#define DRV_HAS_DRAW_TEXT           1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_POINTS            0 ///< Support gslc_DrvDrawPoints()
+#define DRV_HAS_DRAW_LINE              1 ///< Support gslc_DrvDrawLine()
+#define DRV_HAS_DRAW_RECT_FRAME        1 ///< Support gslc_DrvDrawFrameRect()
+#define DRV_HAS_DRAW_RECT_FILL         1 ///< Support gslc_DrvDrawFillRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FRAME  1 ///< Support gslc_DrvDrawFrameRoundRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FILL   1 ///< Support gslc_DrvDrawFillRoundRect()
+#define DRV_HAS_DRAW_CIRCLE_FRAME      1 ///< Support gslc_DrvDrawFrameCircle()
+#define DRV_HAS_DRAW_CIRCLE_FILL       1 ///< Support gslc_DrvDrawFillCircle()
+#define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
+#define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
+#define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
 
-#define DRV_OVERRIDE_TXT_ALIGN      1 ///< Driver provides text alignment
+#define DRV_OVERRIDE_TXT_ALIGN         1 ///< Driver provides text alignment
 
 // =======================================================================
 // Driver-specific members
@@ -419,6 +421,33 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol);
 
 
 ///
+/// Draw a framed rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to frame
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to fill
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
+
+
+///
 /// Draw a line
 ///
 /// \param[in]  pGui:        Pointer to GUI
@@ -524,6 +553,7 @@ bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRe
 /// \return none
 ///
 void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY, const unsigned char *pBitmap,bool bProgMem);
+
 
 ///
 /// Draw a color 24-bit depth bitmap from a memory array

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.8"
+#define GUISLICE_VER "0.11.3.9"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
Add support for rounded buttons / rects
- `ElemSetRoundEn()` to enable for an element
- `SetRoundRadius()` to change global rounded radius

For example, to change a button to use a rounded profile:
```c++
  pElemRef = gslc_ElemCreateBtnTxt(&m_gui,...);
  gslc_ElemSetRoundEn(&m_gui,pElemRef,true);
```
