### PR TITLE
Adapt TFT_eSPI integrated touch to use raw capture

### DIFF
--- a/configs/esp-tftespi-default-xpt2046_int.h
+++ b/configs/esp-tftespi-default-xpt2046_int.h
@@ -117,17 +117,33 @@ extern "C" {
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4B: Update your calibration settings here
-  // - These values should come from the TFT_eSPI/Touch_calibrate utility
+  // - These values should come from the diag_ard_touch_calib sketch output
+  // - Please update the values to the right of ADATOUCH_X/Y_MIN/MAX_* accordingly
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
-  // Calibration data from TFT_eSPI for integrated XPT2046
-  #define TFT_ESPI_TOUCH_CALIB { 321,3498,280,3593,3 }
+  // Calibration settings from diag_ard_touch_calib:
+  #define ADATOUCH_X_MIN    3914
+  #define ADATOUCH_X_MAX    211
+  #define ADATOUCH_Y_MIN    3945
+  #define ADATOUCH_Y_MAX    407
   // Certain touch controllers may swap X & Y coords
   #define ADATOUCH_REMAP_YX 0
+
+
+  // Calibration data from TFT_eSPI for integrated XPT2046
+  // NOTE: The TFT_ESPI_TOUCH_CALIB calibration settings will be unused as we will
+	//       bypass TFT_eSPI's calibration and use raw touch values instead.
+  //       Reference: https://github.com/Bodmer/TFT_eSPI/issues/365
+  #define TFT_ESPI_TOUCH_CALIB { 321,3498,280,3593,3 }
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
   // SECTION 4D: Additional touch configuration
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Define pressure threshold for detecting a touch
+  #define ADATOUCH_PRESS_MIN  200
+  #define ADATOUCH_PRESS_MAX  4000
+
 
 
   // -----------------------------------------------------------------------------

--- a/examples/arduino/diag_ard_touch_calib/diag_ard_touch_calib.ino
+++ b/examples/arduino/diag_ard_touch_calib/diag_ard_touch_calib.ino
@@ -34,6 +34,7 @@
 #elif defined(DRV_TOUCH_ADA_RA8875)
 #elif defined(DRV_TOUCH_XPT2046_STM)
 #elif defined(DRV_TOUCH_XPT2046_PS)
+#elif defined(DRV_TOUCH_TFT_ESPI)
 #else
   #error "Calibration only supported for resistive touch displays"
 #endif // DRV_TOUCH_*

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -70,6 +70,8 @@ extern "C" {
 #elif defined(DRV_TOUCH_XPT2046_PS)
   #define DRV_TOUCH_TYPE_EXTERNAL
   #define DRV_TOUCH_TYPE_RES         // Resistive
+#elif defined(DRV_TOUCH_TFT_ESPI)
+  #define DRV_TOUCH_TYPE_RES         // Resistive
 #elif defined(DRV_TOUCH_INPUT)
   #define DRV_TOUCH_TYPE_EXTERNAL
 #elif defined(DRV_TOUCH_HANDLER)

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.12"
+#define GUISLICE_VER "0.11.3.20"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
Adapt TFT_eSPI integrated touch to use raw capture
- Address touch rotation issue from #141
- `DRV_TOUCH_TFT_ESPI` use TFT_eSPI's raw touch APIs and defer dynamic rotation and calibration to GUIslice. TFT_eSPI `getTouch()` API (with its own calibration) is no longer used.
- Revised config `esp-tftespi-default-xpt2046_int`
- GUIslice calibration utility (`diag_ard_touch_calib`) now supports `DRV_TOUCH_TFT_ESPI` mode