### PR TITLE
Add XKeyPad component

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Design your GUI with a **drag & drop builder**, then apply the same code to a wi
 ## Features ##
 - Pure C library, no dynamic memory allocation
 - *Widgets*:
-  - text, images, buttons, checkboxes, radio buttons, sliders,
+  - text, images, buttons, checkboxes, radio buttons, sliders, keypad,
   radial controls, scrolling textbox / terminal, graphs, etc. plus extensions and multiple pages.
 - Cross-platform **GUIslice Builder** (beta) desktop application to generate layouts
 - *Platform-independent* GUI core currently supports:

--- a/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
+++ b/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
@@ -120,23 +120,18 @@ bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, 
     switch (pElem->nId) {
       //<Button Enums !Start!>
     case E_TXT_VAL1:
-      // Clicked on edit field, so show popup box if not already active
-      if (m_nPopup == -1) {
-        m_nPopup = E_TXT_VAL1; // Keep track of field to edit
-        gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
-        // Preload current value
-        gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
-
-      }
+      // Clicked on edit field, so show popup box and associate with this text field
+      gslc_ElemXKeyPadTargetIdSet(&m_gui, &m_sKeyPadNum.sKeyPad, E_TXT_VAL1);
+      gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
+      // Preload current value
+      gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
       break;
     case E_TXT_VAL2:
-      // Clicked on edit field, so show popup box if not already active
-      if (m_nPopup == -1) {
-        m_nPopup = E_TXT_VAL2; // Keep track of field to edit
-        gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
-        // Preload current value
-        gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
-      }
+      // Clicked on edit field, so show popup box and associate with this text field
+      gslc_ElemXKeyPadTargetIdSet(&m_gui, &m_sKeyPadNum.sKeyPad, E_TXT_VAL2);
+      gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
+      // Preload current value
+      gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
       break;
     case E_BTN_ADD:
       // Compute the sum and update the result
@@ -180,20 +175,19 @@ bool CbInputCommon(void* pvGui, void *pvElemRef, int16_t nState, void* pvData)
   char acTxtNum[11];
   // From the element's ID we can determine which element is ready.
   if (pElem->nId == E_ELEM_KEYPAD) {
+    int16_t nTargetElemId = gslc_ElemXKeyPadDataTargetIdGet(pGui, pvData);
     switch (nState) {
     case XKEYPAD_CB_STATE_DONE:
       // User clicked on Enter to leave popup
       // - If we have a popup active, pass the return value directly to
       //   the corresponding value field
-      if (m_nPopup == E_TXT_VAL1) {
-        gslc_ElemSetTxtStr(pGui, m_pElemVal1, (char*)pvData);
+      if (nTargetElemId == E_TXT_VAL1) {
+        gslc_ElemSetTxtStr(pGui, m_pElemVal1, gslc_ElemXKeyPadDataValGet(pGui, pvData));
         gslc_PopupHide(&m_gui);
-        m_nPopup = -1; // Clear the active popup indicator
       }
-      else if (m_nPopup == E_TXT_VAL2) {
-        gslc_ElemSetTxtStr(pGui, m_pElemVal2, (char*)pvData);
+      else if (nTargetElemId == E_TXT_VAL2) {
+        gslc_ElemSetTxtStr(pGui, m_pElemVal2, gslc_ElemXKeyPadDataValGet(pGui, pvData));
         gslc_PopupHide(&m_gui);
-        m_nPopup = -1; // Clear the active popup indicator
       }
       else {
         // ERROR
@@ -202,12 +196,11 @@ bool CbInputCommon(void* pvGui, void *pvElemRef, int16_t nState, void* pvData)
     case XKEYPAD_CB_STATE_CANCEL:
       // User escaped from popup, so don't update values
       gslc_PopupHide(&m_gui);
-      m_nPopup = -1; // Clear the active popup indicator
       break;
 
     case XKEYPAD_CB_STATE_UPDATE:
       // KeyPad was updated, so could optionally take action here
-		  break;
+      break;
 
     default:
       break;

--- a/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
+++ b/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
@@ -90,14 +90,13 @@ gslc_tsXKeyPad_Num          m_sKeyPadNum; // Keypad
 gslc_tsElemRef*  m_pElemVal1 = NULL;
 gslc_tsElemRef*  m_pElemVal2 = NULL;
 gslc_tsElemRef*  m_pElemResult = NULL;
+gslc_tsElemRef*  m_pElemKeyPad = NULL;
 //<Save_References !End!>
 
 
 // ------------------------------------------------
 // Program Globals
 // ------------------------------------------------
-
-int16_t m_nPopup = -1; // Initialize to no popup active
 
 // Define debug message function
 static int16_t DebugOut(char ch) { if (ch == (char)'\n') Serial.println(""); else Serial.write(ch); return 0; }
@@ -301,9 +300,9 @@ bool InitGUI()
   gslc_ElemXKeyPadCfgSetFloatEn(&sCfg, false);
   gslc_ElemXKeyPadCfgSetSignEn(&sCfg, true);
   gslc_ElemXKeyPadCfgSetButtonSz(&sCfg, 25, 25);
-  pElemRef = gslc_ElemXKeyPadCreate_Num(&m_gui, E_ELEM_KEYPAD, E_POP_KEYPAD,
+  m_pElemKeyPad = gslc_ElemXKeyPadCreate_Num(&m_gui, E_ELEM_KEYPAD, E_POP_KEYPAD,
     &m_sKeyPadNum, 65, 80, E_FONT_TXT1, &sCfg);
-  gslc_ElemXKeyPadValSetCb(&m_gui, pElemRef, &CbInputCommon);
+  gslc_ElemXKeyPadValSetCb(&m_gui, m_pElemKeyPad, &CbInputCommon);
 
   //<InitGUI !End!>
 

--- a/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
+++ b/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
@@ -46,7 +46,7 @@
 enum { E_PG_MAIN, E_POP_KEYPAD };
 enum {
   E_BOX1, E_BTN_ADD, E_BTN_MULT, E_BTN_SUB
-  , E_TXT7, E_TXT_VAL1, E_TXT_VAL2, E_ELEM_KEYPAD
+  , E_TXT_RESULT, E_TXT_VAL1, E_TXT_VAL2, E_ELEM_KEYPAD
 };
 enum { E_FONT_SANS2, E_FONT_TXT1 };
 //<Enum !End!>
@@ -112,7 +112,7 @@ bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, 
   gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
 
   char acTxtNum[11];
-  int16_t nVal1, nVal2, nResult;
+  int32_t nVal1, nVal2, nResult;
 
   if (eTouch == GSLC_TOUCH_UP_IN) {
     // From the element's ID we can determine which button was pressed.
@@ -134,26 +134,26 @@ bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, 
       break;
     case E_BTN_ADD:
       // Compute the sum and update the result
-      nVal1 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
-      nVal2 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      nVal1 = atol(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      nVal2 = atol(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
       nResult = nVal1 + nVal2;
-      itoa(nResult, acTxtNum, 10);
+      ltoa(nResult, acTxtNum, 10);
       gslc_ElemSetTxtStr(&m_gui, m_pElemResult, acTxtNum);
       break;
     case E_BTN_SUB:
       // Compute the subtraction and update the result
-      nVal1 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
-      nVal2 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      nVal1 = atol(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      nVal2 = atol(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
       nResult = nVal1 - nVal2;
-      itoa(nResult, acTxtNum, 10);
+      ltoa(nResult, acTxtNum, 10);
       gslc_ElemSetTxtStr(&m_gui, m_pElemResult, acTxtNum);
       break;
     case E_BTN_MULT:
       // Compute the multiplication and update the result
-      nVal1 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
-      nVal2 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      nVal1 = atol(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      nVal2 = atol(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
       nResult = nVal1 * nVal2;
-      itoa(nResult, acTxtNum, 10);
+      ltoa(nResult, acTxtNum, 10);
       gslc_ElemSetTxtStr(&m_gui, m_pElemResult, acTxtNum);
       break;
       //<Button Enums !End!>
@@ -261,6 +261,7 @@ bool InitGUI()
   gslc_ElemSetTxtMargin(&m_gui, pElemRef, 5);
   gslc_ElemSetClickEn(&m_gui, pElemRef, true);
   gslc_ElemSetTouchFunc(&m_gui, pElemRef, &CbBtnCommon);
+  m_pElemVal1 = pElemRef; // Save for later
 
   // Create E_TXT_VAL2 modifiable text label
   static char m_strtxt6[11] = "";
@@ -272,12 +273,14 @@ bool InitGUI()
   gslc_ElemSetTxtMargin(&m_gui, pElemRef, 5);
   gslc_ElemSetClickEn(&m_gui, pElemRef, true);
   gslc_ElemSetTouchFunc(&m_gui, pElemRef, &CbBtnCommon);
+  m_pElemVal2 = pElemRef; // Save for later
 
-  // Create E_TXT7 modifiable text label
-  static char m_strtxt7[11] = "";
-  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT7, E_PG_MAIN, (gslc_tsRect) { 150, 200, 62, 12 },
-    (char*)m_strtxt7, 11, E_FONT_TXT1);
+  // Create E_TXT_RESULT modifiable text label
+  static char m_strResult[11] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_RESULT, E_PG_MAIN, (gslc_tsRect) { 150, 200, 62, 12 },
+    (char*)m_strResult, 11, E_FONT_TXT1);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_GREEN);
+  m_pElemResult = pElemRef; // Save for later
 
   // create E_BTN_ADD button with text label
   pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_ADD, E_PG_MAIN,
@@ -339,9 +342,6 @@ void setup()
   // Save some element references for quick access
   // ------------------------------------------------
   //<Quick_Access !Start!>
-  m_pElemVal1 = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT_VAL1);
-  m_pElemVal2 = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT_VAL2);
-  m_pElemResult = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT7);
   //<Quick_Access !End!>
 
   //<Startup !Start!>

--- a/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
+++ b/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
@@ -120,17 +120,17 @@ bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, 
       //<Button Enums !Start!>
     case E_TXT_VAL1:
       // Clicked on edit field, so show popup box and associate with this text field
-      gslc_ElemXKeyPadTargetIdSet(&m_gui, &m_sKeyPadNum.sKeyPad, E_TXT_VAL1);
+      gslc_ElemXKeyPadTargetIdSet(&m_gui, m_pElemKeyPad, E_TXT_VAL1);
       gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
       // Preload current value
-      gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      gslc_ElemXKeyPadValSet(&m_gui, m_pElemKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
       break;
     case E_TXT_VAL2:
       // Clicked on edit field, so show popup box and associate with this text field
-      gslc_ElemXKeyPadTargetIdSet(&m_gui, &m_sKeyPadNum.sKeyPad, E_TXT_VAL2);
+      gslc_ElemXKeyPadTargetIdSet(&m_gui, m_pElemKeyPad, E_TXT_VAL2);
       gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
       // Preload current value
-      gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      gslc_ElemXKeyPadValSet(&m_gui, m_pElemKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
       break;
     case E_BTN_ADD:
       // Compute the sum and update the result

--- a/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
+++ b/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
@@ -1,0 +1,375 @@
+//
+// GUIslice Library Example
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 26 (Arduino):
+//   - Keypad input as popup for simple calculator
+//   - Use of EXTRA Fonts 
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+//
+
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XKeyPad_Num.h"
+
+// Note that font files are located within the Adafruit-GFX library folder:
+//<Fonts !Start!>
+#include <Adafruit_GFX.h>
+#include "Fonts/FreeSans12pt7b.h"
+//<Fonts !End!>
+
+// ------------------------------------------------
+// Defines for resources
+// ------------------------------------------------
+//<Resources !Start!>
+//<Resources !End!>
+
+// ------------------------------------------------
+// Enumerations for pages, elements, fonts, images
+// ------------------------------------------------
+//<Enum !Start!>
+enum { E_PG_MAIN, E_POP_KEYPAD };
+enum {
+  E_BOX1, E_BTN_ADD, E_BTN_MULT, E_BTN_SUB
+  , E_TXT7, E_TXT_VAL1, E_TXT_VAL2, E_ELEM_KEYPAD
+};
+enum { E_FONT_SANS2, E_FONT_TXT1 };
+//<Enum !End!>
+
+// ------------------------------------------------
+// Instantiate the GUI
+// ------------------------------------------------
+
+// Define the maximum number of elements per page
+//<ElementDefines !Start!>
+#define MAX_PAGE                2
+#define MAX_FONT                2
+#define MAX_ELEM_PG_MAIN 11
+#define MAX_ELEM_PG_MAIN_RAM MAX_ELEM_PG_MAIN
+#define MAX_ELEM_POP_KEYPAD 1
+#define MAX_ELEM_POP_KEYPAD_RAM MAX_ELEM_POP_KEYPAD
+//<ElementDefines !End!>
+
+// GUI Elements
+gslc_tsGui                      m_gui;
+gslc_tsDriver                   m_drv;
+gslc_tsFont                     m_asFont[MAX_FONT];
+gslc_tsPage                     m_asPage[MAX_PAGE];
+
+//<GUI_Extra_Elements !Start!>
+gslc_tsElem                 m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef              m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asPopKeypadElem[MAX_ELEM_POP_KEYPAD_RAM];
+gslc_tsElemRef              m_asPopKeypadElemRef[MAX_ELEM_POP_KEYPAD];
+
+gslc_tsXKeyPad_Num          m_sKeyPadNum; // Keypad 
+
+#define MAX_STR                 100
+
+//<GUI_Extra_Elements !End!>
+
+// ------------------------------------------------
+// Save some element references for update loop access
+// ------------------------------------------------
+//<Save_References !Start!>
+gslc_tsElemRef*  m_pElemVal1 = NULL;
+gslc_tsElemRef*  m_pElemVal2 = NULL;
+gslc_tsElemRef*  m_pElemResult = NULL;
+//<Save_References !End!>
+
+
+// ------------------------------------------------
+// Program Globals
+// ------------------------------------------------
+
+int16_t m_nPopup = -1; // Initialize to no popup active
+
+// Define debug message function
+static int16_t DebugOut(char ch) { if (ch == (char)'\n') Serial.println(""); else Serial.write(ch); return 0; }
+
+// ------------------------------------------------
+// Callback Methods
+// ------------------------------------------------
+// Common Button callback
+bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+  gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
+
+  char acTxtNum[11];
+  int16_t nVal1, nVal2, nResult;
+
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    // From the element's ID we can determine which button was pressed.
+    switch (pElem->nId) {
+      //<Button Enums !Start!>
+    case E_TXT_VAL1:
+      // Clicked on edit field, so show popup box if not already active
+      if (m_nPopup == -1) {
+        m_nPopup = E_TXT_VAL1; // Keep track of field to edit
+        gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
+        // Preload current value
+        gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+
+      }
+      break;
+    case E_TXT_VAL2:
+      // Clicked on edit field, so show popup box if not already active
+      if (m_nPopup == -1) {
+        m_nPopup = E_TXT_VAL2; // Keep track of field to edit
+        gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
+        // Preload current value
+        gslc_ElemXKeyPadValSet(&m_gui, &m_sKeyPadNum.sKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      }
+      break;
+    case E_BTN_ADD:
+      // Compute the sum and update the result
+      nVal1 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      nVal2 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      nResult = nVal1 + nVal2;
+      itoa(nResult, acTxtNum, 10);
+      gslc_ElemSetTxtStr(&m_gui, m_pElemResult, acTxtNum);
+      break;
+    case E_BTN_SUB:
+      // Compute the subtraction and update the result
+      nVal1 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      nVal2 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      nResult = nVal1 - nVal2;
+      itoa(nResult, acTxtNum, 10);
+      gslc_ElemSetTxtStr(&m_gui, m_pElemResult, acTxtNum);
+      break;
+    case E_BTN_MULT:
+      // Compute the multiplication and update the result
+      nVal1 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      nVal2 = atoi(gslc_ElemGetTxtStr(&m_gui, m_pElemVal2));
+      nResult = nVal1 * nVal2;
+      itoa(nResult, acTxtNum, 10);
+      gslc_ElemSetTxtStr(&m_gui, m_pElemResult, acTxtNum);
+      break;
+      //<Button Enums !End!>
+    default:
+      break;
+    }
+  }
+  return true;
+}
+
+// KeyPad Input Ready callback
+bool CbInputCommon(void* pvGui, void *pvElemRef, int16_t nState, void* pvData)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+  gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
+
+  char acTxtNum[11];
+  // From the element's ID we can determine which element is ready.
+  if (pElem->nId == E_ELEM_KEYPAD) {
+    switch (nState) {
+    case XKEYPAD_CB_STATE_DONE:
+      // User clicked on Enter to leave popup
+      // - If we have a popup active, pass the return value directly to
+      //   the corresponding value field
+      if (m_nPopup == E_TXT_VAL1) {
+        gslc_ElemSetTxtStr(pGui, m_pElemVal1, (char*)pvData);
+        gslc_PopupHide(&m_gui);
+        m_nPopup = -1; // Clear the active popup indicator
+      }
+      else if (m_nPopup == E_TXT_VAL2) {
+        gslc_ElemSetTxtStr(pGui, m_pElemVal2, (char*)pvData);
+        gslc_PopupHide(&m_gui);
+        m_nPopup = -1; // Clear the active popup indicator
+      }
+      else {
+        // ERROR
+      }
+      break;
+    case XKEYPAD_CB_STATE_CANCEL:
+      // User escaped from popup, so don't update values
+      gslc_PopupHide(&m_gui);
+      m_nPopup = -1; // Clear the active popup indicator
+      break;
+
+    case XKEYPAD_CB_STATE_UPDATE:
+      // KeyPad was updated, so could optionally take action here
+		  break;
+
+    default:
+      break;
+    }
+  }
+}
+
+//<Draw Callback !Start!>
+//<Draw Callback !End!>
+//<Slider Callback !Start!>
+//<Slider Callback !End!>
+//<Tick Callback !Start!>
+//<Tick Callback !End!>
+
+// ------------------------------------------------
+// Create page elements
+// ------------------------------------------------
+bool InitGUI()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  //<InitGUI !Start!>
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPage1Elem, MAX_ELEM_PG_MAIN_RAM, m_asPage1ElemRef, MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui, E_POP_KEYPAD, m_asPopKeypadElem, MAX_ELEM_POP_KEYPAD_RAM, m_asPopKeypadElemRef, MAX_ELEM_POP_KEYPAD);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_BLACK);
+
+  // -----------------------------------
+  // PAGE: E_PG_MAIN
+
+  // Create GSLC_ID_AUTO text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 90, 10, 134, 32 },
+    (char*)"Simple Calc", 0, E_FONT_SANS2);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLUE_LT4);
+
+  // Create GSLC_ID_AUTO text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 20, 65, 62, 17 },
+    (char*)"Value 1:", 0, E_FONT_TXT1);
+
+  // Create GSLC_ID_AUTO text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 20, 90, 62, 17 },
+    (char*)"Value 2:", 0, E_FONT_TXT1);
+
+  // Create GSLC_ID_AUTO text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 80, 200, 62, 12 },
+    (char*)"Result:", 0, E_FONT_TXT1);
+
+  // Create E_BOX1 box
+  pElemRef = gslc_ElemCreateBox(&m_gui, E_BOX1, E_PG_MAIN, (gslc_tsRect) { 10, 120, 300, 60 });
+
+  // Create E_TXT_VAL1 modifiable text label
+  static char m_strtxt5[11] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_VAL1, E_PG_MAIN, (gslc_tsRect) { 90, 65, 62, 17 },
+    (char*)m_strtxt5, 11, E_FONT_TXT1);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK1, GSLC_COL_BLACK, GSLC_COL_BLUE_DK4);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+  gslc_ElemSetTxtMargin(&m_gui, pElemRef, 5);
+  gslc_ElemSetClickEn(&m_gui, pElemRef, true);
+  gslc_ElemSetTouchFunc(&m_gui, pElemRef, &CbBtnCommon);
+
+  // Create E_TXT_VAL2 modifiable text label
+  static char m_strtxt6[11] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_VAL2, E_PG_MAIN, (gslc_tsRect) { 90, 90, 62, 17 },
+    (char*)m_strtxt6, 11, E_FONT_TXT1);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK1, GSLC_COL_BLACK, GSLC_COL_BLUE_DK4);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+  gslc_ElemSetTxtMargin(&m_gui, pElemRef, 5);
+  gslc_ElemSetClickEn(&m_gui, pElemRef, true);
+  gslc_ElemSetTouchFunc(&m_gui, pElemRef, &CbBtnCommon);
+
+  // Create E_TXT7 modifiable text label
+  static char m_strtxt7[11] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT7, E_PG_MAIN, (gslc_tsRect) { 150, 200, 62, 12 },
+    (char*)m_strtxt7, 11, E_FONT_TXT1);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_GREEN);
+
+  // create E_BTN_ADD button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_ADD, E_PG_MAIN,
+    (gslc_tsRect) { 30, 140, 60, 20 }, (char*)"Add", 0, E_FONT_TXT1, &CbBtnCommon);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+
+  // create E_BTN_SUB button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_SUB, E_PG_MAIN,
+    (gslc_tsRect) { 130, 140, 60, 20 }, (char*)"Subtract", 0, E_FONT_TXT1, &CbBtnCommon);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+
+  // create E_BTN_MULT button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_BTN_MULT, E_PG_MAIN,
+    (gslc_tsRect) { 220, 140, 60, 20 }, (char*)"Multiply", 0, E_FONT_TXT1, &CbBtnCommon);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+
+  // -----------------------------------
+  // PAGE: E_POP_KEYPAD
+  gslc_tsXKeyPadCfg sCfg = gslc_ElemXKeyPadCfgInit_Num();
+  gslc_ElemXKeyPadCfgSetFloatEn(&sCfg, false);
+  gslc_ElemXKeyPadCfgSetSignEn(&sCfg, true);
+  gslc_ElemXKeyPadCfgSetButtonSz(&sCfg, 25, 25);
+  pElemRef = gslc_ElemXKeyPadCreate_Num(&m_gui, E_ELEM_KEYPAD, E_POP_KEYPAD,
+    &m_sKeyPadNum, 65, 80, E_FONT_TXT1, &sCfg);
+  gslc_ElemXKeyPadValSetCb(&m_gui, pElemRef, &CbInputCommon);
+
+  //<InitGUI !End!>
+
+  return true;
+}
+
+void setup()
+{
+  // ------------------------------------------------
+  // Initialize
+  // ------------------------------------------------
+  Serial.begin(9600);
+  // Wait for USB Serial 
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  gslc_InitDebug(&DebugOut);
+
+  if (!gslc_Init(&m_gui, &m_drv, m_asPage, MAX_PAGE, m_asFont, MAX_FONT)) { return; }
+
+  // ------------------------------------------------
+  // Load Fonts
+  // ------------------------------------------------
+  //<Load_Fonts !Start!>
+  if (!gslc_FontAdd(&m_gui, E_FONT_SANS2, GSLC_FONTREF_PTR, &FreeSans12pt7b, 1)) { return; }
+  if (!gslc_FontAdd(&m_gui, E_FONT_TXT1, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+  //<Load_Fonts !End!>
+
+  // ------------------------------------------------
+  // Create graphic elements
+  // ------------------------------------------------
+  InitGUI();
+
+  // ------------------------------------------------
+  // Save some element references for quick access
+  // ------------------------------------------------
+  //<Quick_Access !Start!>
+  m_pElemVal1 = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT_VAL1);
+  m_pElemVal2 = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT_VAL2);
+  m_pElemResult = gslc_PageFindElemById(&m_gui, E_PG_MAIN, E_TXT7);
+  //<Quick_Access !End!>
+
+  //<Startup !Start!>
+  // ------------------------------------------------
+  // Start up display on first page
+  // ------------------------------------------------
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+  //<Startup !End!>
+
+}
+
+// -----------------------------------
+// Main event loop
+// -----------------------------------
+void loop()
+{
+
+  // ------------------------------------------------
+  // Update GUI Elements
+  // ------------------------------------------------
+
+
+  // ------------------------------------------------
+  // Periodically call GUIslice update function
+  // ------------------------------------------------
+  gslc_Update(&m_gui);
+
+}
+

--- a/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
+++ b/examples/arduino/ex26_ard_calc/ex26_ard_calc.ino
@@ -19,6 +19,12 @@
 #include "GUIslice.h"
 #include "GUIslice_drv.h"
 
+// Ensure optional compound element feature is enabled in the configuration
+// - Required by XKeyPad component
+#if !(GSLC_FEATURE_COMPOUND)
+  #error "Config: GSLC_FEATURE_COMPOUND required for this example but not enabled. Please update GUIslice_config."
+#endif
+
 #include "elem/XKeyPad_Num.h"
 
 // Note that font files are located within the Adafruit-GFX library folder:

--- a/examples/arduino/ex27_ard_alpha/ex27_ard_alpha.ino
+++ b/examples/arduino/ex27_ard_alpha/ex27_ard_alpha.ino
@@ -1,0 +1,290 @@
+//
+// GUIslice Library Example
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 27 (Arduino):
+//   - Keypad input as popup for text entry
+//   - Use of EXTRA Fonts 
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+//
+
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Ensure optional compound element feature is enabled in the configuration
+// - Required by XKeyPad component
+#if !(GSLC_FEATURE_COMPOUND)
+  #error "Config: GSLC_FEATURE_COMPOUND required for this example but not enabled. Please update GUIslice_config."
+#endif
+
+#include "elem/XKeyPad_Alpha.h"
+
+// Note that font files are located within the Adafruit-GFX library folder:
+//<Fonts !Start!>
+#include <Adafruit_GFX.h>
+#include "Fonts/FreeSans12pt7b.h"
+//<Fonts !End!>
+
+// ------------------------------------------------
+// Defines for resources
+// ------------------------------------------------
+//<Resources !Start!>
+//<Resources !End!>
+
+// ------------------------------------------------
+// Enumerations for pages, elements, fonts, images
+// ------------------------------------------------
+//<Enum !Start!>
+enum { E_PG_MAIN, E_POP_KEYPAD };
+enum {
+  E_BOX1,
+  E_TXT_VAL1, E_ELEM_KEYPAD
+};
+enum { E_FONT_SANS2, E_FONT_TXT1 };
+//<Enum !End!>
+
+// ------------------------------------------------
+// Instantiate the GUI
+// ------------------------------------------------
+
+// Define the maximum number of elements per page
+//<ElementDefines !Start!>
+#define MAX_PAGE                2
+#define MAX_FONT                2
+#define MAX_ELEM_PG_MAIN 3
+#define MAX_ELEM_PG_MAIN_RAM MAX_ELEM_PG_MAIN
+#define MAX_ELEM_POP_KEYPAD 1
+#define MAX_ELEM_POP_KEYPAD_RAM MAX_ELEM_POP_KEYPAD
+//<ElementDefines !End!>
+
+// GUI Elements
+gslc_tsGui                      m_gui;
+gslc_tsDriver                   m_drv;
+gslc_tsFont                     m_asFont[MAX_FONT];
+gslc_tsPage                     m_asPage[MAX_PAGE];
+
+//<GUI_Extra_Elements !Start!>
+gslc_tsElem                 m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef              m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsElem                 m_asPopKeypadElem[MAX_ELEM_POP_KEYPAD_RAM];
+gslc_tsElemRef              m_asPopKeypadElemRef[MAX_ELEM_POP_KEYPAD];
+
+gslc_tsXKeyPad_Alpha        m_sKeyPadAlpha; // Keypad 
+
+#define MAX_STR                 100
+
+//<GUI_Extra_Elements !End!>
+
+// ------------------------------------------------
+// Save some element references for update loop access
+// ------------------------------------------------
+//<Save_References !Start!>
+gslc_tsElemRef*  m_pElemVal1 = NULL;
+gslc_tsElemRef*  m_pElemKeyPad = NULL;
+//<Save_References !End!>
+
+
+// ------------------------------------------------
+// Program Globals
+// ------------------------------------------------
+
+// Define debug message function
+static int16_t DebugOut(char ch) { if (ch == (char)'\n') Serial.println(""); else Serial.write(ch); return 0; }
+
+// ------------------------------------------------
+// Callback Methods
+// ------------------------------------------------
+// Common Button callback
+bool CbBtnCommon(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+  gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
+
+  char acTxtNum[11];
+  int32_t nVal1;
+
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    // From the element's ID we can determine which button was pressed.
+    switch (pElem->nId) {
+      //<Button Enums !Start!>
+    case E_TXT_VAL1:
+      // Clicked on edit field, so show popup box and associate with this text field
+      gslc_ElemXKeyPadTargetIdSet(&m_gui, m_pElemKeyPad, E_TXT_VAL1);
+      gslc_PopupShow(&m_gui, E_POP_KEYPAD, true);
+      // Preload current value
+      gslc_ElemXKeyPadValSet(&m_gui, m_pElemKeyPad, gslc_ElemGetTxtStr(&m_gui, m_pElemVal1));
+      break;
+      //<Button Enums !End!>
+    default:
+      break;
+    }
+  }
+  return true;
+}
+
+// KeyPad Input Ready callback
+bool CbInputCommon(void* pvGui, void *pvElemRef, int16_t nState, void* pvData)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = pElemRef->pElem;
+  gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
+
+  char acTxtNum[11];
+  // From the element's ID we can determine which element is ready.
+  if (pElem->nId == E_ELEM_KEYPAD) {
+    int16_t nTargetElemId = gslc_ElemXKeyPadDataTargetIdGet(pGui, pvData);
+    switch (nState) {
+    case XKEYPAD_CB_STATE_DONE:
+      // User clicked on Enter to leave popup
+      // - If we have a popup active, pass the return value directly to
+      //   the corresponding value field
+      if (nTargetElemId == E_TXT_VAL1) {
+        gslc_ElemSetTxtStr(pGui, m_pElemVal1, gslc_ElemXKeyPadDataValGet(pGui, pvData));
+        gslc_PopupHide(&m_gui);
+      }
+      else {
+        // ERROR
+      }
+      break;
+    case XKEYPAD_CB_STATE_CANCEL:
+      // User escaped from popup, so don't update values
+      gslc_PopupHide(&m_gui);
+      break;
+
+    case XKEYPAD_CB_STATE_UPDATE:
+      // KeyPad was updated, so could optionally take action here
+      break;
+
+    default:
+      break;
+    }
+  }
+}
+
+//<Draw Callback !Start!>
+//<Draw Callback !End!>
+//<Slider Callback !Start!>
+//<Slider Callback !End!>
+//<Tick Callback !Start!>
+//<Tick Callback !End!>
+
+// ------------------------------------------------
+// Create page elements
+// ------------------------------------------------
+bool InitGUI()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  //<InitGUI !Start!>
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPage1Elem, MAX_ELEM_PG_MAIN_RAM, m_asPage1ElemRef, MAX_ELEM_PG_MAIN);
+  gslc_PageAdd(&m_gui, E_POP_KEYPAD, m_asPopKeypadElem, MAX_ELEM_POP_KEYPAD_RAM, m_asPopKeypadElemRef, MAX_ELEM_POP_KEYPAD);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_BLACK);
+
+  // -----------------------------------
+  // PAGE: E_PG_MAIN
+
+  // Create GSLC_ID_AUTO text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 90, 10, 134, 32 },
+    (char*)"Alpha KeyPad", 0, E_FONT_SANS2);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLUE_LT4);
+
+  // Create GSLC_ID_AUTO text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 20, 65, 62, 17 },
+    (char*)"Name:", 0, E_FONT_TXT1);
+
+  // Create E_TXT_VAL1 modifiable text label
+  static char m_strtxt5[11] = "";
+  pElemRef = gslc_ElemCreateTxt(&m_gui, E_TXT_VAL1, E_PG_MAIN, (gslc_tsRect) { 90, 65, 62, 17 },
+    (char*)m_strtxt5, 11, E_FONT_TXT1);
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK1, GSLC_COL_BLACK, GSLC_COL_BLUE_DK4);
+  gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
+  gslc_ElemSetTxtMargin(&m_gui, pElemRef, 5);
+  gslc_ElemSetClickEn(&m_gui, pElemRef, true);
+  gslc_ElemSetTouchFunc(&m_gui, pElemRef, &CbBtnCommon);
+  m_pElemVal1 = pElemRef; // Save for later
+
+
+  // -----------------------------------
+  // PAGE: E_POP_KEYPAD
+  gslc_tsXKeyPadCfg sCfg = gslc_ElemXKeyPadCfgInit_Alpha();
+  gslc_ElemXKeyPadCfgSetButtonSz(&sCfg, 25, 25);
+  m_pElemKeyPad = gslc_ElemXKeyPadCreate_Alpha(&m_gui, E_ELEM_KEYPAD, E_POP_KEYPAD,
+    &m_sKeyPadAlpha, 65, 80, E_FONT_TXT1, &sCfg);
+  gslc_ElemXKeyPadValSetCb(&m_gui, m_pElemKeyPad, &CbInputCommon);
+
+  //<InitGUI !End!>
+
+  return true;
+}
+
+void setup()
+{
+  // ------------------------------------------------
+  // Initialize
+  // ------------------------------------------------
+  Serial.begin(9600);
+  // Wait for USB Serial 
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  gslc_InitDebug(&DebugOut);
+
+  if (!gslc_Init(&m_gui, &m_drv, m_asPage, MAX_PAGE, m_asFont, MAX_FONT)) { return; }
+
+  // ------------------------------------------------
+  // Load Fonts
+  // ------------------------------------------------
+  //<Load_Fonts !Start!>
+  if (!gslc_FontAdd(&m_gui, E_FONT_SANS2, GSLC_FONTREF_PTR, &FreeSans12pt7b, 1)) { return; }
+  if (!gslc_FontAdd(&m_gui, E_FONT_TXT1, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+  //<Load_Fonts !End!>
+
+  // ------------------------------------------------
+  // Create graphic elements
+  // ------------------------------------------------
+  InitGUI();
+
+  // ------------------------------------------------
+  // Save some element references for quick access
+  // ------------------------------------------------
+  //<Quick_Access !Start!>
+  //<Quick_Access !End!>
+
+  //<Startup !Start!>
+  // ------------------------------------------------
+  // Start up display on first page
+  // ------------------------------------------------
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+  //<Startup !End!>
+
+}
+
+// -----------------------------------
+// Main event loop
+// -----------------------------------
+void loop()
+{
+
+  // ------------------------------------------------
+  // Update GUI Elements
+  // ------------------------------------------------
+
+
+  // ------------------------------------------------
+  // Periodically call GUIslice update function
+  // ------------------------------------------------
+  gslc_Update(&m_gui);
+
+}
+

--- a/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
+++ b/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
@@ -108,12 +108,14 @@ bool CbBtnCommon(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int1
 }
 
 // Common Input Ready callback
-bool CbInputCommon(void* pvGui,void *pvElemRef)
+bool CbInputCommon(void* pvGui,void *pvElemRef, int16_t nState, void* pvData)
 {
   gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
   gslc_tsElem* pElem = pElemRef->pElem;
   
   char acTxtNum[4];
+
+  // Assume callback nState == XSPINNER_CB_STATE_UPDATE
 
   // From the element's ID we can determine which input field is ready.
   if (pElem->nId == E_ELEM_COMP1) {

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -1718,6 +1718,8 @@ void gslc_SetStackPage(gslc_tsGui* pGui, uint8_t nStackPos, int16_t nPageId)
   #endif
 
   // A change of page should always force a future redraw
+  // TODO: Consider that showing a popup could potentially optimize out
+  // the forced redraw step.
   if (nPageSaved != nPageId) {
     gslc_PageRedrawSet(pGui,true);
   }
@@ -1908,6 +1910,10 @@ void gslc_PageRedrawGo(gslc_tsGui* pGui)
   // TODO: Handle GSLC_EVTSUB_DRAW_NEEDED
   uint32_t nSubType = (bPageRedraw)?GSLC_EVTSUB_DRAW_FORCE:GSLC_EVTSUB_DRAW_NEEDED;
   void*    pvData = NULL;
+
+  // TODO: Consider creating a flag that indicates whether any elements
+  // on the page have requested redraw. This would enable us to skip
+  // over this exhaustive search every time we call Update()
 
   // Issue page redraw events to all pages in stack
   // - Start from bottom page in stack first
@@ -2939,11 +2945,10 @@ void gslc_ElemSetRedraw(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
   // - For now, assume no need to trigger a parent redraw.
   // - TODO: Consider detecting scenarios in which we should
   //   propagate the redraw to the parent.
-
-  //gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
-  //if (pElem->pElemRefParent != NULL) {
-  //  gslc_ElemSetRedraw(pGui,pElem->pElemRefParent,eRedraw);
-  //}
+  gslc_tsElem*  pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  if (pElem->pElemRefParent != NULL) {
+    gslc_ElemSetRedraw(pGui,pElem->pElemRefParent,eRedraw);
+  }
 #endif
 }
 
@@ -4045,8 +4050,14 @@ gslc_tsElemRef* gslc_CollectElemAdd(gslc_tsGui* pGui,gslc_tsCollect* pCollect,co
     pCollect->nElemRefCnt++;
   }
 
+  // Fetch a pointer to the element reference array entry
+  gslc_tsElemRef* pElemRef = &(pCollect->asElemRef[nElemRefInd]);
+
+  // Mark any newly added element as requiring redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+
   // Return the new element reference
-  return &(pCollect->asElemRef[nElemRefInd]);
+  return pElemRef;
 }
 
 bool gslc_CollectGetRedraw(gslc_tsGui* pGui,gslc_tsCollect* pCollect)
@@ -4103,6 +4114,7 @@ gslc_tsElemRef* gslc_ElemAdd(gslc_tsGui* pGui,int16_t nPageId,gslc_tsElem* pElem
 
   gslc_tsCollect* pCollect = &pPage->sCollect;
   gslc_tsElemRef* pElemRefAdd = gslc_CollectElemAdd(pGui,pCollect,pElem,eFlags);
+
   return pElemRefAdd;
 }
 

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -500,7 +500,7 @@ typedef bool (*GSLC_CB_TICK)(void* pvGui,void* pvElemRef);
 typedef bool (*GSLC_CB_PIN_POLL)(void* pvGui,int16_t* pnPinInd,int16_t* pnPinVal);
 
 /// Callback function for element input ready
-typedef bool (*GSLC_CB_INPUT)(void* pvGui,void* pvElemRef);
+typedef bool (*GSLC_CB_INPUT)(void* pvGui,void* pvElemRef,int16_t nStatus,void* pvData);
 
 // -----------------------------------------------------------------------
 // Structures

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.21"
+#define GUISLICE_VER "0.11.3.22"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.13"
+#define GUISLICE_VER "0.11.3.14"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.15"
+#define GUISLICE_VER "0.11.3.16"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.14"
+#define GUISLICE_VER "0.11.3.15"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.11.3.6"
+#define GUISLICE_VER "0.11.3.7"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XKeyPad.c
+++ b/src/elem/XKeyPad.c
@@ -251,14 +251,10 @@ gslc_tsElemRef* gslc_ElemXKeyPadCreateBase(gslc_tsGui* pGui, int16_t nElemId, in
 
 }
 
-void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, const char* pStrBuf)
+void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, const char* pStrBuf)
 {
-  if (pKeyPad == NULL) {
-    #if defined(DEBUG_LOG)
-    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXKeyPadValSet() element (ID=%d) has NULL pXData\n", pElem->nId);
-    #endif
-    return;
-  }
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return;
 
   // Copy over the new value string
   strncpy(pKeyPad->acValStr, pStrBuf, XKEYPAD_VAL_LEN);
@@ -284,14 +280,10 @@ void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, const cha
   gslc_ElemSetRedraw(pGui,pTxtElemRef,GSLC_REDRAW_INC);
 }
 
-void gslc_ElemXKeyPadTargetIdSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, int16_t nTargetId)
+void gslc_ElemXKeyPadTargetIdSet(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nTargetId)
 {
-  if (pKeyPad == NULL) {
-    #if defined(DEBUG_LOG)
-    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXKeyPadTargetIdSet() element (ID=%d) has NULL pXData\n", pElem->nId);
-    #endif
-    return;
-  }
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return;
   pKeyPad->nTargetId = nTargetId;
 }
 
@@ -323,15 +315,10 @@ char* gslc_ElemXKeyPadDataValGet(gslc_tsGui* pGui, void* pvData)
 
 // NOTE: API changed to pass nStrBufLen (total buffer size including terminator)
 //       instead of nStrBufMax (max index value)
-// TODO: Revise params for API consistency?
-bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, char* pStrBuf, uint8_t nStrBufLen)
+bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, char* pStrBuf, uint8_t nStrBufLen)
 {
-  if (pKeyPad == NULL) {
-    #if defined(DEBUG_LOG)
-    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXKeyPadValGet() element (ID=%d) has NULL pXData\n", pElem->nId);
-    #endif
-    return false;
-  }
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return false;
 
   // return our keypad value field
   char* pValue = pKeyPad->acValStr;

--- a/src/elem/XKeyPad.c
+++ b/src/elem/XKeyPad.c
@@ -132,6 +132,8 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
     pElemRefTmp = gslc_ElemCreateBtnTxt(pGui, nKeyId, GSLC_PAGE_NONE,
       (gslc_tsRect) { nOffsetX + (nCol*nButtonSzW), nOffsetY + (nRow*nButtonSzH), nButtonW - 1, nButtonH - 1 },
       pKeyStr, sizeof(pKeyStr), nFontId, &gslc_ElemXKeyPadClick);
+    // For the text buttons, optionally use rounded profile if enabled
+    gslc_ElemSetRoundEn(pGui, pElemRefTmp, pConfig->bRoundEn);
   }
 
   // Set color
@@ -666,6 +668,12 @@ void gslc_ElemXKeyPadCfgSetSignEn(gslc_tsXKeyPadCfg* pConfig, bool bEn)
 {
   pConfig->bSignEn = bEn;
 }
+
+void gslc_ElemXKeyPadCfgSetRoundEn(gslc_tsXKeyPadCfg* pConfig, bool bEn)
+{
+  pConfig->bRoundEn = bEn;
+}
+
 
 // FIXME: Runtime API not fully functional yet - Do not use
 void gslc_ElemXKeyPadSetFloatEn(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, bool bEn)

--- a/src/elem/XKeyPad.c
+++ b/src/elem/XKeyPad.c
@@ -89,7 +89,7 @@ const char KEYPAD_DISP_DECIMAL_PT = '.';
 
 
 void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId, bool bTxtField, int16_t nRow, int16_t nCol, int8_t nRowSpan, int8_t nColSpan,
-  gslc_tsColor cColFill, gslc_tsColor cColGlow)
+  gslc_tsColor cColFill, gslc_tsColor cColGlow, bool bVisible)
 {
   gslc_tsXKeyPadCfg* pConfig;
   char* pKeyStr = NULL;
@@ -137,6 +137,14 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   // Set color
   gslc_ElemSetTxtCol(pGui, pElemRefTmp, GSLC_COL_WHITE);
   gslc_ElemSetCol(pGui, pElemRefTmp, GSLC_COL_WHITE, cColFill, cColGlow);
+
+  // Set the visibility status
+  // FIXME: Need to fix dynamic visibility change
+  // gslc_ElemSetVisible(pGui, pElemRefTmp, bVisible);
+  if (!bVisible) {
+    // For now, skip addition of invisible buttons
+	  return;
+  }
 
   // Add element to compound element collection
   pElemTmp = gslc_GetElemFromRef(pGui, pElemRefTmp);
@@ -652,13 +660,33 @@ void gslc_ElemXKeyPadCfgSetButtonSz(gslc_tsXKeyPadCfg* pConfig, int8_t nButtonSz
 void gslc_ElemXKeyPadCfgSetFloatEn(gslc_tsXKeyPadCfg* pConfig, bool bEn)
 {
   pConfig->bFloatEn = bEn;
-  //GSLC_DEBUG_PRINT("SetFloatEn: FloatEn=%d\n", pConfig->bFloatEn);
 }
 
 void gslc_ElemXKeyPadCfgSetSignEn(gslc_tsXKeyPadCfg* pConfig, bool bEn)
 {
   pConfig->bSignEn = bEn;
 }
+
+// FIXME: Runtime API not fully functional yet - Do not use
+void gslc_ElemXKeyPadSetFloatEn(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, bool bEn)
+{
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return;
+  pKeyPad->sConfig.bFloatEn = bEn;
+  // Mark as needing full redraw as button visibility may have changed
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+// FIXME: Runtime API not fully functional yet - Do not use
+void gslc_ElemXKeyPadSetSignEn(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, bool bEn)
+{
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return;
+  pKeyPad->sConfig.bSignEn = bEn;
+  // Mark as needing full redraw as button visibility may have changed
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
 
 
 #endif // GSLC_FEATURE_COMPOUND

--- a/src/elem/XKeyPad.c
+++ b/src/elem/XKeyPad.c
@@ -1,0 +1,623 @@
+// =======================================================================
+// GUIslice library extension: XKeyPad control
+// - Paul Conti, Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XKeyPad.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XKeyPad.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+#if (GSLC_FEATURE_COMPOUND)
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: KeyPad
+// - Keypad element with numeric input
+// - Optionally supports floating point values
+// - Optionally supports negative values
+// ============================================================================
+
+// Define the button labels
+// - TODO: Create more efficient storage for the labels
+//   so that it doesn't consume 4 bytes even for labels
+//   that can be generated (eg. 0..9, a--z, etc.)
+// - TODO: Define digit & alphanumeric keypads
+// - NOTE: Not using "const char" in order to support
+//   modification of labels by user.
+
+
+const char KEYPAD_DISP_NEGATIVE = '-';
+const char KEYPAD_DISP_DECIMAL_PT = '.';
+
+
+
+// --------------------------------------------------------------------------
+// Create the keypad definition
+// --------------------------------------------------------------------------
+
+
+void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId, bool bTxtField, int16_t nRow, int16_t nCol, int8_t nRowSpan, int8_t nColSpan,
+  gslc_tsColor cColFill, gslc_tsColor cColGlow)
+{
+  gslc_tsXKeyPadCfg* pConfig;
+  char* pKeyStr = NULL;
+
+  pConfig = &(pXData->sConfig);
+
+  gslc_tsElemRef* pElemRefTmp = NULL;
+  gslc_tsElem*    pElemTmp = NULL;
+
+  int16_t nButtonSzW = pConfig->nButtonSzW;
+  int16_t nButtonSzH = pConfig->nButtonSzH;
+  int16_t nOffsetX = pConfig->nOffsetX;
+  int16_t nOffsetY = pConfig->nOffsetY;
+  int8_t nFontId = pConfig->nFontId;
+
+  int16_t nButtonW = (nColSpan * nButtonSzW);
+  int16_t nButtonH = (nRowSpan * nButtonSzH);
+
+  // Fetch the keypad key string
+  if (bTxtField) {
+    pKeyStr = (char*)pXData->acValStr;
+  } else {
+    XKEYPAD_LOOKUP pfuncLookup = pXData->pfuncLookup;
+    int16_t nKeyInd = (*pfuncLookup)(pGui, nKeyId);
+    pKeyStr = pXData->pacKeys[nKeyInd];
+  }
+
+  //GSLC_DEBUG_PRINT("DBG: KeyId=%d R=%d C=%d str=[%s] SubElemMax=%d\n", nKeyId, nRow,nCol,pKeyStr,pXData->nSubElemMax);
+
+  if (bTxtField) {
+    // Text field
+    pElemRefTmp = gslc_ElemCreateTxt(pGui, nKeyId, GSLC_PAGE_NONE,
+      (gslc_tsRect) { nOffsetX + (nCol*nButtonSzW), nOffsetY + (nRow*nButtonSzH), nButtonW-1, nButtonH - 1 },
+      pKeyStr, XKEYPAD_VAL_LEN, nFontId);
+    gslc_ElemSetFrameEn(pGui, pElemRefTmp, true);
+    gslc_ElemSetTxtMargin(pGui, pElemRefTmp, 5); // Apply default margin
+  } else {
+    // Text button
+    //GSLC_DEBUG_PRINT("DrawBtn: %d [%s] @ r=%d,c=%d,width=%d\n", nKeyId, pXData->pacKeys[nKeyId], nRow, nCol, nButtonW);
+    pElemRefTmp = gslc_ElemCreateBtnTxt(pGui, nKeyId, GSLC_PAGE_NONE,
+      (gslc_tsRect) { nOffsetX + (nCol*nButtonSzW), nOffsetY + (nRow*nButtonSzH), nButtonW - 1, nButtonH - 1 },
+      pKeyStr, sizeof(pKeyStr), nFontId, &gslc_ElemXKeyPadClick);
+  }
+
+  // Set color
+  gslc_ElemSetTxtCol(pGui, pElemRefTmp, GSLC_COL_WHITE);
+  gslc_ElemSetCol(pGui, pElemRefTmp, GSLC_COL_WHITE, cColFill, cColGlow);
+
+  // Add element to compound element collection
+  pElemTmp = gslc_GetElemFromRef(pGui, pElemRefTmp);
+  pElemRefTmp = gslc_CollectElemAdd(pGui, &pXData->sCollect, pElemTmp, GSLC_ELEMREF_DEFAULT);
+}
+
+gslc_tsElemRef* gslc_ElemXKeyPadCreateBase(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXKeyPad* pXData, int16_t nX0, int16_t nY0, int8_t nFontId, gslc_tsXKeyPadCfg* pConfig,
+  XKEYPAD_CREATE pfuncCreate, XKEYPAD_LOOKUP pfuncLookup)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXKeyPadCreate";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return NULL;
+  }
+
+  // Fetch config options
+  int8_t nButtonSzW = pConfig->nButtonSzW;
+  int8_t nButtonSzH = pConfig->nButtonSzH;
+
+  gslc_tsRect rElem;
+  rElem.x = nX0;
+  rElem.y = nY0;
+  rElem.w = (nButtonSzW * pConfig->nMaxCols) + (2 * pConfig->nFrameMargin);
+  rElem.h = (nButtonSzH * pConfig->nMaxRows) + (2 * pConfig->nFrameMargin);
+
+  gslc_tsElem sElem;
+
+  // Initialize composite element
+  sElem = gslc_ElemCreate(pGui, nElemId, nPage, GSLC_TYPEX_KEYPAD, rElem, NULL, 0, GSLC_FONT_NONE);
+  sElem.nFeatures |= GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures |= GSLC_ELEM_FEA_CLICK_EN;
+  sElem.nFeatures &= ~GSLC_ELEM_FEA_GLOW_EN;  // Don't need to glow outer element
+  sElem.nGroup = GSLC_GROUP_ID_NONE;
+
+  gslc_CollectReset(&pXData->sCollect, pXData->psElem, pXData->nSubElemMax, pXData->psElemRef, pXData->nSubElemMax);
+
+  sElem.pXData = (void*)(pXData);
+  // Specify the custom drawing callback
+  sElem.pfuncXDraw = &gslc_ElemXKeyPadDraw;
+  // Specify the custom touch tracking callback
+  sElem.pfuncXTouch = &gslc_ElemXKeyPadTouch;
+
+  // shouldn't be used
+  sElem.colElemFill = GSLC_COL_BLACK;
+  sElem.colElemFillGlow = GSLC_COL_BLACK;
+  sElem.colElemFrame = GSLC_COL_BLUE;
+  sElem.colElemFrameGlow = GSLC_COL_BLUE_LT4;
+
+  // Now create the sub elements
+  gslc_tsElemRef* pElemRefTmp = NULL;
+  gslc_tsElem*    pElemTmp = NULL;
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Determine offset coordinate of compound element so that we can
+  // specify relative positioning during the sub-element Create() operations.
+  int16_t nOffsetX = nX0 + pConfig->nFrameMargin;
+  int16_t nOffsetY = nY0 + pConfig->nFrameMargin;
+
+  // Reset value string
+  memset(pXData->acValStr, 0, XKEYPAD_VAL_LEN);
+  pXData->nValStrPos = 0;
+
+  pXData->pacKeys = pConfig->pacKeys;
+  pXData->pfuncCb = NULL;
+  pXData->pfuncLookup = pfuncLookup;
+  pXData->bValPositive = true;
+  pXData->bValDecimalPt = false;
+
+  // Update config with constructor settings
+  pConfig->nFontId = nFontId;
+  pConfig->nOffsetX = nOffsetX;
+  pConfig->nOffsetY = nOffsetY;
+
+
+  // Copy content into local structure
+  pXData->sConfig = *pConfig;
+
+  // Create the keypad definition
+  // -- Call XKeyPadCreateKeys()
+  if (pfuncCreate != NULL) {
+    (*pfuncCreate)(pGui, pXData);
+  }
+
+  // Now proceed to add the compound element to the page
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui, nPage, &sElem, GSLC_ELEMREF_DEFAULT);
+
+    // Now propagate the parent relationship to enable a cascade
+    // of redrawing from low-level elements to the top
+    gslc_CollectSetParent(pGui, &pXData->sCollect, pElemRef);
+    return pElemRef;
+  }
+  else {
+    #if defined(DEBUG_LOG)
+    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXKeyPadCreate(%s) Compound elements inside compound elements not supported\n", "");
+    #endif
+    return NULL;
+  }
+
+}
+
+void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, const char* pStrBuf)
+{
+  if (pKeyPad == NULL) {
+    #if defined(DEBUG_LOG)
+    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXKeyPadValSet() element (ID=%d) has NULL pXData\n", pElem->nId);
+    #endif
+    return;
+  }
+
+  // Copy over the new value string
+  strncpy(pKeyPad->acValStr, pStrBuf, XKEYPAD_VAL_LEN);
+  pKeyPad->acValStr[XKEYPAD_VAL_LEN - 1] = 0; // Force null terminate
+
+  // andle negation and floating point detection
+  pKeyPad->bValPositive = true;
+  if (pKeyPad->acValStr[0] == KEYPAD_DISP_NEGATIVE) {
+    pKeyPad->bValPositive = false;
+  }
+  pKeyPad->bValDecimalPt = false;
+  if (strchr(pKeyPad->acValStr, KEYPAD_DISP_DECIMAL_PT)) {
+    pKeyPad->bValDecimalPt = true;
+  }
+
+  // Update the current buffer position
+  pKeyPad->nValStrPos = strlen(pKeyPad->acValStr);
+
+  // Find element associated with text field
+  gslc_tsElemRef* pTxtElemRef = gslc_CollectFindElemById(pGui, &pKeyPad->sCollect, KEYPAD_ID_TXT);
+
+  // Mark as needing redraw
+  gslc_ElemSetRedraw(pGui,pTxtElemRef,GSLC_REDRAW_INC);
+}
+
+
+// NOTE: API changed to pass nStrBufLen (total buffer size including terminator)
+//       instead of nStrBufMax (max index value)
+// TODO: Revise params for API consistency?
+bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, char* pStrBuf, uint8_t nStrBufLen)
+{
+  if (pKeyPad == NULL) {
+    #if defined(DEBUG_LOG)
+    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXKeyPadValGet() element (ID=%d) has NULL pXData\n", pElem->nId);
+    #endif
+    return false;
+  }
+
+  // return our keypad value field
+  char* pValue = pKeyPad->acValStr;
+
+  // - Check for negation flag
+  // - If negative, copy minus sign
+  // - Copy the remainder of the string
+  // FIXME: check for shortest of XKEYPAD_VAL_LEN & nStrBufLen
+  char* pBufPtr = pStrBuf;
+  uint8_t nMaxCopyLen = nStrBufLen - 1;
+  // FIXME: Do we still need to do this step?
+  if (!pKeyPad->bValPositive) {
+    *pBufPtr = KEYPAD_DISP_NEGATIVE;
+    pBufPtr++;
+    nMaxCopyLen--;
+  }
+  strncpy(pBufPtr, pKeyPad->acValStr, nMaxCopyLen);
+  pStrBuf[nStrBufLen-1] = '\0';  // Force termination
+
+  // TODO: Do we need to reset the contents?
+
+  return true;
+}
+
+
+// Redraw the KeyPad element
+// - When drawing a KeyPad we do not clear the background.
+//   We do redraw the sub-element collection.
+bool gslc_ElemXKeyPadDraw(void* pvGui, void* pvElemRef, gslc_teRedrawType eRedraw)
+{
+  gslc_tsGui*       pGui  = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef = (gslc_tsElemRef*)(pvElemRef);
+
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return false;
+
+  gslc_tsElem*    pElem = gslc_GetElemFromRef(pGui, pElemRef);
+
+  // Draw any parts of the compound element itself
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    // Force the fill to ensure the background doesn't bleed thorugh gaps
+    // between the sub-elements
+    gslc_DrawFillRect(pGui, pElem->rElem, pElem->colElemFill);
+    if (pElem->nFeatures & GSLC_ELEM_FEA_FRAME_EN) {
+      gslc_DrawFrameRect(pGui, pElem->rElem, pElem->colElemFrame);
+    }
+  }
+
+  // Draw the sub-elements
+  gslc_tsCollect* pCollect = &pKeyPad->sCollect;
+
+  if (eRedraw != GSLC_REDRAW_NONE) {
+    uint8_t sEventSubType = GSLC_EVTSUB_DRAW_NEEDED;
+    if (eRedraw == GSLC_REDRAW_FULL) {
+      sEventSubType = GSLC_EVTSUB_DRAW_FORCE;
+    }
+    gslc_tsEvent  sEvent = gslc_EventCreate(pGui, GSLC_EVT_DRAW, sEventSubType, (void*)(pCollect), NULL);
+    gslc_CollectEvent(pGui, sEvent);
+  }
+
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_NONE);
+
+  // Mark page as needing flip
+  gslc_PageFlipSet(pGui, true);
+
+  return true;
+}
+
+void gslc_ElemXKeyPadValSetCb(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, GSLC_CB_INPUT pfuncCb)
+{
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return;
+
+  pKeyPad->pfuncCb = pfuncCb;
+}
+
+// Change the sign of the number string
+// - This function also performs in-place shifting of the content
+void gslc_ElemXKeyPadValSetSign(gslc_tsGui* pGui, gslc_tsElemRef *pElemRef, bool bPositive)
+{
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return;
+
+  char* pStrBuf = pKeyPad->acValStr;
+
+  //GSLC_DEBUG_PRINT("SetSign: old=%d new=%d\n", pKeyPad->bValPositive, bPositive);
+  if (pKeyPad->bValPositive == bPositive) {
+    // No change to sign
+    return;
+  }
+
+  //GSLC_DEBUG_PRINT("SetSign:   str_old=[%s] idx=%d\n", pStrBuf,pKeyPad->nValStrPos);
+
+  if ((pKeyPad->bValPositive) && (!bPositive)) {
+    // Change from positive to negative
+    // - Shift string right one position, and replace first position with minus sign
+    // - Increase current buffer position
+    memmove(pStrBuf+1, pStrBuf, XKEYPAD_VAL_LEN-1);
+    pStrBuf[0] = KEYPAD_DISP_NEGATIVE; // Overwrite with minus sign
+    pStrBuf[XKEYPAD_VAL_LEN-1] = 0; // Force terminate
+    pKeyPad->nValStrPos++; // Advance buffer position
+  } else if ((!pKeyPad->bValPositive) && (bPositive)) {
+    // Change from negative to positive
+    // - Shift string left one position, overwriting the minus sign
+    memmove(pStrBuf, pStrBuf+1, XKEYPAD_VAL_LEN-1);
+    pStrBuf[XKEYPAD_VAL_LEN-1] = 0; // Force terminate
+    if (pKeyPad->nValStrPos > 0) {
+      // Expect that original position should be non-zero if previously minux
+      pKeyPad->nValStrPos--; // Reduce buffer position
+    }
+  }
+
+  //GSLC_DEBUG_PRINT("SetSign:   str_new=[%s] idx=%d\n", pStrBuf,pKeyPad->nValStrPos);
+
+  // Update sign state
+  pKeyPad->bValPositive = bPositive;
+
+  // The text string sub-element content has already been updated,
+  // so now we can simply mark it for redraw
+  gslc_tsElemRef* pTxtElemRef = gslc_CollectFindElemById(pGui, &pKeyPad->sCollect, KEYPAD_ID_TXT);
+  gslc_ElemSetRedraw(pGui,pTxtElemRef,GSLC_REDRAW_INC);
+
+}
+
+bool ElemXKeyPadAddChar(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, char ch)
+{
+  bool bRedraw = false;
+  // Do we have space for this character?
+  if (pKeyPad->nValStrPos < XKEYPAD_VAL_LEN - 1) {
+    pKeyPad->acValStr[pKeyPad->nValStrPos] = ch;
+    pKeyPad->nValStrPos++;
+    pKeyPad->acValStr[pKeyPad->nValStrPos] = '\0'; // Zero terminate
+    bRedraw = true;
+  }
+  return bRedraw;
+}
+
+// Handle the compound element main functionality
+// - This routine is called by gslc_ElemEvent() to handle
+//   any click events that resulted from the touch tracking process.
+// - The code here will generally represent the core
+//   functionality of the compound element and any communication
+//   between sub-elements.
+// - pvElemRef is a void pointer to the element ref being tracked. From
+//   the pElemRefParent member we can get the parent/compound element
+//   data structures.
+bool gslc_ElemXKeyPadClick(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  #if defined(DRV_TOUCH_NONE)
+  return false;
+  #else
+
+  gslc_tsGui* pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+
+  // Fetch the parent of the clicked element which is the compound
+  // element itself. This enables us to access the extra control data.
+  gslc_tsElemRef*    pElemRefParent = pElem->pElemRefParent;
+  if (pElemRefParent == NULL) {
+    GSLC_DEBUG_PRINT("ERROR: ElemXKeyPadClick(%s) parent ElemRef ptr NULL\n", "");
+    return false;
+  }
+
+  gslc_tsXKeyPad* pKeyPad = (gslc_tsXKeyPad*)gslc_GetXDataFromRef(pGui, pElemRefParent, GSLC_TYPEX_KEYPAD, __LINE__);
+  if (!pKeyPad) return false;
+
+  //GSLC_DEBUG_PRINT("KeyPad Click   Touch=%d\n", eTouch);
+
+  // Handle the various button presses
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    // Get the tracked element ID
+    gslc_tsElemRef* pElemRefTracked = pKeyPad->sCollect.pElemRefTracked;
+    gslc_tsElem*    pElemTracked = gslc_GetElemFromRef(pGui, pElemRefTracked);
+
+    int nSubElemId = pElemTracked->nId;
+    int16_t nKeyInd = 0;
+    bool bValRedraw = false;
+
+    GSLC_CB_INPUT pfuncXInput = pKeyPad->pfuncCb;
+    XKEYPAD_LOOKUP pfuncLookup = pKeyPad->pfuncLookup;
+
+  if (pfuncLookup != NULL) {
+      // FIXME: ERROR
+  }
+
+    //GSLC_DEBUG_PRINT("KeyPad Click   ID=%d\n", nSubElemId);
+
+    switch (nSubElemId) {
+
+    case KEYPAD_ID_ENTER:
+      //GSLC_DEBUG_PRINT("KeyPad Key=ENT\n", "");
+      //GSLC_DEBUG_PRINT("KeyPad Done Str=[%s]\n", pKeyPad->acValStr);
+
+      // Issue callback with Done status
+      if (pfuncXInput != NULL) {
+        (*pfuncXInput)(pvGui, (void*)(pElemRefParent), XKEYPAD_CB_STATE_DONE, (void*)pKeyPad->acValStr);
+      }
+
+      // Clear the contents
+      memset(pKeyPad->acValStr, 0, XKEYPAD_VAL_LEN);
+      pKeyPad->nValStrPos = 0;
+      break;
+
+    case KEYPAD_ID_ESC:
+      //GSLC_DEBUG_PRINT("KeyPad Key=ESC\n", "");
+      // Clear the contents
+      memset(pKeyPad->acValStr, 0, XKEYPAD_VAL_LEN);
+      pKeyPad->nValStrPos = 0;
+      bValRedraw = true;
+      //GSLC_DEBUG_PRINT("KeyPad Done Str=[%s]\n", pKeyPad->acValStr);
+      // Issue callback with Cancel status
+      if (pfuncXInput != NULL) {
+        (*pfuncXInput)(pvGui, (void*)(pElemRefParent), XKEYPAD_CB_STATE_CANCEL, (void*)pKeyPad->acValStr);
+      }
+      break;
+
+    case KEYPAD_ID_DECIMAL:
+      //GSLC_DEBUG_PRINT("KeyPad Key=Decimal\n", "");
+      if (!pKeyPad->sConfig.bFloatEn) break; // Ignore if floating point not enabled
+      if (!pKeyPad->bValDecimalPt) {
+        bValRedraw |= ElemXKeyPadAddChar(pGui, pKeyPad, KEYPAD_DISP_DECIMAL_PT);
+      }
+      break;
+
+    case KEYPAD_ID_MINUS:
+      //GSLC_DEBUG_PRINT("KeyPad Key=Minus\n", "");
+      if (!pKeyPad->sConfig.bSignEn) break; // Ignore if negative numbers not enabled
+      // Toggle sign
+      gslc_ElemXKeyPadValSetSign(pGui, pElemRefParent, pKeyPad->bValPositive ? false : true);
+      bValRedraw = true;
+      break;
+
+    case KEYPAD_ID_BACKSPACE:
+      //GSLC_DEBUG_PRINT("KeyPad Key=BS\n", "");
+      if (pKeyPad->nValStrPos < 1) break;
+      pKeyPad->nValStrPos--;
+      // Handle the special case of decimal point if floating point enabled
+      if (pKeyPad->sConfig.bFloatEn) {
+        if (pKeyPad->acValStr[pKeyPad->nValStrPos] == KEYPAD_DISP_DECIMAL_PT) {
+          //GSLC_DEBUG_PRINT("KeyPad Key=BS across decimal\n", "");
+          pKeyPad->bValDecimalPt = false;
+        }
+      }
+      if (pKeyPad->nValStrPos == 0) {
+        memset(pKeyPad->acValStr, 0, XKEYPAD_VAL_LEN);
+        pKeyPad->bValPositive = true;
+      }
+      pKeyPad->acValStr[pKeyPad->nValStrPos] = '\0';
+      bValRedraw = true;
+      break;
+
+    case KEYPAD_ID_PERIOD:
+    case KEYPAD_ID_SPACE:
+    default:
+      // Normal character
+      //GSLC_DEBUG_PRINT("KeyPad Key=Digit\n", "");
+      // For basic buttons, we need to fetch the keypad string index
+      nKeyInd = (*pfuncLookup)(pGui, nSubElemId);
+      bValRedraw |= ElemXKeyPadAddChar(pGui, pKeyPad, pKeyPad->pacKeys[nKeyInd][0]);
+      break;
+    } // switch
+
+    // Do we need to redraw the text field?
+    if (bValRedraw) {
+      pElemRef = gslc_CollectFindElemById(pGui, &pKeyPad->sCollect, KEYPAD_ID_TXT);
+      gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_INC);
+      // Issue callback with Update status
+      if (pfuncXInput != NULL) {
+        (*pfuncXInput)(pvGui, (void*)(pElemRefParent), XKEYPAD_CB_STATE_UPDATE, (void*)pKeyPad->acValStr);
+      }
+    } // bValRedraw
+
+  } // eTouch
+
+  return true;
+  #endif // !DRV_TOUCH_NONE
+}
+
+bool gslc_ElemXKeyPadTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, int16_t nRelX, int16_t nRelY)
+{
+  #if defined(DRV_TOUCH_NONE)
+  return false;
+  #else
+
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXKeyPadTouch";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return false;
+  }
+  gslc_tsGui*           pGui = NULL;
+  gslc_tsElemRef*       pElemRef = NULL;
+  gslc_tsElem*          pElem = NULL;
+  gslc_tsXKeyPad*       pKeyPad = NULL;
+
+
+  // Typecast the parameters to match the GUI
+  pGui = (gslc_tsGui*)(pvGui);
+  pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  pElem = gslc_GetElemFromRef(pGui, pElemRef);
+  pKeyPad = (gslc_tsXKeyPad*)(pElem->pXData);
+
+  // Get Collection
+  gslc_tsCollect* pCollect = &pKeyPad->sCollect;
+
+  // Cascade the touch event to the sub-element collection
+  return gslc_CollectTouchCompound(pvGui, pvElemRef, eTouch, nRelX, nRelY, pCollect);
+  #endif // !DRV_TOUCH_NONE
+}
+
+
+
+void gslc_ElemXKeyPadCfgSetButtonSz(gslc_tsXKeyPadCfg* pConfig, int8_t nButtonSzW, int8_t nButtonSzH)
+{
+  pConfig->nButtonSzW = nButtonSzW;
+  pConfig->nButtonSzH = nButtonSzH;
+}
+
+void gslc_ElemXKeyPadCfgSetFloatEn(gslc_tsXKeyPadCfg* pConfig, bool bEn)
+{
+  pConfig->bFloatEn = bEn;
+  //GSLC_DEBUG_PRINT("SetFloatEn: FloatEn=%d\n", pConfig->bFloatEn);
+}
+
+void gslc_ElemXKeyPadCfgSetSignEn(gslc_tsXKeyPadCfg* pConfig, bool bEn)
+{
+  pConfig->bSignEn = bEn;
+}
+
+
+#endif // GSLC_FEATURE_COMPOUND
+
+
+// ============================================================================

--- a/src/elem/XKeyPad.h
+++ b/src/elem/XKeyPad.h
@@ -113,7 +113,7 @@ typedef int16_t (*XKEYPAD_LOOKUP)(gslc_tsGui* pGui, int16_t nKeyId);
   ///   the resulting edited value.
   typedef struct {
     char*               pStr;             ///< Final value of edited value field
-	int16_t             nTargetId;        ///< Target element ID to receive the value
+    int16_t             nTargetId;        ///< Target element ID to receive the value
   } gslc_tsXKeyPadData;
 
   /// Extended data for KeyPad element
@@ -159,11 +159,12 @@ typedef void (*XKEYPAD_CREATE)(gslc_tsGui* pGui,gslc_tsXKeyPad* pXData);
   /// \param[in]  nColSpan:    Number of rows to occupy by element (1 for normal size, 2 for double height)
   /// \param[in]  cColFill:    Fill color for element
   /// \param[in]  cColGlow:    Fill color for element when glowing
+  /// \param[in]  bVisible:    Initial key visibility state
   ///
   /// \return none
   ///
 void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId, bool bTxtField, int16_t nRow, int16_t nCol,
-  int8_t nRowSpan, int8_t nColSpan, gslc_tsColor cColFill, gslc_tsColor cColGlow);
+  int8_t nRowSpan, int8_t nColSpan, gslc_tsColor cColFill, gslc_tsColor cColGlow, bool bVisible);
 
   ///
   /// Create a KeyPad Element
@@ -332,6 +333,30 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   /// \return none
   ///
   void gslc_ElemXKeyPadCfgSetButtonSz(gslc_tsXKeyPadCfg* pConfig, int8_t nButtonSzW, int8_t nButtonSzH);
+
+  ///
+  /// Update the KeyPad active configuration to enable negative numbers
+  /// - Effectively disables/enables the sign button & handling
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pElemRef:    Pointer to KeyPad element reference
+  /// \param[in]  bEn:         Enable flag (true if negative numbers enabled)
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadSetFloatEn(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, bool bEn);
+
+  ///
+  /// Update the KeyPad active configuration to enable negative numbers
+  /// - Effectively disables/enables the sign button & handling
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pElemRef:    Pointer to KeyPad element reference
+  /// \param[in]  bEn:         Enable flag (true if negative numbers enabled)
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadSetSignEn(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, bool bEn);
 
   #endif // GSLC_FEATURE_COMPOUND
 

--- a/src/elem/XKeyPad.h
+++ b/src/elem/XKeyPad.h
@@ -1,0 +1,303 @@
+#ifndef _GUISLICE_EX_XKEYPAD_H_
+#define _GUISLICE_EX_XKEYPAD_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: XKeyPad control
+// - Paul Conti, Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XKeyPad.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+
+#if (GSLC_FEATURE_COMPOUND)
+// ============================================================================
+// Extended Element: KeyPad (Number Selector)
+// - Demonstration of a compound element consisting of
+//   a counter text field along with an increment and
+//   decrement button.
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define GSLC_TYPEX_KEYPAD GSLC_TYPE_BASE_EXTEND + 20
+
+#define XKEYPAD_VAL_LEN  12  // Maximum buffer length for input string
+
+// Define the status for GSLC_CB_INPUT callback
+#define XKEYPAD_CB_STATE_DONE 1
+#define XKEYPAD_CB_STATE_CANCEL 2
+#define XKEYPAD_CB_STATE_UPDATE 3
+
+
+// Define global list of button ID types
+// - A given keypad may not use all of these
+enum {
+  // --------------------------------------------
+  // --- Special Buttons
+  KEYPAD_ID_BACKSPACE,
+  KEYPAD_ID_PERIOD,
+  KEYPAD_ID_SPACE,
+  KEYPAD_ID_DECIMAL,
+  KEYPAD_ID_MINUS,
+  KEYPAD_ID_ESC,
+  KEYPAD_ID_ENTER,
+  // --- Basic Buttons
+  KEYPAD_ID_BASIC_START=100,
+  // --------------------------------------------
+  // --- Extra elements
+  KEYPAD_ID_TXT=200,        // Value string text area
+};
+
+/// Function for KeyPad creation
+typedef int16_t (*XKEYPAD_LOOKUP)(gslc_tsGui* pGui, int16_t nKeyId);
+
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+  /// Configuration for the KeyPad
+  typedef struct {
+    bool                bFloatEn;         ///< Enable floating point (ie. decimal point)
+    bool                bSignEn;          ///< Enable negative numbers
+    int8_t              nButtonSzW;       ///< Button width (in pixels)
+    int8_t              nButtonSzH;       ///< Button height (in pixels)
+    char**              pacKeys;          ///< Array of character strings for KeyPad labels
+
+    // From constructor
+    int16_t             nFontId;          ///< Configured font for KeyPad labels
+    int16_t             nOffsetX;         ///< Configured offset (X direction) for buttons from parent container
+    int16_t             nOffsetY;         ///< Configured offset (Y direction) for buttons from parent container
+
+    int8_t              nFrameMargin;     ///< Margin around text value field
+    uint8_t             nMaxCols;         ///< Maximum number of columns to occupy
+    uint8_t             nMaxRows;         ///< Maximum number of rows to occupy
+  } gslc_tsXKeyPadCfg;
+
+  /// Extended data for KeyPad element
+  typedef struct {
+
+    // State
+    uint8_t             nValStrPos;  ///< Counter for number digits stored
+    char                acValStr[XKEYPAD_VAL_LEN];  ///< Where input is stored until enter button pressed
+    bool                bValPositive;     ///< Value is positive if true, negative if false
+    bool                bValDecimalPt;    ///> Value string includes decimal point
+
+    // Config
+    char**              pacKeys;          ///< Array of character strings for KeyPad labels
+    gslc_tsXKeyPadCfg   sConfig;          ///< Configuration options
+
+    GSLC_CB_INPUT       pfuncCb;          ///< Callback function for KeyPad actions
+    XKEYPAD_LOOKUP      pfuncLookup;      ///< Callback function for converting key into key label
+
+    // Internal sub-element members
+    gslc_tsCollect      sCollect;         ///< Collection management for sub-elements
+    uint8_t             nSubElemMax;      ///< Maximum number of sub-elements to create within KeyPad container
+    gslc_tsElemRef*     psElemRef;        ///< Ptr to storage for sub-element references
+    gslc_tsElem*        psElem;           ///< Ptr to storage for sub-elements
+
+  } gslc_tsXKeyPad;
+
+
+// Callback function for KeyPad creation
+typedef void (*XKEYPAD_CREATE)(gslc_tsGui* pGui,gslc_tsXKeyPad* pXData);
+
+
+  ///
+  /// Add a key to the KeyPad control
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pXData:      Ptr to extended element data structure
+  /// \param[in]  nKeyId:      ID to associated with the key
+  /// \param[in]  bTxtField:   Is this the text value field?
+  /// \param[in]  nRow:        Element placement position (row index, 0 at top)
+  /// \param[in]  nCol:        Element placement position (column index, 0 at left)
+  /// \param[in]  nRowSpan:    Number of columns to occupy by element (1 for normal size, 2 for double width)
+  /// \param[in]  nColSpan:    Number of rows to occupy by element (1 for normal size, 2 for double height)
+  /// \param[in]  cColFill:    Fill color for element
+  /// \param[in]  cColGlow:    Fill color for element when glowing
+  ///
+  /// \return none
+  ///
+void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId, bool bTxtField, int16_t nRow, int16_t nCol,
+  int8_t nRowSpan, int8_t nColSpan, gslc_tsColor cColFill, gslc_tsColor cColGlow);
+
+  ///
+  /// Create a KeyPad Element
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+  /// \param[in]  nPage:       Page ID to attach element to
+  /// \param[in]  pXData:      Ptr to extended element data structure
+  /// \param[in]  nX0:         X KeyPad Starting Coordinate 
+  /// \param[in]  nY0:         Y KeyPad Starting Coordinate 
+  /// \param[in]  nFontId:     Font ID to use for drawing the element
+  /// \param[in]  sConfig:     Config options
+  ///
+  /// \return Pointer to Element or NULL if failure
+  ///
+  gslc_tsElemRef* gslc_ElemXKeyPadCreateBase(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+    gslc_tsXKeyPad* pXData, int16_t nX0, int16_t nY0, int8_t nFontId, gslc_tsXKeyPadCfg* pConfig,
+    XKEYPAD_CREATE pfuncCreate, XKEYPAD_LOOKUP pfuncLookup);
+
+
+  ///
+  /// Set the current value for the editable text field
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pKeyPad:     Ptr to KeyPad Element
+  /// \param[in]  pStrBuf:     String to copy into keypad
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, const char* pStrBuf);
+
+
+  ///
+  /// Set the current output string buffer associated with NumericInput element
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pKeyPad:     Ptr to KeyPad Element
+  /// \param[in]  pStrBuf:     String to copy into element
+  /// \param[in]  nStrBufMax:  Maximum length of string buffer (pStrBuf)
+  ///
+  /// \return none
+  ///
+  bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, char* pStrBuf, uint8_t nStrBufMax);
+
+  ///
+  /// Draw a KeyPad element on the screen
+  /// - Called during redraw
+  ///
+  /// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+  /// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+  /// \param[in]  eRedraw:     Redraw mode
+  ///
+  /// \return true if success, false otherwise
+  ///
+  bool gslc_ElemXKeyPadDraw(void* pvGui, void* pvElemRef, gslc_teRedrawType eRedraw);
+
+  ///
+  /// Handle a click event within the KeyPad
+  /// - This is called internally by the KeyPad touch handler
+  ///
+  /// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+  /// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+  /// \param[in]  eTouch:      Touch event type
+  /// \param[in]  nX:          Touch X coord
+  /// \param[in]  nY:          Touch Y coord
+  ///
+  /// \return none
+  ///
+  bool gslc_ElemXKeyPadClick(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY);
+
+  ///
+  /// Handle touch (up,down,move) events to KeyPad element
+  /// - Called from gslc_ElemSendEventTouch()
+  ///
+  /// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+  /// \param[in]  pvElem:      Void ptr to Element (typecast to gslc_tsElem*)
+  /// \param[in]  eTouch:      Touch event type
+  /// \param[in]  nRelX:       Touch X coord relative to element
+  /// \param[in]  nRelY:       Touch Y coord relative to element
+  ///
+  /// \return true if success, false otherwise
+  ///
+  bool gslc_ElemXKeyPadTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, int16_t nRelX, int16_t nRelY);
+
+  ///
+  /// Set the callback function associated with the KeyPad
+  /// - This function will be called during updates and OK / Cancel
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pElemRef:    Pointer to Element Reference for KeyPad
+  /// \param[in]  pfuncCb:     Callback function pointer
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadValSetCb(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, GSLC_CB_INPUT pfuncCb);
+
+  ///
+  /// Update the KeyPad configuration to enable floating point numbers
+  /// - Effectively disables/enables the decimal point button & handling
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pConfig:     Pointer to the XKeyPad config structure
+  /// \param[in]  bEn:         Enable flag (true if floating point enabled)
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadCfgSetFloatEn(gslc_tsXKeyPadCfg* pConfig,bool bEn);
+
+  ///
+  /// Update the KeyPad configuration to enable negative numbers
+  /// - Effectively disables/enables the sign button & handling
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pConfig:     Pointer to the XKeyPad config structure
+  /// \param[in]  bEn:         Enable flag (true if negative numbers enabled)
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadCfgSetSignEn(gslc_tsXKeyPadCfg* pConfig,bool bEn);
+
+  ///
+  /// Update the KeyPad configuration to define the KeyPad button sizing
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pConfig:     Pointer to the XKeyPad config structure
+  /// \param[in]  nButtonSzW:  Width of buttons in pixels
+  /// \param[in]  nButtonSzH:  Width of buttons in pixels
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadCfgSetButtonSz(gslc_tsXKeyPadCfg* pConfig, int8_t nButtonSzW, int8_t nButtonSzH);
+
+  #endif // GSLC_FEATURE_COMPOUND
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XKEYPAD_H_
+

--- a/src/elem/XKeyPad.h
+++ b/src/elem/XKeyPad.h
@@ -93,6 +93,7 @@ typedef int16_t (*XKEYPAD_LOOKUP)(gslc_tsGui* pGui, int16_t nKeyId);
   typedef struct {
     bool                bFloatEn;         ///< Enable floating point (ie. decimal point)
     bool                bSignEn;          ///< Enable negative numbers
+	  bool                bRoundEn;         ///< Enable rounded corners
     int8_t              nButtonSzW;       ///< Button width (in pixels)
     int8_t              nButtonSzH;       ///< Button height (in pixels)
     char**              pacKeys;          ///< Array of character strings for KeyPad labels
@@ -321,6 +322,17 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   /// \return none
   ///
   void gslc_ElemXKeyPadCfgSetSignEn(gslc_tsXKeyPadCfg* pConfig,bool bEn);
+
+  ///
+  /// Update the KeyPad configuration to enable rounded button corners
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  pConfig:     Pointer to the XKeyPad config structure
+  /// \param[in]  bEn:         Enable rounded corners
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadCfgSetRoundEn(gslc_tsXKeyPadCfg* pConfig,bool bEn);
 
   ///
   /// Update the KeyPad configuration to define the KeyPad button sizing

--- a/src/elem/XKeyPad.h
+++ b/src/elem/XKeyPad.h
@@ -107,14 +107,23 @@ typedef int16_t (*XKEYPAD_LOOKUP)(gslc_tsGui* pGui, int16_t nKeyId);
     uint8_t             nMaxRows;         ///< Maximum number of rows to occupy
   } gslc_tsXKeyPadCfg;
 
+  /// Input callback data structure
+  /// - This struct is returned in GSLC_CB_INPUT when the
+  ///   KeyPad edits are complete, and is used to provide
+  ///   the resulting edited value.
+  typedef struct {
+    char*               pStr;             ///< Final value of edited value field
+	int16_t             nTargetId;        ///< Target element ID to receive the value
+  } gslc_tsXKeyPadData;
+
   /// Extended data for KeyPad element
   typedef struct {
 
     // State
-    uint8_t             nValStrPos;  ///< Counter for number digits stored
-    char                acValStr[XKEYPAD_VAL_LEN];  ///< Where input is stored until enter button pressed
+    uint8_t             nValStrPos;       ///< Current number of characters stored in edit value string
+    char                acValStr[XKEYPAD_VAL_LEN];  ///< Storage for edit value string
     bool                bValPositive;     ///< Value is positive if true, negative if false
-    bool                bValDecimalPt;    ///> Value string includes decimal point
+    bool                bValDecimalPt;    ///< Value string includes decimal point
 
     // Config
     char**              pacKeys;          ///< Array of character strings for KeyPad labels
@@ -122,6 +131,7 @@ typedef int16_t (*XKEYPAD_LOOKUP)(gslc_tsGui* pGui, int16_t nKeyId);
 
     GSLC_CB_INPUT       pfuncCb;          ///< Callback function for KeyPad actions
     XKEYPAD_LOOKUP      pfuncLookup;      ///< Callback function for converting key into key label
+    int16_t             nTargetId;        ///< Target element ID associated with keypad (GSLC_CB_INPUT)
 
     // Internal sub-element members
     gslc_tsCollect      sCollect;         ///< Collection management for sub-elements
@@ -185,6 +195,22 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   ///
   void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, const char* pStrBuf);
 
+  ///
+  /// Set target element ID for KeyPad return value
+  /// - The Target ID is used in the GSLC_CB_INPUT callback so that the user
+  ///   has the context needed to determine which field should be edited
+  ///   with the contents of the KeyPad edit field
+  /// - It is expected that the user will call this function when showing
+  ///   the KeyPad popup dialog
+  ///
+  /// \param[in]  pGui:       Pointer to GUI
+  /// \param[in]  pKeyPad:    Ptr to KeyPad Element
+  /// \param[in]  nTargetId:  Element enum ID for target of KeyPad value
+  ///
+  /// \return none
+  ///
+  void gslc_ElemXKeyPadTargetIdSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, int16_t nId);
+
 
   ///
   /// Set the current output string buffer associated with NumericInput element
@@ -197,6 +223,27 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   /// \return none
   ///
   bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, char* pStrBuf, uint8_t nStrBufMax);
+
+  ///
+  /// Fetch the edited value string from the KeyPad
+  ///
+  /// \param[in]  pGui:       Pointer to GUI
+  /// \param[in]  pvData :    Void ptr to callback data structure
+  ///
+  /// \return Pointer to edited character string
+  ///
+  char* gslc_ElemXKeyPadDataValGet(gslc_tsGui* pGui, void* pvData);
+
+
+  ///
+  /// Fetch the element target ID associated with this KeyPad
+  ///
+  /// \param[in]  pGui:       Pointer to GUI
+  /// \param[in]  pvData :    Void ptr to callback data structure
+  ///
+  /// \return Target Element ID or GSLC_ID_NONE if unspecified
+  ///
+  int16_t gslc_ElemXKeyPadDataTargetIdGet(gslc_tsGui* pGui, void* pvData);
 
   ///
   /// Draw a KeyPad element on the screen

--- a/src/elem/XKeyPad.h
+++ b/src/elem/XKeyPad.h
@@ -190,12 +190,12 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   /// Set the current value for the editable text field
   ///
   /// \param[in]  pGui:        Pointer to GUI
-  /// \param[in]  pKeyPad:     Ptr to KeyPad Element
+  /// \param[in]  pElemRef:   Ptr to KeyPad Element reference
   /// \param[in]  pStrBuf:     String to copy into keypad
   ///
   /// \return none
   ///
-  void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, const char* pStrBuf);
+  void gslc_ElemXKeyPadValSet(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, const char* pStrBuf);
 
   ///
   /// Set target element ID for KeyPad return value
@@ -206,25 +206,25 @@ void XKeyPadAddKeyElem(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData, int16_t nKeyId,
   ///   the KeyPad popup dialog
   ///
   /// \param[in]  pGui:       Pointer to GUI
-  /// \param[in]  pKeyPad:    Ptr to KeyPad Element
+  /// \param[in]  pElemRef:   Ptr to KeyPad Element reference
   /// \param[in]  nTargetId:  Element enum ID for target of KeyPad value
   ///
   /// \return none
   ///
-  void gslc_ElemXKeyPadTargetIdSet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, int16_t nId);
+  void gslc_ElemXKeyPadTargetIdSet(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nId);
 
 
   ///
   /// Set the current output string buffer associated with NumericInput element
   ///
   /// \param[in]  pGui:        Pointer to GUI
-  /// \param[in]  pKeyPad:     Ptr to KeyPad Element
+  /// \param[in]  pElemRef:    Ptr to KeyPad Element reference
   /// \param[in]  pStrBuf:     String to copy into element
   /// \param[in]  nStrBufMax:  Maximum length of string buffer (pStrBuf)
   ///
   /// \return none
   ///
-  bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsXKeyPad* pKeyPad, char* pStrBuf, uint8_t nStrBufMax);
+  bool gslc_ElemXKeyPadValGet(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, char* pStrBuf, uint8_t nStrBufMax);
 
   ///
   /// Fetch the edited value string from the KeyPad

--- a/src/elem/XKeyPad_Alpha.c
+++ b/src/elem/XKeyPad_Alpha.c
@@ -1,0 +1,196 @@
+// =======================================================================
+// GUIslice library extension: XKeyPad control (Alpha entry)
+// - Paul Conti, Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XKeyPad.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XKeyPad.h"
+#include "elem/XKeyPad_Alpha.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+#if (GSLC_FEATURE_COMPOUND)
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: KeyPad
+// - Keypad element with alpha input
+// ============================================================================
+
+// Define the button labels
+// - TODO: Create more efficient storage for the labels
+//   so that it doesn't consume 4 bytes even for labels
+//   that can be generated (eg. 0..9, a--z, etc.)
+// - TODO: Support use of PROGMEM. Note that these labels
+//   are not currently using "const char" since we may
+//   want to support user-modification of the labels.
+
+static char* KEYPAD_LABEL_STRINGS[] = {
+  // Special buttons
+  "<", ".", " ", "ESC", "ENT",
+  // Basic buttons
+  "A", "B", "C", "D", "E", "F", "G", "H" ,"I", "J",
+  "K", "L", "M", "N", "O", "P", "Q", "R" ,"S", "T",
+  "U", "V", "W", "X", "Y", "Z",
+};
+
+// Define enums for KEYPAD_LABEL_STRINGS
+enum {
+  // - Special buttons
+  KEYPAD_LBL_BACKSPACE,
+  KEYPAD_LBL_PERIOD,
+  KEYPAD_LBL_SPACE,
+  KEYPAD_LBL_ESC,
+  KEYPAD_LBL_ENTER,
+  // - Basic buttons
+  KEYPAD_LBL_BASIC_START
+};
+
+
+// Generate the keypad layout
+void XKeyPadCreateKeys_Alpha(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData)
+{
+  int16_t nKeyId;
+  int16_t nKeyInd;
+  int16_t nRow, nCol;
+
+  // - Create the "special" buttons
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_BACKSPACE, false, 1, 6, 1, 2, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_PERIOD, false, 3, 7, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_SPACE, false, 3, 6, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ESC, false, 2, 6, 1, 2, GSLC_COL_RED, GSLC_COL_RED_LT4);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ENTER, false, 0, 6, 1, 2, GSLC_COL_GREEN, GSLC_COL_GREEN_LT4);
+
+  // - Create the "simple" buttons
+  for (int16_t nKeyId = KEYPAD_ID_BASIC_START; nKeyId < (KEYPAD_ID_BASIC_START + XKEYPADALPHA_BTN_BASIC); nKeyId++) {
+    nKeyInd = nKeyId - KEYPAD_ID_BASIC_START;
+    nRow = (nKeyInd / 6) + 1;
+    nCol = nKeyInd % 6;
+    XKeyPadAddKeyElem(pGui, pXData, nKeyId, false, nRow, nCol, 1, 1, GSLC_COL_BLUE_LT1, GSLC_COL_BLUE_LT4);
+  }
+
+  // - Create the text field
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_TXT, true, 0, 0, 1, 6, GSLC_COL_BLACK, GSLC_COL_BLACK);
+}
+
+// Convert between keypad ID and the index into the keypad label array
+int16_t XKeyPadLookup_Alpha(gslc_tsGui* pGui, int16_t nKeyId)
+{
+  int16_t nKeyInd;
+
+  // Basic button
+  if (nKeyId >= KEYPAD_ID_BASIC_START) {
+    nKeyInd = (nKeyId - KEYPAD_ID_BASIC_START) + KEYPAD_LBL_BASIC_START;
+  } else {
+    // Special button
+    switch (nKeyId) {
+    case KEYPAD_ID_PERIOD:
+      nKeyInd = KEYPAD_LBL_PERIOD;
+      break;
+    case KEYPAD_ID_SPACE:
+      nKeyInd = KEYPAD_LBL_SPACE;
+      break;
+    case KEYPAD_ID_BACKSPACE:
+      nKeyInd = KEYPAD_LBL_BACKSPACE;
+      break;
+    case KEYPAD_ID_ESC:
+      nKeyInd = KEYPAD_LBL_ESC;
+      break;
+    case KEYPAD_ID_ENTER:
+      nKeyInd = KEYPAD_LBL_ENTER;
+      break;
+    default:
+      // FIXME: ERROR
+      nKeyInd = -1; // Not expected
+      break;
+    }
+  }
+  return nKeyInd;
+}
+
+// Create the XKeyPad_Alpha compound element
+// - Note that this also revises some of the members of the base XKeyPad struct
+gslc_tsElemRef* gslc_ElemXKeyPadCreate_Alpha(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXKeyPad_Alpha* pXData, int16_t nX0, int16_t nY0, int8_t nFontId, gslc_tsXKeyPadCfg* pConfig)
+{
+  gslc_tsXKeyPad* pXDataBase = (gslc_tsXKeyPad*)pXData;
+  pXDataBase->nSubElemMax = XKEYPADALPHA_ELEM_MAX;
+  pXDataBase->psElemRef = pXData->asElemRef;
+  pXDataBase->psElem = pXData->asElem;
+  return gslc_ElemXKeyPadCreateBase(pGui, nElemId, nPage, pXDataBase, nX0, nY0, nFontId, pConfig,
+    &XKeyPadCreateKeys_Alpha,&XKeyPadLookup_Alpha);
+}
+
+// Reset the XKeyPad config struct
+// - This must be called before any XKeyPad config update APIs are called
+gslc_tsXKeyPadCfg gslc_ElemXKeyPadCfgInit_Alpha()
+{
+  gslc_tsXKeyPadCfg sConfig;
+  sConfig.nButtonSzW = 25;
+  sConfig.nButtonSzH = 25;
+  sConfig.bFloatEn = false; // Unused
+  sConfig.bSignEn = false; // Unused
+  sConfig.nFontId = GSLC_FONT_NONE; // Will be overwritten
+  sConfig.pacKeys = KEYPAD_LABEL_STRINGS;
+  sConfig.nMaxCols = 8;
+  sConfig.nMaxRows = 6;
+  sConfig.nFrameMargin = 2;
+  return sConfig;
+}
+
+#endif // GSLC_FEATURE_COMPOUND
+
+// ============================================================================

--- a/src/elem/XKeyPad_Alpha.c
+++ b/src/elem/XKeyPad_Alpha.c
@@ -108,22 +108,22 @@ void XKeyPadCreateKeys_Alpha(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData)
   int16_t nRow, nCol;
 
   // - Create the "special" buttons
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_BACKSPACE, false, 1, 6, 1, 2, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_PERIOD, false, 3, 7, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_SPACE, false, 3, 6, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ESC, false, 2, 6, 1, 2, GSLC_COL_RED, GSLC_COL_RED_LT4);
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ENTER, false, 0, 6, 1, 2, GSLC_COL_GREEN, GSLC_COL_GREEN_LT4);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_BACKSPACE, false, 1, 6, 1, 2, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3, true);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_PERIOD, false, 3, 7, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3, true);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_SPACE, false, 3, 6, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3, true);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ESC, false, 2, 6, 1, 2, GSLC_COL_RED, GSLC_COL_RED_LT4, true);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ENTER, false, 0, 6, 1, 2, GSLC_COL_GREEN, GSLC_COL_GREEN_LT4, true);
 
   // - Create the "simple" buttons
   for (int16_t nKeyId = KEYPAD_ID_BASIC_START; nKeyId < (KEYPAD_ID_BASIC_START + XKEYPADALPHA_BTN_BASIC); nKeyId++) {
     nKeyInd = nKeyId - KEYPAD_ID_BASIC_START;
     nRow = (nKeyInd / 6) + 1;
     nCol = nKeyInd % 6;
-    XKeyPadAddKeyElem(pGui, pXData, nKeyId, false, nRow, nCol, 1, 1, GSLC_COL_BLUE_LT1, GSLC_COL_BLUE_LT4);
+    XKeyPadAddKeyElem(pGui, pXData, nKeyId, false, nRow, nCol, 1, 1, GSLC_COL_BLUE_LT1, GSLC_COL_BLUE_LT4, true);
   }
 
   // - Create the text field
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_TXT, true, 0, 0, 1, 6, GSLC_COL_BLACK, GSLC_COL_BLACK);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_TXT, true, 0, 0, 1, 6, GSLC_COL_BLACK, GSLC_COL_BLACK, true);
 }
 
 // Convert between keypad ID and the index into the keypad label array

--- a/src/elem/XKeyPad_Alpha.c
+++ b/src/elem/XKeyPad_Alpha.c
@@ -183,6 +183,7 @@ gslc_tsXKeyPadCfg gslc_ElemXKeyPadCfgInit_Alpha()
   sConfig.nButtonSzH = 25;
   sConfig.bFloatEn = false; // Unused
   sConfig.bSignEn = false; // Unused
+  sConfig.bRoundEn = false;
   sConfig.nFontId = GSLC_FONT_NONE; // Will be overwritten
   sConfig.pacKeys = KEYPAD_LABEL_STRINGS;
   sConfig.nMaxCols = 8;

--- a/src/elem/XKeyPad_Alpha.h
+++ b/src/elem/XKeyPad_Alpha.h
@@ -1,0 +1,100 @@
+#ifndef _GUISLICE_EX_XKEYPAD_ALPHA_H_
+#define _GUISLICE_EX_XKEYPAD_ALPHA_H_
+
+#include "GUIslice.h"
+
+#include "elem/XKeyPad.h"
+
+// =======================================================================
+// GUIslice library extension: XKeyPad control (alpha entry)
+// - Paul Conti, Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XKeyPad.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#if (GSLC_FEATURE_COMPOUND)
+
+// Define number of buttons & elements
+// - Refer to the definitions in the XKeyPad_*.c file
+#define XKEYPADALPHA_BTN_BASIC 26
+#define XKEYPADALPHA_ELEM_MAX (6 + XKEYPADALPHA_BTN_BASIC)
+
+// ============================================================================
+// Extended Element: KeyPad Character entry
+// - NOTE: The XKeyPad_Alpha extends the XKeyPad base element
+// ============================================================================
+
+typedef struct {
+  // Base XKeyPad struct
+  // - The base type must appear at the top of the derived struct
+  gslc_tsXKeyPad      sKeyPad;                             ///< Base XKeyPad element
+
+  gslc_tsElemRef      asElemRef[XKEYPADALPHA_ELEM_MAX];    ///< Storage for sub-element references
+  gslc_tsElem         asElem[XKEYPADALPHA_ELEM_MAX];       ///< Storage for sub-elements
+} gslc_tsXKeyPad_Alpha;
+
+  ///
+  /// Create a KeyPad Element
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+  /// \param[in]  nPage:       Page ID to attach element to
+  /// \param[in]  pXData:      Ptr to extended element data structure
+  /// \param[in]  nX0:         X KeyPad Starting Coordinate 
+  /// \param[in]  nY0:         Y KeyPad Starting Coordinate 
+  /// \param[in]  nFontId:     Font ID to use for drawing the element
+  /// \param[in]  pConfig:     Ptr to config options
+  ///
+  /// \return Pointer to Element or NULL if failure
+  ///
+  gslc_tsElemRef* gslc_ElemXKeyPadCreate_Alpha(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+    gslc_tsXKeyPad_Alpha* pXData, int16_t nX0, int16_t nY0, int8_t nFontId, gslc_tsXKeyPadCfg* pConfig);
+
+
+  ///
+  /// Initialize the KeyPad config structure
+  /// - This routine should be called to initialize the configuration
+  ///   data structure before calling any of the KeyPad config APIs
+  ///
+  /// \return Initialized KeyPad config structure
+  ///
+  gslc_tsXKeyPadCfg gslc_ElemXKeyPadCfgInit_Alpha();
+
+// ============================================================================
+
+#endif // GSLC_FEATURE_COMPOUND
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XKEYPAD_ALPHA_H_
+

--- a/src/elem/XKeyPad_Num.c
+++ b/src/elem/XKeyPad_Num.c
@@ -1,0 +1,202 @@
+// =======================================================================
+// GUIslice library extension: XKeyPad control (Numeric entry)
+// - Paul Conti, Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XKeyPad.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XKeyPad.h"
+#include "elem/XKeyPad_Num.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+#if (GSLC_FEATURE_COMPOUND)
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: KeyPad
+// - Keypad element with numeric input
+// - Optionally supports floating point values
+// - Optionally supports negative values
+// ============================================================================
+
+// Define the button labels
+// - TODO: Create more efficient storage for the labels
+//   so that it doesn't consume 4 bytes even for labels
+//   that can be generated (eg. 0..9, a--z, etc.)
+// - TODO: Support use of PROGMEM. Note that these labels
+//   are not currently using "const char" since we may
+//   want to support user-modification of the labels.
+
+static char* KEYPAD_LABEL_STRINGS[] = {
+  // Special buttons
+  "<", ".", "-", "ESC", "ENT",
+  // Basic buttons
+  "0", "1", "2", "3", "4", "5", "6", "7" ,"8", "9",
+};
+// Define enums for KEYPAD_LABEL_STRINGS
+enum {
+  // - Special buttons
+  KEYPAD_LBL_BACKSPACE,
+  KEYPAD_LBL_DECIMAL,
+  KEYPAD_LBL_MINUS,
+  KEYPAD_LBL_ESC,
+  KEYPAD_LBL_ENTER,
+  // - Basic buttons
+  KEYPAD_LBL_BASIC_START
+};
+
+
+// Generate the keypad layout
+void XKeyPadCreateKeys_Num(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData)
+{
+  int16_t nKeyId;
+  int16_t nKeyInd;
+  int16_t nRow, nCol;
+  gslc_tsXKeyPadCfg* pConfig = &pXData->sConfig;
+  
+
+  // - Create the "special" buttons
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_BACKSPACE, false, 1, 6, 1, 2, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
+  if (pConfig->bSignEn) {
+    XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_MINUS, false, 1, 5, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
+  }
+  if (pConfig->bFloatEn) {
+	  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_DECIMAL, false, 2, 5, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
+  }
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ESC, false, 2, 6, 1, 2, GSLC_COL_RED, GSLC_COL_RED_LT4);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ENTER, false, 0, 6, 1, 2, GSLC_COL_GREEN, GSLC_COL_GREEN_LT4);
+
+  // - Create the "simple" buttons
+  for (int16_t nKeyId = KEYPAD_ID_BASIC_START; nKeyId < (KEYPAD_ID_BASIC_START + XKEYPADNUM_BTN_BASIC); nKeyId++) {
+    nKeyInd = nKeyId - KEYPAD_ID_BASIC_START;
+    nRow = (nKeyInd / 5) + 1;
+    nCol = nKeyInd % 5;
+    XKeyPadAddKeyElem(pGui, pXData, nKeyId, false, nRow, nCol, 1, 1, GSLC_COL_BLUE_LT1, GSLC_COL_BLUE_LT4);
+  }
+
+  // - Create the text field
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_TXT, true, 0, 0, 1, 6, GSLC_COL_BLACK, GSLC_COL_BLACK);
+}
+
+// Convert between keypad ID and the index into the keypad label array
+int16_t XKeyPadLookup_Num(gslc_tsGui* pGui, int16_t nKeyId)
+{
+  int16_t nKeyInd;
+
+  // Basic button
+  if (nKeyId >= KEYPAD_ID_BASIC_START) {
+    nKeyInd = (nKeyId - KEYPAD_ID_BASIC_START) + KEYPAD_LBL_BASIC_START;
+  } else {
+    // Special button
+    switch (nKeyId) {
+    case KEYPAD_ID_DECIMAL:
+      nKeyInd = KEYPAD_LBL_DECIMAL;
+      break;
+    case KEYPAD_ID_MINUS:
+      nKeyInd = KEYPAD_LBL_MINUS;
+      break;
+    case KEYPAD_ID_BACKSPACE:
+      nKeyInd = KEYPAD_LBL_BACKSPACE;
+      break;
+    case KEYPAD_ID_ESC:
+      nKeyInd = KEYPAD_LBL_ESC;
+      break;
+    case KEYPAD_ID_ENTER:
+      nKeyInd = KEYPAD_LBL_ENTER;
+      break;
+    default:
+      // FIXME: ERROR
+      nKeyInd = -1; // Not expected
+      break;
+    }
+
+  }
+  return nKeyInd;
+}
+
+// Create the XKeyPad_Alpha compound element
+// - Note that this also revises some of the members of the base XKeyPad struct
+gslc_tsElemRef* gslc_ElemXKeyPadCreate_Num(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXKeyPad_Num* pXData, int16_t nX0, int16_t nY0, int8_t nFontId, gslc_tsXKeyPadCfg* pConfig)
+{
+  gslc_tsXKeyPad* pXDataBase = (gslc_tsXKeyPad*)pXData;
+  pXDataBase->nSubElemMax = XKEYPADNUM_ELEM_MAX;
+  pXDataBase->psElemRef = pXData->asElemRef;
+  pXDataBase->psElem = pXData->asElem;
+  return gslc_ElemXKeyPadCreateBase(pGui, nElemId, nPage, pXDataBase, nX0, nY0, nFontId, pConfig,
+    &XKeyPadCreateKeys_Num,&XKeyPadLookup_Num);
+}
+
+// Reset the XKeyPad config struct
+// - This must be called before any XKeyPad config update APIs are called
+gslc_tsXKeyPadCfg gslc_ElemXKeyPadCfgInit_Num()
+{
+  gslc_tsXKeyPadCfg sConfig;
+  sConfig.nButtonSzW = 25;
+  sConfig.nButtonSzH = 25;
+  sConfig.bFloatEn = true;
+  sConfig.bSignEn = true;
+  sConfig.nFontId = GSLC_FONT_NONE; // Will be overwritten
+  sConfig.pacKeys = KEYPAD_LABEL_STRINGS;
+  sConfig.nMaxCols = 8;
+  sConfig.nMaxRows = 3;
+  sConfig.nFrameMargin = 2;
+  return sConfig;
+}
+
+#endif // GSLC_FEATURE_COMPOUND
+
+// ============================================================================

--- a/src/elem/XKeyPad_Num.c
+++ b/src/elem/XKeyPad_Num.c
@@ -109,26 +109,22 @@ void XKeyPadCreateKeys_Num(gslc_tsGui* pGui, gslc_tsXKeyPad* pXData)
   
 
   // - Create the "special" buttons
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_BACKSPACE, false, 1, 6, 1, 2, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
-  if (pConfig->bSignEn) {
-    XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_MINUS, false, 1, 5, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
-  }
-  if (pConfig->bFloatEn) {
-	  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_DECIMAL, false, 2, 5, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3);
-  }
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ESC, false, 2, 6, 1, 2, GSLC_COL_RED, GSLC_COL_RED_LT4);
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ENTER, false, 0, 6, 1, 2, GSLC_COL_GREEN, GSLC_COL_GREEN_LT4);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_BACKSPACE, false, 1, 6, 1, 2, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3, true);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_MINUS, false, 1, 5, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3, pConfig->bSignEn);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_DECIMAL, false, 2, 5, 1, 1, GSLC_COL_GRAY_LT1, GSLC_COL_GRAY_LT3, pConfig->bFloatEn);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ESC, false, 2, 6, 1, 2, GSLC_COL_RED, GSLC_COL_RED_LT4, true);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_ENTER, false, 0, 6, 1, 2, GSLC_COL_GREEN, GSLC_COL_GREEN_LT4, true);
 
   // - Create the "simple" buttons
   for (int16_t nKeyId = KEYPAD_ID_BASIC_START; nKeyId < (KEYPAD_ID_BASIC_START + XKEYPADNUM_BTN_BASIC); nKeyId++) {
     nKeyInd = nKeyId - KEYPAD_ID_BASIC_START;
     nRow = (nKeyInd / 5) + 1;
     nCol = nKeyInd % 5;
-    XKeyPadAddKeyElem(pGui, pXData, nKeyId, false, nRow, nCol, 1, 1, GSLC_COL_BLUE_LT1, GSLC_COL_BLUE_LT4);
+    XKeyPadAddKeyElem(pGui, pXData, nKeyId, false, nRow, nCol, 1, 1, GSLC_COL_BLUE_LT1, GSLC_COL_BLUE_LT4, true);
   }
 
   // - Create the text field
-  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_TXT, true, 0, 0, 1, 6, GSLC_COL_BLACK, GSLC_COL_BLACK);
+  XKeyPadAddKeyElem(pGui, pXData, KEYPAD_ID_TXT, true, 0, 0, 1, 6, GSLC_COL_BLACK, GSLC_COL_BLACK, true);
 }
 
 // Convert between keypad ID and the index into the keypad label array

--- a/src/elem/XKeyPad_Num.c
+++ b/src/elem/XKeyPad_Num.c
@@ -185,6 +185,7 @@ gslc_tsXKeyPadCfg gslc_ElemXKeyPadCfgInit_Num()
   sConfig.nButtonSzH = 25;
   sConfig.bFloatEn = true;
   sConfig.bSignEn = true;
+  sConfig.bRoundEn = false;
   sConfig.nFontId = GSLC_FONT_NONE; // Will be overwritten
   sConfig.pacKeys = KEYPAD_LABEL_STRINGS;
   sConfig.nMaxCols = 8;

--- a/src/elem/XKeyPad_Num.h
+++ b/src/elem/XKeyPad_Num.h
@@ -1,0 +1,100 @@
+#ifndef _GUISLICE_EX_XKEYPAD_NUM_H_
+#define _GUISLICE_EX_XKEYPAD_NUM_H_
+
+#include "GUIslice.h"
+
+#include "elem/XKeyPad.h"
+
+// =======================================================================
+// GUIslice library extension: XKeyPad control (numeric entry)
+// - Paul Conti, Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XKeyPad.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#if (GSLC_FEATURE_COMPOUND)
+
+// Define number of buttons & elements
+// - Refer to the definitions in the XKeyPad_*.c file
+#define XKEYPADNUM_BTN_BASIC 10
+#define XKEYPADNUM_ELEM_MAX (6 + XKEYPADNUM_BTN_BASIC)
+
+// ============================================================================
+// Extended Element: KeyPad Character entry
+// - NOTE: The XKeyPad_Alpha extends the XKeyPad base element
+// ============================================================================
+
+typedef struct {
+  // Base XKeyPad struct
+  // - The base type must appear at the top of the derived struct
+  gslc_tsXKeyPad      sKeyPad;                             ///< Base XKeyPad element
+
+  gslc_tsElemRef      asElemRef[XKEYPADNUM_ELEM_MAX];    ///< Storage for sub-element references
+  gslc_tsElem         asElem[XKEYPADNUM_ELEM_MAX];       ///< Storage for sub-elements
+} gslc_tsXKeyPad_Num;
+
+  ///
+  /// Create a KeyPad Element
+  ///
+  /// \param[in]  pGui:        Pointer to GUI
+  /// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+  /// \param[in]  nPage:       Page ID to attach element to
+  /// \param[in]  pXData:      Ptr to extended element data structure
+  /// \param[in]  nX0:         X KeyPad Starting Coordinate 
+  /// \param[in]  nY0:         Y KeyPad Starting Coordinate 
+  /// \param[in]  nFontId:     Font ID to use for drawing the element
+  /// \param[in]  pConfig:     Ptr to config options
+  ///
+  /// \return Pointer to Element or NULL if failure
+  ///
+  gslc_tsElemRef* gslc_ElemXKeyPadCreate_Num(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+    gslc_tsXKeyPad_Num* pXData, int16_t nX0, int16_t nY0, int8_t nFontId, gslc_tsXKeyPadCfg* pConfig);
+
+
+  ///
+  /// Initialize the KeyPad config structure
+  /// - This routine should be called to initialize the configuration
+  ///   data structure before calling any of the KeyPad config APIs
+  ///
+  /// \return Initialized KeyPad config structure
+  ///
+  gslc_tsXKeyPadCfg gslc_ElemXKeyPadCfgInit_Num();
+
+// ============================================================================
+
+#endif // GSLC_FEATURE_COMPOUND
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XKEYPAD_NUM_H_
+

--- a/src/elem/XSpinner.c
+++ b/src/elem/XSpinner.c
@@ -255,9 +255,14 @@ bool gslc_ElemXSpinnerDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
   // Draw the sub-elements
   // - For now, force redraw of entire compound element
   gslc_tsCollect* pCollect = &pSpinner->sCollect;
-
-  gslc_tsEvent  sEvent = gslc_EventCreate(pGui,GSLC_EVT_DRAW,GSLC_EVTSUB_DRAW_FORCE,(void*)(pCollect),NULL);
-  gslc_CollectEvent(pGui,sEvent);
+  if (eRedraw != GSLC_REDRAW_NONE) {
+    uint8_t sEventSubType = GSLC_EVTSUB_DRAW_NEEDED;
+    if (eRedraw == GSLC_REDRAW_FULL) {
+      sEventSubType = GSLC_EVTSUB_DRAW_FORCE;
+    }
+    gslc_tsEvent  sEvent = gslc_EventCreate(pGui, GSLC_EVT_DRAW, sEventSubType, (void*)(pCollect), NULL);
+    gslc_CollectEvent(pGui, sEvent);
+  }
 
   // Optionally, draw a frame around the compound element
   // - This could instead be done by creating a sub-element

--- a/src/elem/XSpinner.c
+++ b/src/elem/XSpinner.c
@@ -377,7 +377,7 @@ bool gslc_ElemXSpinnerClick(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int1
     // Invoke the callback function
     pfuncXInput = pSpinner->pfuncXInput;
     if (pfuncXInput != NULL) {
-      (*pfuncXInput)(pvGui, pSpinner->pElemRef);
+      (*pfuncXInput)(pvGui, (void*)(pSpinner->pElemRef), XSPINNER_CB_STATE_UPDATE, NULL);
     }
 
   } // eTouch

--- a/src/elem/XSpinner.h
+++ b/src/elem/XSpinner.h
@@ -60,6 +60,9 @@ extern "C" {
 // Define the max string length to allocate for dynamic text elements
 #define XSPINNER_STR_LEN  6
 
+// Define the status for GSLC_CB_INPUT callback
+#define XSPINNER_CB_STATE_UPDATE 3
+
 // Extended element data structures
 // - These data structures are maintained in the gslc_tsElem
 //   structure via the pXData pointer


### PR DESCRIPTION
Implement **XKeyPad** base component for #5 
- Provide **XKeyPad_Num** and **XKeyPad_Alpha** variants, with easy means of creating new variants and user-defined keypad layouts
- Add examples `ex26_ard_calc` as simple calculator to demonstrate XKeyPad_Num and `ex27_ard_alpha`
- Integration of XKeyPad with the Builder is currently in progress
- Note that the XKeyPad APIs are subject to change as the Builder integration is finalized

Outstanding items:
- Multiple keypad page capability (eg. case change)
- Memory-optimized version
- Redraw optimization

Other changes:
- Callback parameter list for `GSLC_CB_INPUT` was changed to provide status and data return