### PR TITLE
XRingGauge

### DIFF
--- a/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
+++ b/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
@@ -1,0 +1,238 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 42 (Arduino):
+//   - Demonstrate ring gauge, controlled by slider
+//   - Expected behavior: Clicking on button terminates program
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XSlider.h"
+#include "elem/XRingGauge.h"
+
+#define USE_EXTRA_FONTS
+
+#ifdef USE_EXTRA_FONTS
+  // Note that these files are located within the Adafruit-GFX library folder:
+  #include <Adafruit_GFX.h>
+  #include "Fonts/FreeSansBold12pt7b.h"
+#endif
+
+// To limit noisy touchscreen input, add optional filtering
+#define FILTER_UPDATES // Comment out to disable filtering
+#define FILTER_MODE 3
+#define UPDATE_PERIOD 200
+#define UPDATE_FLOAT 5
+
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum { E_PG_MAIN };
+enum { E_ELEM_BOX, E_ELEM_BTN_QUIT, E_ELEM_XRING, E_ELEM_SLIDER };
+enum { E_FONT_BTN, E_FONT_DIAL, MAX_FONT };
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_ELEM_PG_MAIN    4
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+gslc_tsXSlider              m_sXSlider;
+gslc_tsXRingGauge           m_sXRingGauge;
+
+// Save some element references for quick access
+gslc_tsElemRef*  m_pElemSlider = NULL;
+gslc_tsElemRef*  m_pElemXRingGauge = NULL;
+
+int16_t m_nSliderPos = 0;
+
+uint16_t m_nLoops = 0;
+int16_t m_nCount = 0;
+bool m_bCountUp = true;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+uint32_t m_nTimeLast = 0;
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui, void *pvElem, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+
+void setup()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  // Initialize
+  if (!gslc_Init(&m_gui, &m_drv, m_asPage, MAX_PAGE, m_asFont, MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontSet(&m_gui, E_FONT_BTN, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+#ifdef USE_EXTRA_FONTS
+  if (!gslc_FontSet(&m_gui, E_FONT_DIAL, GSLC_FONTREF_PTR, &FreeSansBold12pt7b, 1)) { return; }
+#else
+  if (!gslc_FontSet(&m_gui, E_FONT_DIAL, GSLC_FONTREF_PTR, NULL, 2)) { return; }
+#endif
+
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPageElem, MAX_ELEM_PG_MAIN, m_asPageElemRef, MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui, E_ELEM_BOX, E_PG_MAIN, (gslc_tsRect) { 10, 50, 300, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_MAIN,
+    (gslc_tsRect) { 235, 5, 80, 30 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnQuit);
+
+  // Create a RingGauge
+  static char m_str10[10] = "";
+  pElemRef = gslc_ElemXRingGaugeCreate(&m_gui, E_ELEM_XRING, E_PG_MAIN, &m_sXRingGauge,
+    (gslc_tsRect) { 80, 80, 100, 100 }, m_str10, 10, E_FONT_DIAL);
+  gslc_ElemXRingGaugeSetRange(&m_gui, pElemRef, 0, 100);
+  gslc_ElemXRingGaugeSetPos(&m_gui, pElemRef, 60); // Set initial value
+  // The following are some additional config options available
+  //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 15);
+  //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
+  //gslc_ElemXRingGaugeSetRingColorFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
+  //gslc_ElemXRingGaugeSetRingColorGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
+  m_pElemXRingGauge = pElemRef; // Save for quick access
+
+   // Create slider
+  pElemRef = gslc_ElemXSliderCreate(&m_gui, E_ELEM_SLIDER, E_PG_MAIN, &m_sXSlider,
+    (gslc_tsRect) { 200, 80, 100, 20 }, 0, 100, 60, 5, false);
+  gslc_ElemXSliderSetStyle(&m_gui, pElemRef, true, (gslc_tsColor) { 0, 0, 128 }, 10,
+    5, (gslc_tsColor) { 64, 64, 64 });
+  gslc_ElemXSliderSetPosFunc(&m_gui, pElemRef, &CbSlidePos);
+  m_pElemSlider = pElemRef; // Save for quick access
+
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+
+  m_bQuit = false;
+
+  // Initialize startup state
+  m_nSliderPos = gslc_ElemXSliderGetPos(&m_gui, m_pElemSlider);
+  m_nTimeLast = millis();
+}
+
+// Callback function for when a slider's position has been updated
+bool CbSlidePos(void* pvGui, void* pvElemRef, int16_t nPos)
+{
+  gslc_tsGui*     pGui = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem = pElemRef->pElem;
+  //gslc_tsXSlider* pSlider = (gslc_tsXSlider*)(pElem->pXData);
+
+  switch (pElem->nId) {
+  case E_ELEM_SLIDER:
+    m_nSliderPos = gslc_ElemXSliderGetPos(pGui, pElemRef);
+    break;
+  default:
+    break;
+  }
+  return true;
+}
+
+
+
+void loop()
+{
+  char acStr[10];
+
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+  // Do we want to filter out some touchscreen inputs?
+#if !defined(FILTER_UPDATES)
+  // No filtering enabled -- update the XRingGauge immediately
+
+  // Update the XRingGauge position with the slider position
+  gslc_ElemXRingGaugeSetPos(&m_gui, m_pElemXRingGauge, m_nSliderPos);
+
+  // Update the XRingGauge text string with a percentage
+  snprintf(acStr, 10, "%d%%", m_nSliderPos);
+  gslc_ElemSetTxtStr(&m_gui, m_pElemXRingGauge, acStr);
+
+#else
+
+  // Provide some filtering to limit the gauge updates
+  // due to noisy touchscreen readings
+  bool bDoUpdate = false;
+  static int16_t nValLast = -999; // Initialize to invalid value
+
+  // Perform an update if it has been some time since the last
+  // update, or if the position has changed moderately
+  if ((millis() - m_nTimeLast) >= UPDATE_PERIOD) {
+    bDoUpdate = true;
+  } else {
+    if (abs(m_nSliderPos - nValLast) > UPDATE_FLOAT) {
+      bDoUpdate = true;
+    }
+  }
+
+  // Do we want to update the XRingGauge?
+  if (bDoUpdate) {
+    // Update the XRingGauge position with the slider position
+    gslc_ElemXRingGaugeSetPos(&m_gui, m_pElemXRingGauge, m_nSliderPos);
+
+    // Update the XRingGauge text string with a percentage
+    snprintf(acStr, 10, "%d%%", m_nSliderPos);
+    gslc_ElemSetTxtStr(&m_gui, m_pElemXRingGauge, acStr);
+
+    // Remember the time and value of this update
+    nValLast = m_nSliderPos;
+    m_nTimeLast = millis();
+  }
+
+#endif // FILTER_UPDATES
+
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) {}
+  }
+}

--- a/examples/linux/Makefile
+++ b/examples/linux/Makefile
@@ -110,7 +110,8 @@ SRC =   ex01_lnx_basic.c \
 	ex18_lnx_compound.c \
 	ex22_lnx_input_key.c \
 	ex24_lnx_tabs.c \
-	ex31_lnx_listbox.c
+	ex31_lnx_listbox.c \
+	ex42_lnx_ring.c
 
 # Add simple example for specific driver modes
 ifeq (SDL1,${GSLC_DRV})
@@ -195,5 +196,10 @@ ex24_lnx_tabs: ex24_lnx_tabs.c $(GSLC_CORE) $(GSLC_SRCS)
 ex31_lnx_listbox: ex31_lnx_listbox.c $(GSLC_CORE) $(GSLC_SRCS)
 	@echo [Building $@]
 	@$(CC) $(CFLAGS) -o $@ ex31_lnx_listbox.c $(GSLC_CORE) $(GSLC_SRCS) $(LDFLAGS) $(LDLIBS) -I . -I ../../src
+
+ex42_lnx_ring: ex42_lnx_ring.c $(GSLC_CORE) $(GSLC_SRCS)
+	@echo [Building $@]
+	@$(CC) $(CFLAGS) -o $@ ex42_lnx_ring.c $(GSLC_CORE) $(GSLC_SRCS) $(LDFLAGS) $(LDLIBS) -I . -I ../../src
+
 
 

--- a/examples/linux/ex42_lnx_ring.c
+++ b/examples/linux/ex42_lnx_ring.c
@@ -1,0 +1,199 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 42 (LINUX):
+//   - Demonstrate ring gauge, controlled by slider
+//
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XSlider.h"
+#include "elem/XRingGauge.h"
+
+
+// Defines for resources
+#define FONT_FNAME_BTN "/usr/share/fonts/truetype/noto/NotoMono-Regular.ttf"
+#define FONT_FNAME_DIAL "/usr/share/fonts/truetype/noto/NotoMono-Regular.ttf"
+
+// Enumerations for pages, elements, fonts, images
+enum { E_PG_MAIN };
+enum { E_ELEM_BOX, E_ELEM_BTN_QUIT, E_ELEM_XRING, E_ELEM_SLIDER };
+enum { E_FONT_BTN, E_FONT_DIAL, MAX_FONT };
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_ELEM_PG_MAIN    4
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+gslc_tsXSlider              m_sXSlider;
+gslc_tsXRingGauge           m_sXRingGauge;
+
+// Save some element references for quick access
+gslc_tsElemRef*  m_pElemSlider = NULL;
+gslc_tsElemRef*  m_pElemXRingGauge = NULL;
+
+// Program global variables
+int16_t m_nSliderPos = 0;
+
+
+// Configure environment variables suitable for display
+// - These may need modification to match your system
+//   environment and display type
+// - Defaults for GSLC_DEV_FB and GSLC_DEV_TOUCH are in GUIslice_config.h
+// - Note that the environment variable settings can
+//   also be set directly within the shell via export
+//   (or init script).
+//   - eg. export TSLIB_FBDEVICE=/dev/fb1
+void UserInitEnv()
+{
+#if defined(DRV_DISP_SDL1) || defined(DRV_DISP_SDL2)
+  setenv((char*)"FRAMEBUFFER",GSLC_DEV_FB,1);
+  setenv((char*)"SDL_FBDEV",GSLC_DEV_FB,1);
+  setenv((char*)"SDL_VIDEODRIVER",GSLC_DEV_VID_DRV,1);
+#endif
+
+#if defined(DRV_TOUCH_TSLIB)
+  setenv((char*)"TSLIB_FBDEVICE",GSLC_DEV_FB,1);
+  setenv((char*)"TSLIB_TSDEVICE",GSLC_DEV_TOUCH,1);
+  setenv((char*)"TSLIB_CALIBFILE",(char*)"/etc/pointercal",1);
+  setenv((char*)"TSLIB_CONFFILE",(char*)"/etc/ts.conf",1);
+  setenv((char*)"TSLIB_PLUGINDIR",(char*)"/usr/local/lib/ts",1);
+#endif
+
+}
+
+// Define debug message function
+static int16_t DebugOut(char ch) { fputc(ch,stderr); return 0; }
+
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+
+// Callback function for when a slider's position has been updated
+bool CbSlidePos(void* pvGui, void* pvElemRef, int16_t nPos)
+{
+  gslc_tsGui*     pGui     = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem    = gslc_GetElemFromRef(pGui,pElemRef);
+  //gslc_tsXSlider* pSlider = (gslc_tsXSlider*)(pElem->pXData);
+
+  switch (pElem->nId) {
+  case E_ELEM_SLIDER:
+    m_nSliderPos = gslc_ElemXSliderGetPos(pGui, pElemRef);
+    break;
+  default:
+    break;
+  }
+  return true;
+}
+
+// Create page elements
+bool InitOverlays()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+  
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPageElem, MAX_ELEM_PG_MAIN, m_asPageElemRef, MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui, E_ELEM_BOX, E_PG_MAIN, (gslc_tsRect) { 10, 50, 300, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_MAIN,
+    (gslc_tsRect) { 235, 5, 80, 30 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnQuit);
+
+  // Create a RingGauge
+  static char m_str10[10] = "";
+  pElemRef = gslc_ElemXRingGaugeCreate(&m_gui, E_ELEM_XRING, E_PG_MAIN, &m_sXRingGauge,
+    (gslc_tsRect) { 80, 80, 100, 100 }, m_str10, 10, E_FONT_DIAL);
+  gslc_ElemXRingGaugeSetRange(&m_gui, pElemRef, 0, 100);
+  gslc_ElemXRingGaugeSetPos(&m_gui, pElemRef, 60); // Set initial value
+  // The following are some additional config options available
+  //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 15);
+  //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
+  //gslc_ElemXRingGaugeSetRingColorFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
+  //gslc_ElemXRingGaugeSetRingColorGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
+  m_pElemXRingGauge = pElemRef; // Save for quick access
+
+   // Create slider
+  pElemRef = gslc_ElemXSliderCreate(&m_gui, E_ELEM_SLIDER, E_PG_MAIN, &m_sXSlider,
+    (gslc_tsRect) { 200, 80, 100, 20 }, 0, 100, 60, 5, false);
+  gslc_ElemXSliderSetStyle(&m_gui, pElemRef, true, (gslc_tsColor) { 0, 0, 128 }, 10,
+    5, (gslc_tsColor) { 64, 64, 64 });
+  gslc_ElemXSliderSetPosFunc(&m_gui, pElemRef, &CbSlidePos);
+  m_pElemSlider = pElemRef; // Save for quick access
+  
+  return true;
+}
+
+
+int main( int argc, char* args[] )
+{
+  char   acStr[10];  
+
+  // -----------------------------------
+  // Initialize
+  gslc_InitDebug(&DebugOut);
+  UserInitEnv();
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { exit(1); }
+
+  // Load Fonts
+  // - Normally we would select a number of different fonts 
+  if (!gslc_FontSet(&m_gui, E_FONT_BTN, GSLC_FONTREF_FNAME, FONT_FNAME_BTN, 10)) { return 0; }
+  if (!gslc_FontSet(&m_gui, E_FONT_DIAL, GSLC_FONTREF_FNAME, FONT_FNAME_DIAL, 18)) { return 0; }
+
+  // -----------------------------------
+  // Start display
+  InitOverlays();
+
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+
+  // Initialize startup state
+  m_nSliderPos = gslc_ElemXSliderGetPos(&m_gui, m_pElemSlider);
+
+  // -----------------------------------
+  // Main event loop
+  while (!m_bQuit) {
+  
+    // Update the XRingGauge position with the slider position
+    gslc_ElemXRingGaugeSetPos(&m_gui, m_pElemXRingGauge, m_nSliderPos);
+
+    // Update the XRingGauge text string with a percentage
+    snprintf(acStr, 10, "%d%%", m_nSliderPos);
+    gslc_ElemSetTxtStr(&m_gui, m_pElemXRingGauge, acStr);  
+  
+    gslc_Update(&m_gui);
+  }
+
+  // -----------------------------------
+  // Close down display
+  gslc_Quit(&m_gui);
+
+  return 0;
+}

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2967,8 +2967,7 @@ void gslc_ElemSetTxtStr(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,const char* pS
   if (strncmp(pElem->pStrBuf,pStr,pElem->nStrBufMax-1)) {
     strncpy(pElem->pStrBuf,pStr,pElem->nStrBufMax-1);
     pElem->pStrBuf[pElem->nStrBufMax-1] = '\0';  // Force termination
-    // TODO: Might want to change to GSLC_REDRAW_INC
-    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
   }
 }
 

--- a/src/elem/XKeyPad_Alpha.c
+++ b/src/elem/XKeyPad_Alpha.c
@@ -170,6 +170,14 @@ gslc_tsElemRef* gslc_ElemXKeyPadCreate_Alpha(gslc_tsGui* pGui, int16_t nElemId, 
   pXDataBase->nSubElemMax = XKEYPADALPHA_ELEM_MAX;
   pXDataBase->psElemRef = pXData->asElemRef;
   pXDataBase->psElem = pXData->asElem;
+
+  // Provide default config if none supplied
+  gslc_tsXKeyPadCfg sConfigTmp;
+  if (pConfig == NULL) {
+    sConfigTmp = gslc_ElemXKeyPadCfgInit_Alpha();
+    pConfig = &sConfigTmp;
+  }
+
   return gslc_ElemXKeyPadCreateBase(pGui, nElemId, nPage, pXDataBase, nX0, nY0, nFontId, pConfig,
     &XKeyPadCreateKeys_Alpha,&XKeyPadLookup_Alpha);
 }

--- a/src/elem/XKeyPad_Num.c
+++ b/src/elem/XKeyPad_Num.c
@@ -172,6 +172,14 @@ gslc_tsElemRef* gslc_ElemXKeyPadCreate_Num(gslc_tsGui* pGui, int16_t nElemId, in
   pXDataBase->nSubElemMax = XKEYPADNUM_ELEM_MAX;
   pXDataBase->psElemRef = pXData->asElemRef;
   pXDataBase->psElem = pXData->asElem;
+
+  // Provide default config if none supplied
+  gslc_tsXKeyPadCfg sConfigTmp;
+  if (pConfig == NULL) {
+    sConfigTmp = gslc_ElemXKeyPadCfgInit_Num();
+    pConfig = &sConfigTmp;
+  }
+
   return gslc_ElemXKeyPadCreateBase(pGui, nElemId, nPage, pXDataBase, nX0, nY0, nFontId, pConfig,
     &XKeyPadCreateKeys_Num,&XKeyPadLookup_Num);
 }

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -1,0 +1,387 @@
+// =======================================================================
+// GUIslice library (Ring control)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XRingGauge.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XRingGauge.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: Ring gauge
+// ============================================================================
+
+// Create a text element and add it to the GUI element list
+// - Defines default styling for the element
+// - Defines callback for redraw and touch
+gslc_tsElemRef* gslc_ElemXRingGaugeCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+    gslc_tsXRingGauge* pXData, gslc_tsRect rElem, char* pStrBuf, uint8_t nStrBufMax, int16_t nFontId)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRingGaugeCreate";
+    GSLC_DEBUG_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_RING,rElem,pStrBuf,nStrBufMax,nFontId);
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_BLUE;
+  sElem.colElemText       = GSLC_COL_YELLOW;
+  sElem.nFeatures         = GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_CLICK_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_GLOW_EN;
+  sElem.eTxtAlign         = GSLC_ALIGN_MID_MID;
+
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+
+  // Provide default config
+  pXData->nPosMin = 0;
+  pXData->nPosMax = 100;
+  pXData->nThickness = 10;
+
+  pXData->nDeg64PerSeg = 5 * 64; // Defaul to 5 degree segments
+  pXData->bGradient = false;
+  pXData->nSegGap = 0;
+  pXData->colRing1 = GSLC_COL_BLUE_LT4;
+  pXData->colRing2 = GSLC_COL_RED;
+  pXData->colRingRemain = (gslc_tsColor) { 0, 0, 48 };
+
+  pXData->nPos = 0;
+  pXData->nPosLast = 0;
+  pXData->acStrLast[0] = 0;
+
+
+  sElem.pXData            = (void*)(pXData);
+  // Specify the custom drawing callback
+  sElem.pfuncXDraw        = &gslc_ElemXRingGaugeDraw;
+  // Specify the custom touch tracking callback
+  sElem.pfuncXTouch = NULL;
+
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+
+// Redraw the element
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)pvElemRef;
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return false;
+
+
+  // --------------------------------------------------------------------------
+  // Init for default drawing
+  // --------------------------------------------------------------------------
+
+  bool      bGlowEn,bGlowing,bGlowNow;
+  int16_t   nElemX,nElemY;
+  uint16_t  nElemW,nElemH;
+
+  nElemX    = pElem->rElem.x;
+  nElemY    = pElem->rElem.y;
+  nElemW    = pElem->rElem.w;
+  nElemH    = pElem->rElem.h;
+  bGlowEn   = pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN; // Does the element support glow state?
+  bGlowing  = gslc_ElemGetGlow(pGui,pElemRef); // Element should be glowing (if enabled)
+  bGlowNow  = bGlowEn & bGlowing; // Element is currently glowing
+
+  int16_t nVal = pXRingGauge->nPos;
+  int16_t nValLast = pXRingGauge->nPosLast;
+
+  gslc_tsColor colRingActive1 = pXRingGauge->colRing1;
+  gslc_tsColor colRingActive2 = pXRingGauge->colRing2;
+  gslc_tsColor colRingInactive = pXRingGauge->colRingRemain;
+  gslc_tsColor colBg = pElem->colElemFill; // Background color used for text clearance
+  gslc_tsColor colStep;
+
+  // Calculate the ring center and radius
+  int16_t nMidX = nElemX + nElemW / 2;
+  int16_t nMidY = nElemY + nElemH / 2;
+  int16_t nRad2 = (nElemW < nElemH) ? nElemW / 2 : nElemH / 2;
+  int16_t nRad1 = nRad2 - pXRingGauge->nThickness;
+
+  // --------------------------------------------------------------------------
+
+  gslc_tsPt anPts[4]; // Storage for points in segment quadrilaterla
+  int16_t nAng64Start,nAng64End;
+  int16_t nX, nY;
+
+  // Calculate segment ranges
+  // - TODO: Handle nPosMin, nPosMax
+  // - TODO: Rewrite to use nDeg64PerSeg more effectively
+  // - FIXME: Handle case with nDeg64PerSeg < 64 (ie. <1 degree)
+  int16_t nStep64 = pXRingGauge->nDeg64PerSeg; // Trig functions work on 1/64 degree units
+  int16_t nStepAng = nStep64 / 64;
+  uint32_t nValSegs = ((uint32_t)nVal * 360 / 100) / nStepAng; // Segment index of current value
+  uint32_t nLastSegs = ((uint32_t)nValLast * 360 / 100) / nStepAng; // Segment index of previous value
+  int16_t nMaxSegs = 360 / nStepAng; // Final segment index of circle
+
+  // Determine whether we should draw the full range (full redraw)
+  // or a smaller, updated region (incremental redraw)
+  bool bInc = (eRedraw == GSLC_REDRAW_INC) ? true : false;
+  int16_t nSegStart, nSegEnd;
+  if (bInc) {
+    if (nVal > nValLast) {
+      nSegStart = nLastSegs;
+      nSegEnd = nValSegs;
+    } else {
+      nSegStart = nValSegs;
+      nSegEnd = nLastSegs;
+    }
+  } else {
+    nSegStart = 0;
+    nSegEnd = nMaxSegs;
+  }
+  //GSLC_DEBUG_PRINT("DBG: redraw inc=%d last=%d cur=%d segs %d..%d\n", bInc,nValLast,nVal,nSegStart, nSegEnd);
+
+  // TODO: Consider drawing in reverse order if (nVal < nValLast)
+  for (uint16_t nSegInd = nSegStart; nSegInd < nSegEnd; nSegInd++) {
+    nAng64Start = nSegInd * nStep64;
+    nAng64End = nAng64Start + nStep64;
+
+    // Convert polar coordinates into cartesian
+    gslc_PolarToXY(nRad1, nAng64Start, &nX, &nY);
+    anPts[0] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+    gslc_PolarToXY(nRad2, nAng64Start, &nX, &nY);
+    anPts[1] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+    gslc_PolarToXY(nRad2, nAng64End, &nX, &nY);
+    anPts[2] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+    gslc_PolarToXY(nRad1, nAng64End, &nX, &nY);
+    anPts[3] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+
+    // Adjust color depending on which segment we are rendering
+    if (nSegInd < nValSegs) {
+		  if (pXRingGauge->bGradient) {
+        // Gradient coloring
+			  uint16_t nGradPos = 1000.0 * nSegInd / nMaxSegs;
+			  colStep = gslc_ColorBlend2(colRingActive1, colRingActive2, 500, nGradPos);
+		  } else {
+        // Flat coloring
+			  colStep = colRingActive1;
+		  }
+    } else {
+      colStep = colRingInactive;
+    }
+
+    // TODO: Support gapped regions between segments
+
+    // Draw the quadrilateral representing the circle segment
+    gslc_DrawFillQuad(pGui, anPts, colStep);
+
+  }
+
+  // --------------------------------------------------------------------------
+  // Text overlays
+  // --------------------------------------------------------------------------
+
+  // Draw text string if defined
+  if (pElem->pStrBuf) {
+    gslc_tsColor  colTxt    = (bGlowNow)? pElem->colElemTextGlow : pElem->colElemText;
+    int16_t       nMargin   = pElem->nTxtMargin;
+
+    // Erase old string content using "background" color
+    if (strlen(pXRingGauge->acStrLast) != 0) {
+      gslc_DrawTxtBase(pGui, pXRingGauge->acStrLast, pElem->rElem, pElem->pTxtFont, pElem->eTxtFlags,
+        pElem->eTxtAlign, colBg, GSLC_COL_BLACK, nMargin, nMargin);
+    }
+
+    // Draw new string content
+    gslc_DrawTxtBase(pGui, pElem->pStrBuf, pElem->rElem, pElem->pTxtFont, pElem->eTxtFlags,
+      pElem->eTxtAlign, colTxt, GSLC_COL_BLACK, nMargin, nMargin);
+
+    // Save a copy of the new string content so we can support future erase
+    strncpy(pXRingGauge->acStrLast, pElem->pStrBuf, XRING_STR_MAX);
+    pXRingGauge->acStrLast[XRING_STR_MAX - 1] = 0; // Force null terminator
+
+  } // pStrBuf
+
+  // Save the position to enable future incremental calculations
+  pXRingGauge->nPosLast = pXRingGauge->nPos;
+
+
+  // --------------------------------------------------------------------------
+
+  // Mark the element as no longer requiring redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  return true;
+
+}
+
+void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPos)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  int16_t           nPosOld;
+
+  // Clip position
+  if (nPos < pXRingGauge->nPosMin) { nPos = pXRingGauge->nPosMin; }
+  if (nPos > pXRingGauge->nPosMax) { nPos = pXRingGauge->nPosMax; }
+
+  // Update
+  nPosOld = pXRingGauge->nPos;
+  pXRingGauge->nPos = nPos;
+
+  // Only update if changed
+  if (nPos != nPosOld) {
+    // Mark for redraw
+    // - Only need incremental redraw
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+  }
+
+}
+
+void gslc_ElemXRingGaugeSetRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  pXRingGauge->nPosMin = nPosMin;
+  pXRingGauge->nPosMax = nPosMax;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXRingGaugeSetThickness(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nThickness)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  pXRingGauge->nThickness = nThickness;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  pXRingGauge->bGradient = false;
+  pXRingGauge->colRing1 = colActive;
+  pXRingGauge->colRing2 = colActive;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  pXRingGauge->bGradient = true;
+  pXRingGauge->colRing1 = colStart;
+  pXRingGauge->colRing2 = colEnd;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+
+void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  pXRingGauge->bGradient = true;
+  pXRingGauge->colRingRemain = colInactive;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+
+
+void gslc_ElemXRingGaugeSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nSegments)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  // Convert from number of segments to degrees
+  uint16_t nDeg64PerSeg = 360 * 64 / nSegments;
+  pXRingGauge->nDeg64PerSeg = nDeg64PerSeg;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+
+// ============================================================================

--- a/src/elem/XRingGauge.h
+++ b/src/elem/XRingGauge.h
@@ -1,0 +1,150 @@
+#ifndef _GUISLICE_EX_XRING_H_
+#define _GUISLICE_EX_XRING_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: XRingGauge
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XRingGauge.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+// ============================================================================
+// Extended Element: XRingGauge
+// - NOTE: This element type is new and the APIs are subject to change
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_RING GSLC_TYPE_BASE_EXTEND + 23
+
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+#define XRING_STR_MAX 10
+
+/// Extended data for XRingGauge element
+typedef struct {
+  // Config
+  int16_t           nPosMin;
+  int16_t           nPosMax;
+
+  // Style config
+  uint16_t          nDeg64PerSeg;
+  int8_t            nThickness;
+  bool              bGradient;
+  uint8_t           nSegGap;
+  gslc_tsColor      colRing1;
+  gslc_tsColor      colRing2;
+  gslc_tsColor      colRingRemain;
+
+  // State
+  int16_t           nPos;           ///< Current position value
+  int16_t           nPosLast;       ///< Previous position value
+  char              acStrLast[XRING_STR_MAX];
+
+  // Callbacks
+
+} gslc_tsXRingGauge;
+
+
+///
+/// Create an XRingGauge element
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining element size
+/// \param[in]  pStrBuf:     String buffer to use for gauge inner text
+/// \param[in]  nStrBufMax:  Maximum length of string buffer (pStrBuf)
+/// \param[in]  nFontId:     Font ID to use for text display
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXRingGaugeCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXRingGauge* pXData, gslc_tsRect rElem, char* pStrBuf, uint8_t nStrBufMax, int16_t nFontId);
+
+
+///
+/// Draw the template element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+
+///
+/// Set an XRingGauge element's current position
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nPos:        New position value
+///
+/// \return none
+///
+void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos);
+
+/// \todo
+void gslc_ElemXRingGaugeSetRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax);
+void gslc_ElemXRingGaugeSetThickness(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nThickness);
+void gslc_ElemXRingGaugeSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nSegments);
+void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive);
+void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive);
+void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd);
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XRING_H_
+


### PR DESCRIPTION
Add **XRingGauge** element
- Provides a circular / donut chart control
- Supports gradient fill, thickness controls
- Custom inner text display

![image](https://user-images.githubusercontent.com/8510097/58852289-c60db600-864a-11e9-8243-c0b621a01103.png)

Example code: (see ex42)
```c++
  static char m_str10[10] = "";
  pElemRef = gslc_ElemXRingGaugeCreate(&m_gui, E_ELEM_XRING, E_PG_MAIN, &m_sXRingGauge,
    (gslc_tsRect) { 80, 80, 100, 100 }, m_str10, 10, E_FONT_DIAL);
  gslc_ElemXRingGaugeSetPos(&m_gui, pElemRef, 60); // Set initial value
  gslc_ElemXRingGaugeSetRingColorGradient(&m_gui, pElemRef, GSLC_COL_BLUE, GSLC_COL_RED);
```