### PR TITLE
Add XGlowball element

### DIFF
--- a/examples/arduino/ex43_ard_glowball/ex43_ard_glowball.ino
+++ b/examples/arduino/ex43_ard_glowball/ex43_ard_glowball.ino
@@ -136,7 +136,7 @@ void setup()
 
   // Create a Glowball
   pElemRef = gslc_ElemXGlowballCreate(&m_gui, E_ELEM_XGLOW, E_PG_MAIN, &m_sXGlowball,
-    160, 120, asRings, NUM_RINGS);
+    120, 120, asRings, NUM_RINGS);
   gslc_ElemXGlowballSetColorBack(&m_gui, pElemRef, GSLC_COL_BLACK);
   gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 0, 360); // Full-circle (default)
   //gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 270, 360 + 90); // Semi-circle

--- a/examples/arduino/ex43_ard_glowball/ex43_ard_glowball.ino
+++ b/examples/arduino/ex43_ard_glowball/ex43_ard_glowball.ino
@@ -1,0 +1,156 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 43 (Arduino):
+//   - XGlowball demo
+//
+
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XGlowball.h"
+
+// Defines for resources
+
+// Enumerations for pages, elements, fonts, images
+enum { E_PG_MAIN };
+enum { E_ELEM_BOX, E_ELEM_BTN_QUIT, E_ELEM_XGLOW };
+enum { E_FONT_BTN };
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_FONT            1
+#define MAX_ELEM_PG_MAIN    3
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+gslc_tsXGlowball  m_sXGlowball;
+
+// Save some element references for quick access
+gslc_tsElemRef* m_pElemXGlowball = NULL;
+
+
+// Define debug message function
+static int16_t DebugOut(char ch) { Serial.write(ch); return 0; }
+
+int16_t m_nCount = 0;
+bool m_bCountUp = true;
+
+
+// Define the XGlowball appearance
+// The tsXGlowballRing array defines each ring in the Glowball:
+// - Inner radius
+// - Outer radius
+// - Color of ring
+// Note that rings should be defined from inner to outer.
+// It is valid to leave gaps between the rings if desired.
+// If the maximum radius is large, then the quality setting
+// may need to be increased to ensure the ring has a smooth appearance.
+#define NUM_RINGS 9
+gslc_tsXGlowballRing asRings[NUM_RINGS] = {
+  {0,12,(gslc_tsColor) { 138, 0, 255 }},
+  {12,18,(gslc_tsColor) { 0, 12, 255 }},
+  {18,24,(gslc_tsColor) { 0, 96, 255 }},
+  {24,30,(gslc_tsColor) { 0, 198, 255 }},
+  {30,36,(gslc_tsColor) { 0, 255, 150 }},
+  {36,42,(gslc_tsColor) { 33, 217, 0 }},
+  {42,48,(gslc_tsColor) { 255, 234, 0 }},
+  {48,54,(gslc_tsColor) { 255, 152, 0 }},
+  {54,60,(gslc_tsColor) { 255, 0, 0 }}
+};
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui, void *pvElem, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+
+
+void setup()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Initialize debug output
+  Serial.begin(9600);
+  gslc_InitDebug(&DebugOut);
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  // Initialize
+  if (!gslc_Init(&m_gui, &m_drv, m_asPage, MAX_PAGE, m_asFont, MAX_FONT)) { return; }
+
+  // Load Fonts
+  if (!gslc_FontAdd(&m_gui, E_FONT_BTN, GSLC_FONTREF_PTR, NULL, 1)) { return; }
+
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPageElem, MAX_ELEM_PG_MAIN, m_asPageElemRef, MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui, E_ELEM_BOX, E_PG_MAIN, (gslc_tsRect) { 10, 50, 300, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_MAIN,
+    (gslc_tsRect) { 235, 5, 80, 30 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnQuit);
+
+  pElemRef = gslc_ElemXGlowballCreate(&m_gui, E_ELEM_XGLOW, E_PG_MAIN, &m_sXGlowball,
+    160, 120, asRings, NUM_RINGS);
+  gslc_ElemXGlowballSetColorBack(&m_gui, pElemRef, GSLC_COL_BLACK);
+  gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 0, 360); // Full-circle (default)
+  //gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 270, 360 + 90); // Semi-circle
+  //gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 0, 90); // Quarter-circle
+  m_pElemXGlowball = pElemRef; // Save for quick access
+
+  // -----------------------------------
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui, E_PG_MAIN);
+
+  m_bQuit = false;
+
+  m_nCount = 0;
+}
+
+
+void loop()
+{
+  // Periodically call GUIslice update function
+  gslc_Update(&m_gui);
+
+
+  // Create pulsing counter
+  m_nCount += (m_bCountUp) ? 1 : -1;
+  if (m_nCount >= NUM_RINGS) { m_bCountUp = false; m_nCount = NUM_RINGS; }
+  else if (m_nCount < 0) { m_bCountUp = true; m_nCount = 1; }
+
+  gslc_ElemXGlowballSetVal(&m_gui, m_pElemXGlowball, m_nCount);
+
+  // In a real program, we would detect the button press and take an action.
+  // For this Arduino demo, we will pretend to exit by emulating it with an
+  // infinite loop. Note that interrupts are not disabled so that any debug
+  // messages via Serial have an opportunity to be transmitted.
+  if (m_bQuit) {
+    gslc_Quit(&m_gui);
+    while (1) {}
+  }
+}

--- a/examples/linux/Makefile
+++ b/examples/linux/Makefile
@@ -113,7 +113,8 @@ SRC =   ex01_lnx_basic.c \
 	ex22_lnx_input_key.c \
 	ex24_lnx_tabs.c \
 	ex31_lnx_listbox.c \
-	ex42_lnx_ring.c
+	ex42_lnx_ring.c \
+	ex43_lnx_glowball.c
 
 # Add simple example for specific driver modes
 ifeq (SDL1,${GSLC_DRV})
@@ -210,6 +211,10 @@ ex31_lnx_listbox: ex31_lnx_listbox.c $(GSLC_CORE) $(GSLC_SRCS)
 ex42_lnx_ring: ex42_lnx_ring.c $(GSLC_CORE) $(GSLC_SRCS)
 	@echo [Building $@]
 	@$(CC) $(CFLAGS) -o $@ ex42_lnx_ring.c $(GSLC_CORE) $(GSLC_SRCS) $(LDFLAGS) $(LDLIBS) -I . -I ../../src
+
+ex43_lnx_glowball: ex43_lnx_glowball.c $(GSLC_CORE) $(GSLC_SRCS)
+	@echo [Building $@]
+	@$(CC) $(CFLAGS) -o $@ ex43_lnx_glowball.c $(GSLC_CORE) $(GSLC_SRCS) $(LDFLAGS) $(LDLIBS) -I . -I ../../src
 
 
 

--- a/examples/linux/ex43_lnx_glowball.c
+++ b/examples/linux/ex43_lnx_glowball.c
@@ -1,0 +1,213 @@
+//
+// GUIslice Library Examples
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// - Example 43 (LINUX):
+//   - Demonstrate XGlowball gauge, controlled by slider
+//
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XSlider.h"
+#include "elem/XGlowball.h"
+
+
+// Defines for resources
+#define FONT_FNAME_BTN "/usr/share/fonts/truetype/noto/NotoMono-Regular.ttf"
+
+// Enumerations for pages, elements, fonts, images
+enum { E_PG_MAIN };
+enum { E_ELEM_BOX, E_ELEM_BTN_QUIT, E_ELEM_XGLOW, E_ELEM_SLIDER };
+enum { E_FONT_BTN, MAX_FONT };
+
+bool    m_bQuit = false;
+
+// Instantiate the GUI
+#define MAX_PAGE            1
+#define MAX_ELEM_PG_MAIN    4
+
+gslc_tsGui                  m_gui;
+gslc_tsDriver               m_drv;
+gslc_tsFont                 m_asFont[MAX_FONT];
+gslc_tsPage                 m_asPage[MAX_PAGE];
+gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN];
+gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
+
+gslc_tsXSlider              m_sXSlider;
+gslc_tsXGlowball            m_sXGlowball;
+
+// Save some element references for quick access
+gslc_tsElemRef* m_pElemSlider = NULL;
+gslc_tsElemRef* m_pElemXGlowball = NULL;
+
+
+// Program global variables
+int16_t m_nSliderPos = 0;
+
+
+
+// Define the XGlowball appearance
+// The tsXGlowballRing array defines each ring in the Glowball:
+// - Inner radius
+// - Outer radius
+// - Color of ring
+// Note that rings should be defined from inner to outer.
+// It is valid to leave gaps between the rings if desired.
+// If the maximum radius is large, then the quality setting
+// may need to be increased to ensure the ring has a smooth appearance.
+#define NUM_RINGS 9
+gslc_tsXGlowballRing asRings[NUM_RINGS] = {
+  {0,12,(gslc_tsColor) { 138, 0, 255 }},
+  {12,18,(gslc_tsColor) { 0, 12, 255 }},
+  {18,24,(gslc_tsColor) { 0, 96, 255 }},
+  {24,30,(gslc_tsColor) { 0, 198, 255 }},
+  {30,36,(gslc_tsColor) { 0, 255, 150 }},
+  {36,42,(gslc_tsColor) { 33, 217, 0 }},
+  {42,48,(gslc_tsColor) { 255, 234, 0 }},
+  {48,54,(gslc_tsColor) { 255, 152, 0 }},
+  {54,60,(gslc_tsColor) { 255, 0, 0 }}
+};
+
+// Configure environment variables suitable for display
+// - These may need modification to match your system
+//   environment and display type
+// - Defaults for GSLC_DEV_FB and GSLC_DEV_TOUCH are in GUIslice_config.h
+// - Note that the environment variable settings can
+//   also be set directly within the shell via export
+//   (or init script).
+//   - eg. export TSLIB_FBDEVICE=/dev/fb1
+void UserInitEnv()
+{
+#if defined(DRV_DISP_SDL1) || defined(DRV_DISP_SDL2)
+  setenv((char*)"FRAMEBUFFER",GSLC_DEV_FB,1);
+  setenv((char*)"SDL_FBDEV",GSLC_DEV_FB,1);
+  setenv((char*)"SDL_VIDEODRIVER",GSLC_DEV_VID_DRV,1);
+#endif
+
+#if defined(DRV_TOUCH_TSLIB)
+  setenv((char*)"TSLIB_FBDEVICE",GSLC_DEV_FB,1);
+  setenv((char*)"TSLIB_TSDEVICE",GSLC_DEV_TOUCH,1);
+  setenv((char*)"TSLIB_CALIBFILE",(char*)"/etc/pointercal",1);
+  setenv((char*)"TSLIB_CONFFILE",(char*)"/etc/ts.conf",1);
+  setenv((char*)"TSLIB_PLUGINDIR",(char*)"/usr/local/lib/ts",1);
+#endif
+
+}
+
+// Define debug message function
+static int16_t DebugOut(char ch) { fputc(ch,stderr); return 0; }
+
+
+// Button callbacks
+bool CbBtnQuit(void* pvGui, void *pvElemRef, gslc_teTouch eTouch, int16_t nX, int16_t nY)
+{
+  if (eTouch == GSLC_TOUCH_UP_IN) {
+    m_bQuit = true;
+  }
+  return true;
+}
+
+
+// Callback function for when a slider's position has been updated
+bool CbSlidePos(void* pvGui, void* pvElemRef, int16_t nPos)
+{
+  gslc_tsGui*     pGui     = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem    = gslc_GetElemFromRef(pGui,pElemRef);
+  //gslc_tsXSlider* pSlider = (gslc_tsXSlider*)(pElem->pXData);
+
+  switch (pElem->nId) {
+  case E_ELEM_SLIDER:
+    m_nSliderPos = gslc_ElemXSliderGetPos(pGui, pElemRef);
+    break;
+  default:
+    break;
+  }
+  return true;
+}
+
+// Create page elements
+bool InitOverlays()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+  
+  // -----------------------------------
+  // Create page elements
+  gslc_PageAdd(&m_gui, E_PG_MAIN, m_asPageElem, MAX_ELEM_PG_MAIN, m_asPageElemRef, MAX_ELEM_PG_MAIN);
+
+  // Background flat color
+  gslc_SetBkgndColor(&m_gui, GSLC_COL_GRAY_DK2);
+
+  // Create background box
+  pElemRef = gslc_ElemCreateBox(&m_gui, E_ELEM_BOX, E_PG_MAIN, (gslc_tsRect) { 10, 50, 300, 150 });
+  gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
+
+  // Create Quit button with text label
+  pElemRef = gslc_ElemCreateBtnTxt(&m_gui, E_ELEM_BTN_QUIT, E_PG_MAIN,
+    (gslc_tsRect) { 235, 5, 80, 30 }, (char*)"Quit", 0, E_FONT_BTN, &CbBtnQuit);
+
+  // Create a Glowball
+  pElemRef = gslc_ElemXGlowballCreate(&m_gui, E_ELEM_XGLOW, E_PG_MAIN, &m_sXGlowball,
+    80, 120, asRings, NUM_RINGS);
+  gslc_ElemXGlowballSetColorBack(&m_gui, pElemRef, GSLC_COL_BLACK);
+  gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 0, 360); // Full-circle (default)
+  //gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 270, 360 + 90); // Semi-circle
+  //gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 0, 90); // Quarter-circle
+  m_pElemXGlowball = pElemRef; // Save for quick access
+
+
+   // Create slider
+  pElemRef = gslc_ElemXSliderCreate(&m_gui, E_ELEM_SLIDER, E_PG_MAIN, &m_sXSlider,
+    (gslc_tsRect) { 200, 80, 100, 20 }, 0, 9, 0, 5, false);
+  gslc_ElemXSliderSetStyle(&m_gui, pElemRef, true, (gslc_tsColor) { 0, 0, 128 }, 10,
+    5, (gslc_tsColor) { 64, 64, 64 });
+  gslc_ElemXSliderSetPosFunc(&m_gui, pElemRef, &CbSlidePos);
+  m_pElemSlider = pElemRef; // Save for quick access
+  
+  return true;
+}
+
+
+int main( int argc, char* args[] )
+{
+
+  // -----------------------------------
+  // Initialize
+  gslc_InitDebug(&DebugOut);
+  UserInitEnv();
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { exit(1); }
+
+  // Load Fonts
+  // - Normally we would select a number of different fonts 
+  if (!gslc_FontSet(&m_gui, E_FONT_BTN, GSLC_FONTREF_FNAME, FONT_FNAME_BTN, 10)) { return 0; }
+
+  // -----------------------------------
+  // Start display
+  InitOverlays();
+
+  // Start up display on main page
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+
+  m_bQuit = false;
+
+  // Initialize startup state
+  m_nSliderPos = gslc_ElemXSliderGetPos(&m_gui, m_pElemSlider);
+
+  // -----------------------------------
+  // Main event loop
+  while (!m_bQuit) {
+  
+    // Update the XGlowball value with the slider position
+    gslc_ElemXGlowballSetVal(&m_gui, m_pElemXGlowball, m_nSliderPos);
+
+    gslc_Update(&m_gui);
+  }
+
+  // -----------------------------------
+  // Close down display
+  gslc_Quit(&m_gui);
+
+  return 0;
+}

--- a/examples/linux/ex43_lnx_glowball.c
+++ b/examples/linux/ex43_lnx_glowball.c
@@ -150,7 +150,7 @@ bool InitOverlays()
 
   // Create a Glowball
   pElemRef = gslc_ElemXGlowballCreate(&m_gui, E_ELEM_XGLOW, E_PG_MAIN, &m_sXGlowball,
-    80, 120, asRings, NUM_RINGS);
+    120, 120, asRings, NUM_RINGS);
   gslc_ElemXGlowballSetColorBack(&m_gui, pElemRef, GSLC_COL_BLACK);
   gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 0, 360); // Full-circle (default)
   //gslc_ElemXGlowballSetAngles(&m_gui, pElemRef, 270, 360 + 90); // Semi-circle

--- a/src/elem/XGlowball.c
+++ b/src/elem/XGlowball.c
@@ -1,0 +1,332 @@
+// =======================================================================
+// GUIslice library extension: XGlowball
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XGlowball.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XGlowball.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: XGlowball
+// ============================================================================
+
+// Create a XGlowball element and add it to the GUI element list
+// - Defines default styling for the element
+// - Defines callback for redraw and touch
+gslc_tsElemRef* gslc_ElemXGlowballCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXGlowball* pXData, int16_t nMidX, int16_t nMidY, gslc_tsXGlowballRing* pRings, uint8_t nNumRings)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXGlowballCreate";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+
+  // Calculate the actual element dimensions based on the ring defintion
+  // - Note that we use the outer radius of the last ring
+  int16_t nRadMax;
+  gslc_tsRect rElem;
+  nRadMax = pRings[nNumRings - 1].nRad2;
+  rElem.w = 2 * nRadMax;
+  rElem.h = 2 * nRadMax;
+  rElem.x = nMidX - nRadMax;
+  rElem.y = nMidY - nRadMax;
+
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_GLOW,rElem,NULL,0,GSLC_FONT_NONE);
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_GRAY;
+  sElem.colElemText       = GSLC_COL_WHITE;
+  sElem.colElemTextGlow   = GSLC_COL_WHITE;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_CLICK_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_GLOW_EN;
+  sElem.eTxtAlign         = GSLC_ALIGN_MID_LEFT;
+
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+
+  // Initialize any pxData members with default parameters
+  pXData->nVal = 0;
+  pXData->nQuality = 72;
+  pXData->nAngStart = 0;
+  pXData->nAngEnd = 360;
+  pXData->pRings = pRings;
+  pXData->nNumRings = nNumRings;
+  pXData->nMidX = nMidX;
+  pXData->nMidY = nMidY;
+  pXData->colBg = GSLC_COL_BLACK;
+  pXData->nValLast = 0;
+
+
+  sElem.pXData            = (void*)(pXData);
+  // Specify the custom drawing callback
+  sElem.pfuncXDraw        = &gslc_ElemXGlowballDraw;
+  // Specify the custom touch tracking callback
+  sElem.pfuncXTouch = NULL;
+
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+
+void drawXGlowballArc(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMidX, int16_t nMidY, int16_t nRad1, int16_t nRad2, gslc_tsColor cArc, uint16_t nAngStart, uint16_t nAngEnd)
+{
+  gslc_tsPt anPts[4];
+  // TODO: Cleanup
+  int16_t nStepAng = 360 / pGlowball->nQuality;
+  int16_t nStep64 = 64 * nStepAng;
+  int16_t nAng64;
+  int16_t nSegs = pGlowball->nQuality;
+  int16_t nX, nY;
+  int16_t nSegStart, nSegEnd;
+  nSegStart = nAngStart * pGlowball->nQuality / 360;
+  nSegEnd = nAngEnd * pGlowball->nQuality / 360;
+
+  for (uint16_t nSegInd = nSegStart; nSegInd < nSegEnd; nSegInd++) {
+    nAng64 = nSegInd * nStep64;
+    nAng64 = nAng64 % (360 * 64);
+
+    gslc_PolarToXY(nRad1, nAng64, &nX, &nY);
+    anPts[0] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+    gslc_PolarToXY(nRad2, nAng64, &nX, &nY);
+    anPts[1] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+    gslc_PolarToXY(nRad2, nAng64 + nStep64, &nX, &nY);
+    anPts[2] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+    gslc_PolarToXY(nRad1, nAng64 + nStep64, &nX, &nY);
+    anPts[3] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+
+    gslc_DrawFillQuad(pGui, anPts, cArc);
+  }
+}
+
+
+void drawXGlowballRing(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMidX, int16_t nMidY, int16_t nVal, uint16_t nAngStart, uint16_t nAngEnd, bool bErase)
+{
+  int16_t nRad1, nRad2;
+  gslc_tsColor cCol;
+
+  if ((nVal <= 0) || (nVal > pGlowball->nNumRings)) {
+    return;
+  }
+
+  nRad1 = pGlowball->pRings[nVal - 1].nRad1;
+  nRad2 = pGlowball->pRings[nVal - 1].nRad2;
+  cCol = (bErase) ? pGlowball->colBg : pGlowball->pRings[nVal - 1].cCol;
+
+  drawXGlowballArc(pGui, pGlowball, nMidX, nMidY, nRad1, nRad2, cCol, nAngStart, nAngEnd);
+}
+
+// nAngStart & nAngEnd define the range (in degrees) for the XGlowball arcs
+// - Angles are measured with 0 degrees at the top, incrementing clockwise
+// - Note that the supported range is 0..510 degrees
+// nVal represents the value to set (0.. NUM_RINGS)
+// nMidX,nMidY define the center of the XGlowball
+void drawXGlowball(gslc_tsGui* pGui,gslc_tsXGlowball* pGlowball, int16_t nMidX, int16_t nMidY, int16_t nVal, uint16_t nAngStart, uint16_t nAngEnd)
+{
+  int16_t nValLast = pGlowball->nValLast;
+  int8_t nRingInd;
+
+  if (nVal > nValLast) {
+    for (nRingInd = nValLast + 1; nRingInd <= nVal; nRingInd++) {
+      drawXGlowballRing(pGui, pGlowball, nMidX, nMidY, nRingInd, nAngStart, nAngEnd, false);
+    }
+  } else {
+    for (nRingInd = nValLast; nRingInd > nVal; nRingInd--) {
+      drawXGlowballRing(pGui, pGlowball, nMidX, nMidY, nRingInd, nAngStart, nAngEnd, true);
+    }
+  }
+  pGlowball->nValLast = nVal;
+}
+
+void gslc_ElemXGlowballSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nVal)
+{
+  if ((pGui == NULL) || (pElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXGlowballSetVal";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXGlowball* pGlowball = (gslc_tsXGlowball*)(pElem->pXData);
+
+  // Update the value
+  pGlowball->nVal = nVal;
+
+  // Mark for redraw
+  // - Only need incremental redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+}
+
+void gslc_ElemXGlowballSetAngles(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nAngStart, int16_t nAngEnd)
+{
+  if ((pGui == NULL) || (pElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXGlowballSetAngles";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXGlowball* pGlowball = (gslc_tsXGlowball*)(pElem->pXData);
+
+  // Update the angular ranges
+  pGlowball->nAngStart = nAngStart;
+  pGlowball->nAngEnd = nAngEnd;
+
+  // Mark for redraw
+  // - Force full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXGlowballSetColorBack(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colBg)
+{
+  if ((pGui == NULL) || (pElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXGlowballSetColorBack";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXGlowball* pGlowball = (gslc_tsXGlowball*)(pElem->pXData);
+
+  // Update the background color
+  pGlowball->colBg = colBg;
+
+  // Mark for redraw
+  // - Force full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+// Redraw the element
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+bool gslc_ElemXGlowballDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXGlowballDraw";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return false;
+  }
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui  = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui,pElemRef);
+
+  // Fetch the element's extended data structure
+  gslc_tsXGlowball* pGlowball;
+  pGlowball = (gslc_tsXGlowball*)(pElem->pXData);
+  if (pGlowball == NULL) {
+    GSLC_DEBUG2_PRINT("ERROR: ElemXGlowballDraw(%s) pXData is NULL\n","");
+    return false;
+  }
+
+  // --------------------------------------------------------------------------
+  // Init for default drawing
+  // --------------------------------------------------------------------------
+
+  int16_t   nElemX,nElemY;
+  uint16_t  nElemW,nElemH;
+
+  nElemX    = pElem->rElem.x;
+  nElemY    = pElem->rElem.y;
+  nElemW    = pElem->rElem.w;
+  nElemH    = pElem->rElem.h;
+
+  // Calculate center of XGlowball
+  int16_t nMidX, nMidY;
+  nMidX = nElemX + (nElemW / 2);
+  nMidY = nElemY + (nElemH / 2);
+
+  // Fetch the current value
+  int16_t nVal = pGlowball->nVal;
+  int16_t nAngStart = pGlowball->nAngStart;
+  int16_t nAngEnd = pGlowball->nAngEnd;
+
+  // Check to see if we need full redraw
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    // Erase the region
+	  gslc_DrawFillRect(pGui, pElem->rElem, pGlowball->colBg);
+    // Now force redraw from zero level to current value
+	  pGlowball->nValLast = 0;
+  }
+
+  // Draw the glowball
+  drawXGlowball(pGui, pGlowball, nMidX, nMidY, nVal, nAngStart, nAngEnd);
+  // --------------------------------------------------------------------------
+
+  // Mark the element as no longer requiring redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  return true;
+
+}
+
+// ============================================================================

--- a/src/elem/XGlowball.c
+++ b/src/elem/XGlowball.c
@@ -144,8 +144,7 @@ void drawXGlowballArc(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMi
 {
   gslc_tsPt anPts[4];
   // TODO: Cleanup
-  int16_t nStepAng = 360 / pGlowball->nQuality;
-  int16_t nStep64 = 64 * nStepAng;
+  int16_t nStep64 = 64*360 / pGlowball->nQuality;
   int16_t nAng64;
   int16_t nX, nY;
   int16_t nSegStart, nSegEnd;
@@ -239,6 +238,24 @@ void gslc_ElemXGlowballSetAngles(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int
   // Update the angular ranges
   pGlowball->nAngStart = nAngStart;
   pGlowball->nAngEnd = nAngEnd;
+
+  // Mark for redraw
+  // - Force full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXGlowballSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nQuality)
+{
+  if ((pGui == NULL) || (pElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXGlowballSetQuality";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsElem*      pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXGlowball* pGlowball = (gslc_tsXGlowball*)(pElem->pXData);
+
+  // Update the rendering quality setting
+  pGlowball->nQuality = nQuality;
 
   // Mark for redraw
   // - Force full redraw

--- a/src/elem/XGlowball.c
+++ b/src/elem/XGlowball.c
@@ -147,7 +147,6 @@ void drawXGlowballArc(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMi
   int16_t nStepAng = 360 / pGlowball->nQuality;
   int16_t nStep64 = 64 * nStepAng;
   int16_t nAng64;
-  int16_t nSegs = pGlowball->nQuality;
   int16_t nX, nY;
   int16_t nSegStart, nSegEnd;
   nSegStart = nAngStart * pGlowball->nQuality / 360;

--- a/src/elem/XGlowball.h
+++ b/src/elem/XGlowball.h
@@ -68,7 +68,7 @@ typedef struct {
   gslc_tsXGlowballRing* pRings;         ///< Ring definition array
   uint8_t               nNumRings;      ///< Number of rings in definition
   // Style config
-  uint8_t               nQuality;       ///< Rendering quality (number of segments / rotation)
+  uint16_t              nQuality;       ///< Rendering quality (number of segments / rotation)
   int16_t               nAngStart;      ///< Starting angle (0..510 degrees)
   int16_t               nAngEnd;        ///< Ending angle (0..510 degrees)
   gslc_tsColor          colBg;          ///< Background color (for redraw)
@@ -119,6 +119,7 @@ void drawXGlowball(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMidX,
 
 void gslc_ElemXGlowballSetAngles(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nAngStart, int16_t nAngEnd);
 void gslc_ElemXGlowballSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nVal);
+void gslc_ElemXGlowballSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nQuality);
 void gslc_ElemXGlowballSetColorBack(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colBg);
 
 // ============================================================================

--- a/src/elem/XGlowball.h
+++ b/src/elem/XGlowball.h
@@ -1,0 +1,138 @@
+#ifndef _GUISLICE_EX_XGLOWBALL_H_
+#define _GUISLICE_EX_XGLOWBALL_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: XGlowball
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XGlowball.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+// ============================================================================
+// Extended Element: Example template
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_GLOW GSLC_TYPE_BASE_EXTEND + 24
+
+// Defines the attributes of each ring in the XGlowball gauge
+typedef struct {
+  uint8_t        nRad1;      // Inner radius
+  uint8_t        nRad2;      // Outer radius
+  gslc_tsColor   cCol;       // Fill color
+} gslc_tsXGlowballRing;
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+/// Extended data for Slider element
+typedef struct {
+  // Config
+  int16_t               nMidX;          ///< Gauge midpoint X coord
+  int16_t               nMidY;          ///< Gauge midpoint Y coord
+  gslc_tsXGlowballRing* pRings;         ///< Ring definition array
+  uint8_t               nNumRings;      ///< Number of rings in definition
+  // Style config
+  uint8_t               nQuality;       ///< Rendering quality (number of segments / rotation)
+  int16_t               nAngStart;      ///< Starting angle (0..510 degrees)
+  int16_t               nAngEnd;        ///< Ending angle (0..510 degrees)
+  gslc_tsColor          colBg;          ///< Background color (for redraw)
+  // State
+  int16_t               nVal;           ///< Current value
+  int16_t               nValLast;       ///< Previous value
+  // Callbacks
+} gslc_tsXGlowball;
+
+
+///
+/// Create a XGlowball element
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining checkbox size
+/// \param[in]  nPosMin:     Minimum position value
+/// \param[in]  nPosMax:     Maximum position value
+/// \param[in]  nPos:        Starting position value
+/// \param[in]  nThumbSz:    Size of the thumb control
+/// \param[in]  bVert:       Orientation (true for vertical)
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+/// \todo doc fix
+gslc_tsElemRef* gslc_ElemXGlowballCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
+  gslc_tsXGlowball* pXData, int16_t nMidX, int16_t nMidY, gslc_tsXGlowballRing* pRings, uint8_t nNumRings);
+
+
+///
+/// Draw the XGlowball element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXGlowballDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+// XGlowball draw helper routines
+void drawXGlowballArc(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMidX, int16_t nMidY, int16_t nRad1, int16_t nRad2, gslc_tsColor cArc, uint16_t nAngStart, uint16_t nAngEnd);
+void drawXGlowballRing(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMidX, int16_t nMidY, int16_t nVal, uint16_t nAngStart, uint16_t nAngEnd, bool bErase);
+void drawXGlowball(gslc_tsGui* pGui, gslc_tsXGlowball* pGlowball, int16_t nMidX, int16_t nMidY, int16_t nVal, uint16_t nAngStart, uint16_t nAngEnd);
+
+void gslc_ElemXGlowballSetAngles(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nAngStart, int16_t nAngEnd);
+void gslc_ElemXGlowballSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nVal);
+void gslc_ElemXGlowballSetColorBack(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colBg);
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XGLOWBALL_H_
+


### PR DESCRIPTION
- Provide a circular gauge that expands / glows according to value
- Supports full as well as partial rotation (eg. semi-circular, quarter-circular)
- Custom ring color can produce color gradients and gaps between rings