### PR TITLE
Add support for UTFT & URTouch

### DIFF
--- a/configs/ard-shld-ili9341_16b_touch.h
+++ b/configs/ard-shld-ili9341_16b_touch.h
@@ -1,0 +1,212 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration #???) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: ILI9341 16-bit parallel (via UTFT)
+//   - Touch:   XPT2046 (via URTouch)
+//   - Wiring:  MEGA shield / TFT01 adapter
+//
+//   - Example display:
+//     - 3.2" TFT with MEGA shield adapter / TFT01 (Generic 320x240 ILI9341 16-bit)
+//     - TFT_320QDT_9341 3.2" 320x240, 2x20 pin + TFT LCD Mega Shield v2.2 / TFT01
+//     - ITEAD Arduino 3.2 TFT LCD Touch Shield V2
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a shield, no additional
+//   wiring is required to support the GUI operation
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_UTFT             // UTFT
+  #define DRV_TOUCH_URTOUCH         // URTouch
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  #define DRV_DISP_UTFT_INIT  ILI9341_16, 38, 39, 40, 41
+
+  // SD Card -- UNTESTED
+  #define ADAGFX_PIN_SDCS     5     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+  // -----------------------------------------------------------------------------
+  // SECTION 4: Touch Handling
+  // - Documentation for configuring touch support can be found at:
+  //   https://github.com/ImpulseAdventure/GUIslice/wiki/Configure-Touch-Support
+  // -----------------------------------------------------------------------------
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4A: Update your pin connections here
+  // - These values should come from the diag_ard_touch_calib sketch output
+  // - Please update the values to the right of ADATOUCH_PIN_* accordingly
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Touch bus & pinout
+  #define DRV_TOUCH_URTOUCH_INIT  6, 5, 4, 3, 2
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XGAUGE_RADIAL  0   // XGauge control with radial support
+  #define GSLC_FEATURE_XGAUGE_RAMP    0   // XGauge control with ramp support
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 0=disable, 1=SD lib (HW SPI), 2=SdFat lib (SW SPI)
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default:pink)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
   "name": "GUIslice",
-  "version": "0.12.1",
-  "keywords": "arduino, GUI, tft, embedded, ILI9341, ESP32, ESP8266, teensy, NodeMCU, SDL, STM32, M5Stack, feather, adafruit-gfx, raspberry pi, linux, mcufriend",
+  "version": "0.12.2",
+  "keywords": "arduino, GUI, tft, embedded, ILI9341, ESP32, ESP8266, teensy, NodeMCU, UTFT, SDL, STM32, M5Stack, feather, adafruit-gfx, raspberry pi, linux, mcufriend",
   "description": "GUIslice embedded touchscreen GUI library in C for Arduino & Raspberry Pi. Drag & drop GUI supports Adafruit-GFX and TFT_eSPI graphics drivers on Arduino, ESP8266 / NodeMCU, ESP32, Teensy, Feather M0, nRF52, STM32",
   "repository":
   {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=GUIslice
-version=0.12.1
+version=0.12.2
 author=Calvin Hass <guislice@impulseadventure.com>
 maintainer=Calvin Hass <guislice@impulseadventure.com>
 sentence=GUIslice embedded touchscreen GUI library in C for Arduino & Raspberry Pi

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -67,6 +67,7 @@ extern "C" {
   //#include "../configs/ard-shld-adafruit_28_res.h"
   //#include "../configs/ard-shld-elegoo_28_res.h"
   //#include "../configs/ard-shld-generic1_35_touch.h"
+  //#include "../configs/ard-shld-ili9341_16b_touch.h"
   //#include "../configs/ard-shld-mcufriend.h"
   //#include "../configs/ard-shld-mcufriend_4wire.h"
   //#include "../configs/ard-shld-mcufriend_xpt2046.h"

--- a/src/GUIslice_drv.h
+++ b/src/GUIslice_drv.h
@@ -51,6 +51,8 @@ extern "C" {
   #include "GUIslice_drv_tft_espi.h"
 #elif defined(DRV_DISP_M5STACK)
   #include "GUIslice_drv_m5stack.h"
+#elif defined(DRV_DISP_UTFT)
+  #include "GUIslice_drv_utft.h"
 #else
   #error "Driver needs to be specified in GUIslice_config_*.h (DRV_DISP_*)"
 #endif

--- a/src/GUIslice_drv_utft.cpp
+++ b/src/GUIslice_drv_utft.cpp
@@ -1,0 +1,1295 @@
+// =======================================================================
+// GUIslice library (driver layer for UTFT)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file GUIslice_drv_utft.cpp
+
+
+// Compiler guard for requested driver
+#include "GUIslice_config.h" // Sets DRV_DISP_*
+#if defined(DRV_DISP_UTFT)
+
+// =======================================================================
+// Driver Layer for UTFT
+// =======================================================================
+
+// GUIslice library
+#include "GUIslice_drv_utft.h"
+
+#include <stdio.h>
+
+#if defined(DRV_DISP_UTFT)
+  #include <UTFT.h>
+#else
+  #error "CONFIG: Need to enable a supported DRV_DISP_* option in GUIslice config"
+#endif
+
+
+#if defined(DRV_TOUCH_URTOUCH)
+  #include <URTouch.h>
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+
+// ------------------------------------------------------------------------
+#if defined(DRV_DISP_UTFT)
+  const char* m_acDrvDisp = "UTFT";
+  UTFT m_disp(DRV_DISP_UTFT_INIT);
+
+// ------------------------------------------------------------------------
+#endif // DRV_DISP_*
+
+
+
+// ------------------------------------------------------------------------
+#if defined(DRV_TOUCH_URTOUCH)
+  const char* m_acDrvTouch = "URTOUCH";
+  URTouch m_touch(DRV_TOUCH_URTOUCH_INIT);
+// ------------------------------------------------------------------------
+#elif defined(DRV_TOUCH_INPUT)
+  const char* m_acDrvTouch = "INPUT";
+// ------------------------------------------------------------------------
+#elif defined(DRV_TOUCH_NONE)
+  const char* m_acDrvTouch = "NONE";
+// ------------------------------------------------------------------------
+#endif // DRV_TOUCH_*
+
+// -----------------------------------------------------------------------
+// Font Definitions
+// -----------------------------------------------------------------------
+  extern uint8_t SmallFont[];
+  extern uint8_t BigFont[];
+
+// =======================================================================
+// Public APIs to GUIslice core library
+// =======================================================================
+
+// -----------------------------------------------------------------------
+// Configuration Functions
+// -----------------------------------------------------------------------
+
+bool gslc_DrvInit(gslc_tsGui* pGui)
+{
+
+  // Report any debug info if enabled
+  #if defined(DBG_DRIVER)
+  // TODO
+  #endif
+
+  // Initialize any library-specific members
+  if (pGui->pvDriver) {
+    gslc_tsDriver*  pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+
+    pDriver->nColBkgnd = GSLC_COL_BLACK;
+
+    // These displays can accept partial redraw as they retain the last
+    // image in the controller graphics RAM
+    pGui->bRedrawPartialEn = true;
+
+    // Support any additional initialization prior to display init
+
+    // Perform any display initialization
+    #if defined(DRV_DISP_UTFT)
+      m_disp.InitLCD();
+      m_disp.clrScr();
+
+    #endif
+
+    // Now that we have initialized the display, we can assign
+    // the rotation parameters and clipping region
+    gslc_DrvRotate(pGui,GSLC_ROTATE);
+
+
+    // Initialize SD card usage
+    #if (GSLC_SD_EN)
+    if (!SD.begin(ADAGFX_PIN_SDCS)) {
+      GSLC_DEBUG_PRINT("ERROR: DrvInit() SD init failed\n",0);
+      return false;
+    }
+    #endif
+
+  }
+  return true;
+}
+
+
+void gslc_DrvDestruct(gslc_tsGui* pGui)
+{
+}
+
+const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui)
+{
+  return m_acDrvDisp;
+}
+
+const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui)
+{
+  return m_acDrvTouch;
+}
+
+
+// -----------------------------------------------------------------------
+// Image/surface handling Functions
+// -----------------------------------------------------------------------
+
+void* gslc_DrvLoadImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef)
+{
+  // GUIslice adapter for Adafruit-GFX doesn't preload the
+  // images into RAM (to keep RAM requirements low), so we
+  // don't need to do any further processing here. Instead,
+  // the loading is done during render.
+  if (sImgRef.eImgFlags == GSLC_IMGREF_NONE) {
+    return NULL;
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_FILE) {
+    return NULL;  // No image preload done
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_SD) {
+    return NULL;  // No image preload done
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_RAM) {
+    return NULL;  // No image preload done
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_PROG) {
+    return NULL;  // No image preload done
+  }
+
+  // Default
+  return NULL;
+}
+
+
+bool gslc_DrvSetBkgndImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef)
+{
+  // Dispose of previous background
+  if (pGui->sImgRefBkgnd.eImgFlags != GSLC_IMGREF_NONE) {
+    gslc_DrvImageDestruct(pGui->sImgRefBkgnd.pvImgRaw);
+    pGui->sImgRefBkgnd = gslc_ResetImage();
+  }
+  pGui->sImgRefBkgnd = sImgRef;
+  pGui->sImgRefBkgnd.pvImgRaw = gslc_DrvLoadImage(pGui,sImgRef);
+  if (pGui->sImgRefBkgnd.pvImgRaw == NULL) {
+    GSLC_DEBUG2_PRINT("ERROR: DrvSetBkgndImage(%s) failed\n","");
+    return false;
+  }
+
+  return true;
+}
+
+
+bool gslc_DrvSetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol)
+{
+  if (pGui->pvDriver) {
+    gslc_tsDriver*  pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+    pDriver->nColBkgnd = nCol;
+  }
+  return true;
+}
+
+
+bool gslc_DrvSetElemImageNorm(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef)
+{
+  // This driver doesn't preload the image to memory,
+  // so we just save the reference for loading upon render
+  pElem->sImgRefNorm = sImgRef;
+  return true; // TODO
+}
+
+
+bool gslc_DrvSetElemImageGlow(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef)
+{
+  // This driver doesn't preload the image to memory,
+  // so we just save the reference for loading upon render
+  pElem->sImgRefGlow = sImgRef;
+  return true; // TODO
+}
+
+
+void gslc_DrvImageDestruct(void* pvImg)
+{
+}
+
+bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
+{
+  // NOTE: The clipping rect is currently saved in the
+  // driver struct, but the drawing code does not currently
+  // use it.
+  gslc_tsDriver*  pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (pRect == NULL) {
+    // Default to entire display
+    pDriver->rClipRect = {0,0,pGui->nDispW,pGui->nDispH};
+  } else {
+    pDriver->rClipRect = *pRect;
+  }
+
+  // TODO: For ILI9341, perhaps we can leverage m_disp.setAddrWindow(x0, y0, x1, y1)?
+  return true;
+}
+
+
+
+// -----------------------------------------------------------------------
+// Font handling Functions
+// -----------------------------------------------------------------------
+
+const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType, const void* pvFontRef, uint16_t nFontSz)
+{
+  // Arduino mode currently only supports font definitions from memory
+  if (eFontRefType != GSLC_FONTREF_PTR) {
+    GSLC_DEBUG2_PRINT("ERROR: DrvFontAdd(%s) failed - Arduino only supports memory-based fonts\n", "");
+    return NULL;
+  }
+  // For UTFT, we will force "SmallFont" to be the "default" font
+  // - The Adafruit-GFX convention for default/built-in font is to pass NULL font pointer
+  //   along with a size specifier
+  if (pvFontRef == NULL) {
+    //GSLC_DEBUG2_PRINT("DBG: DrvFontAdd() forcing SmallFont\n", "");
+    pvFontRef = SmallFont;
+  }
+  return pvFontRef;
+}
+
+void gslc_DrvFontsDestruct(gslc_tsGui* pGui)
+{
+  // Nothing to deallocate
+}
+
+bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,
+        int16_t* pnTxtX,int16_t* pnTxtY,uint16_t* pnTxtSzW,uint16_t* pnTxtSzH)
+{
+  //uint16_t  nTxtScale = 0;
+  m_disp.setFont((uint8_t*)pFont->pvFont);
+  uint16_t nTxtLen = 0;
+
+  // Get length
+  if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_RAM) {
+    // Fetch the text bounds
+    nTxtLen = strlen((char*)pStr);
+  } else if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_PROG) {
+#if (GSLC_USE_PROGMEM)
+    nTxtLen = strlen_P(pStr);
+#else
+    // NOTE: Should not get here
+    // - The text string has been marked as being stored in
+    //   FLASH via PROGMEM (typically for Arduino) but
+    //   the current device does not support the PROGMEM
+    //   methodology.
+    // - Degrade back to using SRAM directly
+
+    // Fetch the text bounds
+    nTxtLen = strlen((char*)pStr);
+#endif
+  }
+
+  // Estimate the length of the monospaced font
+  *pnTxtSzW = nTxtLen * m_disp.getFontXsize();
+  *pnTxtSzH = 1 * m_disp.getFontYsize(); // TODO: Handle multi-line
+
+  // TODO m_disp.setFont();
+  return true;
+
+}
+
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt, gslc_tsColor colBg=GSLC_COL_BLACK)
+{
+  //uint16_t  nTxtScale = pFont->nSize;
+  uint16_t  nColRaw = gslc_DrvAdaptColorToRaw(colTxt);
+  char      ch;
+  int16_t   nTxtXStart;
+
+  // Initialize the font and positioning
+  m_disp.setFont((uint8_t*)pFont->pvFont);
+  m_disp.setColor(nColRaw);
+  // Default to transparent text rendering
+  m_disp.setBackColor(VGA_TRANSPARENT);
+
+  // TODO m_disp.setCursor(nTxtX,nTxtY);
+  // TODO m_disp.setTextSize(nTxtScale);
+
+  // Driver-specific overrides
+
+  // Default to accessing RAM directly (GSLC_TXT_MEM_RAM)
+  bool bProg = false;
+  if ((eTxtFlags & GSLC_TXT_MEM) == GSLC_TXT_MEM_PROG) {
+    bProg = true;
+  }
+
+  // Save the original starting X coordinate for line wraps
+  nTxtXStart = nTxtX;
+
+  while (1) {
+    // Fetch the next character
+    if (!bProg) {
+      // String in SRAM; can access buffer directly
+      ch = *(pStr++);
+    } else {
+      // String in PROGMEM (flash); must access via pgm_* calls
+      ch = pgm_read_byte(pStr++);
+    }
+
+    // Detect string terminator
+    if (ch == 0) {
+      break;
+    }
+
+    // Render the character
+    // Call UTFT for rendering
+    // Note that UTFT:printChar() is public but not documented
+    m_disp.printChar(ch,nTxtX,nTxtY);
+    // Advance the current position
+    nTxtX += m_disp.getFontXsize();
+
+    // Handle multi-line text:
+    // If we just output a newline, Adafruit-GFX will automatically advance
+    // the Y cursor but reset the X cursor to 0. Therefore we need to
+    // readjust the X cursor to our aligned bounding box.
+    if (ch == '\n') {
+      nTxtX = nTxtXStart;
+      nTxtY += m_disp.getFontYsize();
+    }
+
+  } // while(1)
+
+  // Restore the font
+  // TODO m_disp.setFont();
+
+  return true;
+}
+
+// -----------------------------------------------------------------------
+// Screen Management Functions
+// -----------------------------------------------------------------------
+
+void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
+{
+  #if defined(DRV_DISP_ADAGFX_SSD1306)
+    // Show the display buffer on the hardware.
+    // NOTE: You _must_ call display after making any drawing commands
+    // to make them visible on the display hardware!
+    m_disp.display();
+    // TODO: Might need to call m_disp.clearDisplay() now?
+
+  #else
+    // Nothing to do as we're not double-buffered
+
+  #endif
+}
+
+
+// -----------------------------------------------------------------------
+// Graphics Primitives Functions
+// -----------------------------------------------------------------------
+
+
+bool gslc_DrvDrawPoint(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol)
+{
+#if (GSLC_CLIP_EN)
+  // Perform clipping
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (!gslc_ClipPt(&pDriver->rClipRect,nX,nY)) { return true; }
+#endif
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+  m_disp.drawPixel(nX, nY);
+  return true;
+}
+
+
+bool gslc_DrvDrawPoints(gslc_tsGui* pGui,gslc_tsPt* asPt,uint16_t nNumPt,gslc_tsColor nCol)
+{
+  return false;
+}
+
+bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
+{
+#if (GSLC_CLIP_EN)
+  // Perform clipping
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (!gslc_ClipRect(&pDriver->rClipRect,&rRect)) { return true; }
+#endif
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+  m_disp.fillRect(rRect.x, rRect.y, rRect.x + rRect.w - 1, rRect.y + rRect.h - 1);
+  return true;
+}
+
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+  // TODO: Handle radius?
+  m_disp.fillRoundRect(rRect.x, rRect.y, rRect.x + rRect.w - 1, rRect.y + rRect.h - 1);
+  return true;
+}
+
+
+bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
+{
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+#if (GSLC_CLIP_EN)
+  // Perform clipping
+  // - TODO: Optimize the following, perhaps with new ClipLineHV()
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  int16_t nX0, nY0, nX1, nY1;
+  // Top
+  nX0 = rRect.x;
+  nY0 = rRect.y;
+  nX1 = rRect.x + rRect.w - 1;
+  nY1 = nY0;
+  if (gslc_ClipLine(&pDriver->rClipRect, &nX0, &nY0, &nX1, &nY1)) { m_disp.drawLine(nX0, nY0, nX1, nY1); }
+  // Bottom
+  nX0 = rRect.x;
+  nY0 = rRect.y + rRect.h - 1;
+  nX1 = rRect.x + rRect.w - 1;
+  nY1 = nY0;
+  if (gslc_ClipLine(&pDriver->rClipRect, &nX0, &nY0, &nX1, &nY1)) { m_disp.drawLine(nX0, nY0, nX1, nY1); }
+  // Left
+  nX0 = rRect.x;
+  nY0 = rRect.y;
+  nX1 = nX0;
+  nY1 = rRect.y + rRect.h - 1;
+  if (gslc_ClipLine(&pDriver->rClipRect, &nX0, &nY0, &nX1, &nY1)) { m_disp.drawLine(nX0, nY0, nX1, nY1); }
+  // Right
+  nX0 = rRect.x + rRect.w - 1;
+  nY0 = rRect.y;
+  nX1 = nX0;
+  nY1 = rRect.y + rRect.h - 1;
+  if (gslc_ClipLine(&pDriver->rClipRect, &nX0, &nY0, &nX1, &nY1)) { m_disp.drawLine(nX0, nY0, nX1, nY1); }
+#else
+  m_disp.drawRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1);
+#endif
+  return true;
+}
+
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol)
+{
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+
+  // TODO: Support GSLC_CLIP_EN
+  // - Would need to determine how to clip the rounded corners
+  m_disp.setColor(nColRaw);
+  // TODO: Handle radius?
+  m_disp.drawRoundRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1);
+  return true;
+}
+
+
+
+bool gslc_DrvDrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol)
+{
+#if (GSLC_CLIP_EN)
+  gslc_tsDriver* pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+  if (!gslc_ClipLine(&pDriver->rClipRect,&nX0,&nY0,&nX1,&nY1)) { return true; }
+#endif
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+  m_disp.drawLine(nX0, nY0, nX1, nY1);
+  return true;
+}
+
+bool gslc_DrvDrawFrameCircle(gslc_tsGui*,int16_t nMidX,int16_t nMidY,uint16_t nRadius,gslc_tsColor nCol)
+{
+#if (GSLC_CLIP_EN)
+  // TODO
+#endif
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+  m_disp.drawCircle(nMidX, nMidY, nRadius);
+  return true;
+}
+
+bool gslc_DrvDrawFillCircle(gslc_tsGui*,int16_t nMidX,int16_t nMidY,uint16_t nRadius,gslc_tsColor nCol)
+{
+#if (GSLC_CLIP_EN)
+  // TODO
+#endif
+
+  uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
+  m_disp.setColor(nColRaw);
+  m_disp.fillCircle(nMidX, nMidY, nRadius);
+  return true;
+}
+
+
+
+// ----- REFERENCE CODE begin
+// The following code was based upon the following reference code but modified to
+// adapt for use in GUIslice.
+//
+//   URL:              https://github.com/adafruit/Adafruit-GFX-Library/blob/master/Adafruit_GFX.cpp
+//   Original author:  Adafruit
+//   Function:         drawBitmap()
+
+// Draw a 1-bit image (bitmap) at the specified (x,y) position from the
+// provided bitmap buffer using the foreground color defined in the
+// header (unset bits are transparent).
+
+// GUIslice modified the raw memory format to add a header:
+// Image array format:
+// - Width[15:8],  Width[7:0],
+// - Height[15:8], Height[7:0],
+// - ColorR[7:0],  ColorG[7:0],
+// - ColorB[7:0],  0x00,
+// - Monochrome bitmap follows...
+//
+void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
+ const unsigned char *pBitmap,bool bProgMem)
+ {
+  const unsigned char*  bmap_base = pBitmap;
+  int16_t         w,h;
+  gslc_tsColor    nCol;
+
+  // Read header
+  w       = ( (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++) ) << 8;
+  w      |= ( (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++) ) << 0;
+  h       = ( (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++) ) << 8;
+  h      |= ( (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++) ) << 0;
+  nCol.r  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
+  nCol.g  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
+  nCol.b  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
+  bmap_base++;
+
+  int16_t i, j, byteWidth = (w + 7) / 8;
+  uint8_t nByte = 0;
+
+  for(j=0; j<h; j++) {
+    for(i=0; i<w; i++) {
+      if(i & 7) nByte <<= 1;
+      else {
+        if (bProgMem) {
+          nByte = pgm_read_byte(bmap_base + j * byteWidth + i / 8);
+        } else {
+          nByte = bmap_base[j * byteWidth + i / 8];
+        }
+      }
+      if(nByte & 0x80) {
+        gslc_DrvDrawPoint(pGui,nDstX+i,nDstY+j,nCol);
+      }
+    }
+  }
+}
+// ----- REFERENCE CODE end
+
+void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,const unsigned char* pBitmap,bool bProgMem)
+{
+  // AdaFruit GFX doesn't have a routine for this so we output pixel by pixel
+  const int16_t* pImage = (const int16_t*)pBitmap;
+  int16_t h, w;
+  if (bProgMem) {
+    h = pgm_read_word(pImage++);
+    w = pgm_read_word(pImage++);
+  } else {
+    h = *(pImage++);
+    w = *(pImage++);
+  }
+  #if defined(DBG_DRIVER)
+  GSLC_DEBUG_PRINT("DBG: DrvDrawBmp24FromMem() w=%d h=%d\n", w, h);
+  #endif
+  int row, col;
+  for (row=0; row<h; row++) { // For each scanline...
+    for (col=0; col<w; col++) { // For each pixel...
+      if (bProgMem) {
+        //To read from Flash Memory, pgm_read_XXX is required.
+        //Since image is stored as uint16_t, pgm_read_word is used as it uses 16bit address
+        m_disp.setColor(pgm_read_word(pImage++));
+        m_disp.drawPixel(nDstX + col, nDstY + row);
+      } else {
+        m_disp.setColor(*(pImage++));
+        m_disp.drawPixel(nDstX + col, nDstY + row);
+      }
+    } // end pixel
+  }
+}
+
+#if (GSLC_SD_EN)
+// ----- REFERENCE CODE begin
+// The following code was based upon the following reference code but modified to
+// adapt for use in GUIslice.
+//
+//   URL:              https://github.com/adafruit/Adafruit_ILI9341/blob/master/examples/spitftbitmap/spitftbitmap.ino
+//   Original author:  Adafruit
+//   Function:         bmpDraw()
+
+// These read 16- and 32-bit types from the SD card file.
+// BMP data is stored little-endian, Arduino is little-endian too.
+// May need to reverse subscript order if porting elsewhere.
+uint16_t gslc_DrvRead16SD(File f) {
+  uint16_t result;
+  ((uint8_t *)&result)[0] = f.read(); // LSB
+  ((uint8_t *)&result)[1] = f.read(); // MSB
+  return result;
+}
+
+uint32_t gslc_DrvRead32SD(File f) {
+  uint32_t result;
+  ((uint8_t *)&result)[0] = f.read(); // LSB
+  ((uint8_t *)&result)[1] = f.read();
+  ((uint8_t *)&result)[2] = f.read();
+  ((uint8_t *)&result)[3] = f.read(); // MSB
+  return result;
+}
+
+void gslc_DrvDrawBmp24FromSD(gslc_tsGui* pGui,const char *filename, uint16_t x, uint16_t y)
+{
+  File     bmpFile;
+  int      bmpWidth, bmpHeight;   // W+H in pixels
+  uint8_t  bmpDepth;              // Bit depth (currently must be 24)
+  uint32_t bmpImageoffset;        // Start of image data in file
+  uint32_t rowSize;               // Not always = bmpWidth; may have padding
+  uint8_t  sdbuffer[3*GSLC_SD_BUFFPIXEL]; // pixel buffer (R+G+B per pixel)
+  uint8_t  buffidx = sizeof(sdbuffer); // Current position in sdbuffer
+  boolean  goodBmp = false;       // Set to true on valid header parse
+  boolean  flip    = true;        // BMP is stored bottom-to-top
+  int      w, h, row, col;
+  uint8_t  r, g, b;
+  uint32_t pos = 0, startTime = millis();
+  (void)startTime; // Unused
+
+  if((x >= pGui->nDispW) || (y >= pGui->nDispH)) return;
+
+  //Serial.println();
+  //Serial.print("Loading image '");
+  //Serial.print(filename);
+  //Serial.println('\'');
+
+  // Open requested file on SD card
+  if ((bmpFile = SD.open(filename)) == 0) {
+    GSLC_DEBUG2_PRINT("ERROR: DrvDrawBmp24FromSD() file not found [%s]",filename);
+    return;
+  }
+  // Parse BMP header
+  if(gslc_DrvRead16SD(bmpFile) == 0x4D42) { // BMP signature
+    uint32_t nFileSize = gslc_DrvRead32SD(bmpFile);
+    (void)nFileSize; // Unused
+    //Serial.print("File size: "); Serial.println(nFileSize);
+    (void)gslc_DrvRead32SD(bmpFile); // Read & ignore creator bytes
+    bmpImageoffset = gslc_DrvRead32SD(bmpFile); // Start of image data
+    //Serial.print("Image Offset: "); Serial.println(bmpImageoffset, DEC);
+    // Read DIB header
+    uint32_t nHdrSize = gslc_DrvRead32SD(bmpFile);
+    (void)nHdrSize; // Unused
+    //Serial.print("Header size: "); Serial.println(nHdrSize);
+    bmpWidth  = gslc_DrvRead32SD(bmpFile);
+    bmpHeight = gslc_DrvRead32SD(bmpFile);
+    if(gslc_DrvRead16SD(bmpFile) == 1) { // # planes -- must be '1'
+      bmpDepth = gslc_DrvRead16SD(bmpFile); // bits per pixel
+      //Serial.print("Bit Depth: "); Serial.println(bmpDepth);
+      if((bmpDepth == 24) && (gslc_DrvRead32SD(bmpFile) == 0)) { // 0 = uncompressed
+        goodBmp = true; // Supported BMP format -- proceed!
+        //Serial.print("Image size: ");
+        //Serial.print(bmpWidth);
+        //Serial.print('x');
+        //Serial.println(bmpHeight);
+
+        // BMP rows are padded (if needed) to 4-byte boundary
+        rowSize = (bmpWidth * 3 + 3) & ~3;
+
+        // If bmpHeight is negative, image is in top-down order.
+        // This is not canon but has been observed in the wild.
+        if(bmpHeight < 0) {
+          bmpHeight = -bmpHeight;
+          flip      = false;
+        }
+
+        // Crop area to be loaded
+        w = bmpWidth;
+        h = bmpHeight;
+        if((x+w-1) >= pGui->nDispW) w = pGui->nDispW  - x;
+        if((y+h-1) >= pGui->nDispH) h = pGui->nDispH - y;
+
+        // Set TFT address window to clipped image bounds
+        //xxx tft.setAddrWindow(x, y, x+w-1, y+h-1);
+
+        for (row=0; row<h; row++) { // For each scanline...
+
+          // Seek to start of scan line.  It might seem labor-
+          // intensive to be doing this on every line, but this
+          // method covers a lot of gritty details like cropping
+          // and scanline padding.  Also, the seek only takes
+          // place if the file position actually needs to change
+          // (avoids a lot of cluster math in SD library).
+          if(flip) // Bitmap is stored bottom-to-top order (normal BMP)
+            pos = bmpImageoffset + (bmpHeight - 1 - row) * rowSize;
+          else     // Bitmap is stored top-to-bottom
+            pos = bmpImageoffset + row * rowSize;
+          if(bmpFile.position() != pos) { // Need seek?
+            bmpFile.seek(pos);
+            buffidx = sizeof(sdbuffer); // Force buffer reload
+          }
+
+          for (col=0; col<w; col++) { // For each pixel...
+            // Time to read more pixel data?
+            if (buffidx >= sizeof(sdbuffer)) { // Indeed
+              bmpFile.read(sdbuffer, sizeof(sdbuffer));
+              buffidx = 0; // Set index to beginning
+            }
+
+            // Convert pixel from BMP to TFT format, push to display
+            b = sdbuffer[buffidx++];
+            g = sdbuffer[buffidx++];
+            r = sdbuffer[buffidx++];
+            //xxx tft.pushColor(tft.Color565(r,g,b));
+            gslc_tsColor nCol = (gslc_tsColor){r,g,b};
+            gslc_tsColor nColTrans = (gslc_tsColor){GSLC_BMP_TRANS_RGB};
+            bool bDrawBit = true;
+            if (GSLC_BMP_TRANS_EN) {
+              if ((nCol.r == nColTrans.r) && (nCol.g == nColTrans.g) && (nCol.b == nColTrans.b)) {
+                bDrawBit = false;
+              }
+            }
+            if (bDrawBit) {
+              gslc_DrvDrawPoint(pGui,x+col,y+row,nCol);
+            }
+
+          } // end pixel
+        } // end scanline
+        //Serial.print("Loaded in ");
+        //Serial.print(millis() - startTime);
+        //Serial.println(" ms");
+      } // end goodBmp
+    }
+  }
+  bmpFile.close();
+  if(!goodBmp) {
+    GSLC_DEBUG2_PRINT("ERROR: DrvDrawBmp24FromSD() BMP format unknown [%s]",filename);
+  }
+}
+// ----- REFERENCE CODE end
+#endif // GSLC_SD_EN
+
+
+bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRef sImgRef)
+{
+  #if defined(DBG_DRIVER)
+  char addr[6];
+  GSLC_DEBUG_PRINT("DBG: DrvDrawImage() with ImgBuf address=","");
+  sprintf(addr,"%04X",(unsigned int)sImgRef.pImgBuf);
+  GSLC_DEBUG_PRINT("%s\n",addr);
+  #endif
+
+  // GUIslice adapter library for Adafruit-GFX does not pre-load
+  // image data into memory before calling DrvDrawImage(), so
+  // we to handle the loading now (when rendering).
+  if (sImgRef.eImgFlags == GSLC_IMGREF_NONE) {
+    return true;  // Nothing to do
+
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_FILE) {
+    return false; // Not supported
+
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_RAM) {
+    if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_RAW1) {
+      // Draw a monochrome bitmap from SRAM
+      // - Dimensions and output color are defined in arrray header
+      gslc_DrvDrawMonoFromMem(pGui,nDstX,nDstY,sImgRef.pImgBuf,false);
+      return true;
+    } else if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_BMP24) {
+      // 24-bit Bitmap in ram
+      gslc_DrvDrawBmp24FromMem(pGui,nDstX,nDstY,sImgRef.pImgBuf,false);
+      return true;
+    } else {
+      return false; // TODO: not yet supported
+    }
+#if (GSLC_USE_PROGMEM)
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_PROG) {
+    // TODO: Probably need to fix this to work with PROGMEM,
+    //       but check (GSLC_USE_PROGMEM) first
+    if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_RAW1) {
+      // Draw a monochrome bitmap from program memory
+      // - Dimensions and output color are defined in array header
+      gslc_DrvDrawMonoFromMem(pGui,nDstX,nDstY,sImgRef.pImgBuf,true);
+      return true;
+    } else if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_BMP24) {
+      // 24-bit Bitmap in flash
+      gslc_DrvDrawBmp24FromMem(pGui,nDstX,nDstY,sImgRef.pImgBuf,true);
+      return true;
+    } else {
+      return false; // TODO: not yet supported
+    }
+#endif
+  } else if ((sImgRef.eImgFlags & GSLC_IMGREF_SRC) == GSLC_IMGREF_SRC_SD) {
+    // Load image from SD media
+    #if (GSLC_SD_EN)
+      if ((sImgRef.eImgFlags & GSLC_IMGREF_FMT) == GSLC_IMGREF_FMT_BMP24) {
+        // 24-bit Bitmap
+        gslc_DrvDrawBmp24FromSD(pGui,sImgRef.pFname,nDstX,nDstY);
+        return true;
+      } else {
+        // Unsupported format
+        return false;
+      }
+    #else
+      // SD card access not enabled
+      return false;
+    #endif
+
+  } else {
+    // Unsupported source
+    GSLC_DEBUG2_PRINT("DBG: DrvDrawImage() unsupported source eImgFlags=%d\n", sImgRef.eImgFlags);
+    return false;
+  }
+}
+
+
+void gslc_DrvDrawBkgnd(gslc_tsGui* pGui)
+{
+  if (pGui->pvDriver) {
+    gslc_tsDriver*  pDriver = (gslc_tsDriver*)(pGui->pvDriver);
+
+    // Check to see if an image has been assigned to the background
+    if (pGui->sImgRefBkgnd.eImgFlags == GSLC_IMGREF_NONE) {
+      // No image assigned, so assume flat color background
+      // TODO: Create a new eImgFlags enum to signal that the
+      //       background should be a flat color instead of
+      //       an image.
+
+      // NOTE: We don't call m_disp.fillScreen() here as
+      //       that API doesn't support clipping. Since
+      //       we may be redrawing the page with a clipping
+      //       region enabled, it is important that we don't
+      //       redraw the entire screen.
+      gslc_tsRect rRect = (gslc_tsRect) { 0, 0, pGui->nDispW, pGui->nDispH };
+      gslc_DrvDrawFillRect(pGui, rRect, pDriver->nColBkgnd);
+    } else {
+      // An image should be loaded
+      // TODO: For now, re-use the DrvDrawImage(). Later, consider
+      //       extending to support different background drawing
+      //       capabilities such as stretching and tiling of background
+      //       image.
+      gslc_DrvDrawImage(pGui,0,0,pGui->sImgRefBkgnd);
+    }
+  }
+}
+
+
+// -----------------------------------------------------------------------
+// Touch Functions (via display driver)
+// -----------------------------------------------------------------------
+
+
+bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
+  if (pGui == NULL) {
+    GSLC_DEBUG2_PRINT("ERROR: DrvInitTouch(%s) called with NULL ptr\n","");
+    return false;
+  }
+  // TODO
+  // Perform any driver-specific touchscreen init here
+  return true;
+}
+
+
+bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal)
+{
+  // TODO
+  return false;
+}
+
+// ------------------------------------------------------------------------
+// Touch Functions (via external touch driver)
+// ------------------------------------------------------------------------
+
+
+
+#if defined(DRV_TOUCH_TYPE_EXTERNAL)
+
+bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
+
+  // Capture default calibration settings for resistive displays
+  #if defined(DRV_TOUCH_TYPE_RES)
+    pGui->nTouchCalXMin = ADATOUCH_X_MIN;
+    pGui->nTouchCalXMax = ADATOUCH_X_MAX;
+    pGui->nTouchCalYMin = ADATOUCH_Y_MIN;
+    pGui->nTouchCalYMax = ADATOUCH_Y_MAX;
+  #endif // DRV_TOUCH_TYPE_RES
+
+  // Support touch controllers with swapped X & Y
+  #if defined(ADATOUCH_REMAP_YX)
+    // Capture swap setting from config file
+    pGui->bTouchRemapYX = ADATOUCH_REMAP_YX;
+  #else
+    // For backward compatibility with older config files
+    // that have not defined this config option
+    pGui->bTouchRemapYX = false;
+  #endif
+
+  #if defined(DRV_TOUCH_URTOUCH)
+    m_touch.InitTouch();
+    m_touch.setPrecision(PREC_MEDIUM);
+    // Disable touch remapping since URTouch handles it
+    gslc_SetTouchRemapEn(pGui, false);
+    return true;
+  #elif defined(DRV_TOUCH_INPUT)
+    // Nothing more to initialize for GPIO input control mode
+    return true;
+  #elif defined(DRV_TOUCH_HANDLER)
+    return true;
+  #else
+    // ERROR: Unsupported driver mode
+    GSLC_DEBUG_PRINT("ERROR: TDrvInitTouch() driver not supported yet\n",0);
+    return false;
+  #endif
+
+}
+
+bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal)
+{
+
+  #if defined(DRV_TOUCH_NONE)
+    return false;
+  #endif
+
+  // As the STMPE610 hardware driver doesn't appear to return
+  // an indication of "touch released" with a coordinate, we
+  // must detect the release transition here and send the last
+  // known coordinate but with pressure=0. To do this, we are
+  // allocating a static variable to maintain the last touch
+  // coordinate.
+  // TODO: This code can be reworked / simplified
+  static int16_t  m_nLastRawX     = 0;
+  static int16_t  m_nLastRawY     = 0;
+  static uint16_t m_nLastRawPress = 0;
+  static bool     m_bLastTouched  = false;
+
+  bool bValid = false;  // Indicate a touch event to GUIslice core?
+
+  // Define maximum bounds for display in native orientation
+  int nDispOutMaxX,nDispOutMaxY;
+  nDispOutMaxX = pGui->nDisp0W-1;
+  nDispOutMaxY = pGui->nDisp0H-1;
+
+  // ----------------------------------------------------------------
+  #if defined(DRV_TOUCH_URTOUCH)
+
+    // Note that we rely on URTouch's calibration
+    // - This is detected by URTouch / URTouch_Calibration
+    // - The calibration settings are stored in URTouch/URTouchCD.h
+
+    uint16_t  nRawX,nRawY;
+    uint16_t  nRawPress;
+    bool bTouchOk = true;
+
+    if (!m_touch.dataAvailable()) {
+      bTouchOk = false;
+    }
+
+    if (bTouchOk) {
+      m_touch.read();
+      nRawX = m_touch.getX();
+      nRawY = m_touch.getY();
+      if ((nRawX == -1) || (nRawY == -1)) {
+        bTouchOk = false;
+      }
+    }
+
+    if (bTouchOk) {
+      nRawPress = 255; // Dummy non-zero value
+      m_nLastRawX = nRawX;
+      m_nLastRawY = nRawY;
+      m_nLastRawPress = nRawPress;
+      m_bLastTouched = true;
+      bValid = true;
+    } else {
+      if (!m_bLastTouched) {
+        // Wasn't touched before; do nothing
+      }
+      else {
+        // Touch release
+        // Indicate old coordinate but with pressure=0
+        m_nLastRawPress = 0;
+        m_bLastTouched = false;
+        bValid = true;
+      }
+    }
+
+  // ----------------------------------------------------------------
+  #elif defined(DRV_TOUCH_INPUT)
+    // No more to do for GPIO-only mode since gslc_Update() already
+    // looks for GPIO inputs before calling TDrvGetTouch().
+    // bValid will default to false
+
+
+  // Assign defaults
+  *pnX = 0;
+  *pnY = 0;
+  *pnPress = 0;
+
+  *peInputEvent = GSLC_INPUT_NONE;
+  *pnInputVal = 0;
+
+  #ifdef DRV_DISP_ADAGFX_SEESAW
+    // Keep track of last value to support simple debouncing
+    static uint32_t nButtonsLast = 0xFFFFFFFF;     // Saved last value (static to preserve b/w calls)
+    uint32_t nButtonsCur = m_seesaw.readButtons(); // Current value (note active low)
+    if ((nButtonsLast & TFTSHIELD_BUTTON_UP) && !(nButtonsCur & TFTSHIELD_BUTTON_UP)) {
+      *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+      *pnInputVal = GSLC_PIN_BTN_UP;
+    } else if ((nButtonsLast & TFTSHIELD_BUTTON_DOWN) && !(nButtonsCur & TFTSHIELD_BUTTON_DOWN)) {
+      *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+      *pnInputVal = GSLC_PIN_BTN_DOWN;
+    } else if ((nButtonsLast & TFTSHIELD_BUTTON_LEFT) && !(nButtonsCur & TFTSHIELD_BUTTON_LEFT)) {
+      *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+      *pnInputVal = GSLC_PIN_BTN_LEFT;
+    } else if ((nButtonsLast & TFTSHIELD_BUTTON_RIGHT) && !(nButtonsCur & TFTSHIELD_BUTTON_RIGHT)) {
+      *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+      *pnInputVal = GSLC_PIN_BTN_RIGHT;
+    } else if ((nButtonsLast & TFTSHIELD_BUTTON_IN) && !(nButtonsCur & TFTSHIELD_BUTTON_IN)) {
+      *peInputEvent = GSLC_INPUT_PIN_ASSERT;
+      *pnInputVal = GSLC_PIN_BTN_SEL;
+    }
+    // Save button state so that transitions can be detected
+    // during the next pass.
+    nButtonsLast = nButtonsCur;
+  #endif
+
+
+  // If we reached here, then we had a button event
+  return true;
+
+  // ----------------------------------------------------------------
+  #endif // DRV_TOUCH_*
+
+
+  // If an event was detected, signal it back to GUIslice
+  if (bValid) {
+
+    int nRawX,nRawY;
+    int nInputX,nInputY;
+    int nOutputX,nOutputY;
+
+    // Input assignment
+    nRawX = m_nLastRawX;
+    nRawY = m_nLastRawY;
+
+    // Handle any hardware swapping in native orientation
+    // This is done prior to any flip/swap as a result of
+    // rotation away from the native orientation.
+    // In most cases, the following is not used, but there
+    // may be touch modules that have swapped their X&Y convention.
+    if (pGui->bTouchRemapYX) {
+      nRawX = m_nLastRawY;
+      nRawY = m_nLastRawX;
+    }
+
+    nInputX = nRawX;
+    nInputY = nRawY;
+
+    // For resistive displays, perform constraint and scaling
+    #if defined(DRV_TOUCH_TYPE_RES)
+      if (pGui->bTouchRemapEn) {
+        // Perform scaling from input to output
+        // - Calibration done in native orientation (GSLC_ROTATE=0)
+        // - Input to map() is done with raw unswapped X,Y
+        // - map() and constrain() done with native dimensions and
+        //   native calibration
+        // - Swap & Flip done to output of map/constrain according
+        //   to GSLC_ROTATE
+        //
+        #if defined(DBG_TOUCH)
+          GSLC_DEBUG_PRINT("DBG: remapX: (%d,%d,%d,%d,%d)\n", nInputX, pGui->nTouchCalXMin, pGui->nTouchCalXMax, 0, nDispOutMaxX);
+          GSLC_DEBUG_PRINT("DBG: remapY: (%d,%d,%d,%d,%d)\n", nInputY, pGui->nTouchCalYMin, pGui->nTouchCalYMax, 0, nDispOutMaxY);
+        #endif
+        nOutputX = map(nInputX, pGui->nTouchCalXMin, pGui->nTouchCalXMax, 0, nDispOutMaxX);
+        nOutputY = map(nInputY, pGui->nTouchCalYMin, pGui->nTouchCalYMax, 0, nDispOutMaxY);
+        // Perform constraining to OUTPUT boundaries
+        nOutputX = constrain(nOutputX, 0, nDispOutMaxX);
+        nOutputY = constrain(nOutputY, 0, nDispOutMaxY);
+      } else {
+        // No scaling from input to output
+        nOutputX = nInputX;
+        nOutputY = nInputY;
+      }
+    #else
+      // No scaling from input to output
+      nOutputX = nInputX;
+      nOutputY = nInputY;
+    #endif  // DRV_TOUCH_TYPE_RES
+  
+    #ifdef DBG_TOUCH
+    GSLC_DEBUG_PRINT("DBG: PreRotate: x=%u y=%u\n", nOutputX, nOutputY);
+    #if defined(DRV_TOUCH_TYPE_RES)
+      GSLC_DEBUG_PRINT("DBG: RotateCfg: remap=%u nSwapXY=%u nFlipX=%u nFlipY=%u\n",
+        pGui->bTouchRemapEn,pGui->nSwapXY,pGui->nFlipX,pGui->nFlipY);
+    #endif // DRV_TOUCH_TYPE_RES
+    #endif // DBG_TOUCH
+
+    // Perform remapping due to current orientation
+    if (pGui->bTouchRemapEn) {
+      // Perform any requested swapping of input axes
+      if (pGui->nSwapXY) {
+        int16_t nOutputXTmp = nOutputX;
+        nOutputX = nOutputY;
+        nOutputY = nOutputXTmp;
+        // Perform any requested output axis flipping
+        // TODO: Collapse these cases
+        if (pGui->nFlipX) {
+          nOutputX = nDispOutMaxY - nOutputX;
+        }
+        if (pGui->nFlipY) {
+          nOutputY = nDispOutMaxX - nOutputY;
+        }
+      } else {
+        // Perform any requested output axis flipping
+        if (pGui->nFlipX) {
+          nOutputX = nDispOutMaxX - nOutputX;
+        }
+        if (pGui->nFlipY) {
+          nOutputY = nDispOutMaxY - nOutputY;
+        }
+      }
+    }
+
+    // Final assignment
+    *pnX          = nOutputX;
+    *pnY          = nOutputY;
+    *pnPress      = m_nLastRawPress;
+    *peInputEvent = GSLC_INPUT_TOUCH;
+    *pnInputVal   = 0;
+
+    // Print output for debug
+    #ifdef DBG_TOUCH
+    GSLC_DEBUG_PRINT("DBG: Touch Press=%u Raw[%d,%d] Out[%d,%d]\n",
+        m_nLastRawPress,m_nLastRawX,m_nLastRawY,nOutputX,nOutputY);
+    #endif
+
+    // Return with indication of new value
+    return true;
+  }
+
+  // No new value
+  return false;
+}
+
+#endif // DRV_TOUCH_*
+
+
+// -----------------------------------------------------------------------
+// Dynamic Screen rotation and Touch axes swap/flip functions
+// -----------------------------------------------------------------------
+
+/// Change display rotation and any associated touch orientation
+bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
+{
+  bool bChange = true;
+  bool bSupportRotation = true;
+
+  // Determine if the new orientation has swapped axes
+  // versus the native orientation (0)
+  bool bSwap = false;
+  if ((nRotation == 1) || (nRotation == 3)) {
+    bSwap = true;
+  }
+  (void)bSwap; // May be Unused in some driver modes
+
+  // Did the orientation change?
+  if (nRotation == pGui->nRotation) {
+    // Orientation did not change -- indicate this by returning
+    // false so that we can avoid a redraw
+    bChange = false;
+  }
+
+  // Update the GUI rotation member
+  pGui->nRotation = nRotation;
+
+  // Inform the display to adjust the orientation and
+  // update the saved display dimensions
+  #if defined(DRV_DISP_UTFT)
+    pGui->nDisp0W = m_disp.getDisplayXSize();
+    pGui->nDisp0H = m_disp.getDisplayYSize();
+    // Temporarily disable support for rotation
+    // TODO m_disp.setRotation(pGui->nRotation);
+    pGui->nDispW = m_disp.getDisplayXSize();
+    pGui->nDispH = m_disp.getDisplayYSize();
+
+  #else
+    // Report error for unsupported display mode
+    // - If we don't trap this condition, the GUI dimensions will be incorrect
+    #error "ERROR: DRV_DISP_* mode not supported in DrvRotate initialization"
+
+  #endif
+
+  // Update the clipping region
+  gslc_tsRect rClipRect = { 0,0,pGui->nDispW,pGui->nDispH };
+  gslc_DrvSetClipRect(pGui, &rClipRect);
+
+  if (!bSupportRotation) {
+    // No support for rotation, so override rotation indicator to 0
+    // This will also ensure that nSwapXY / nFlipX / nFlipY all remain 0
+    pGui->nRotation = 0;
+    // Ensure no redraw forced due to change in rotation value
+    bChange = false;
+  }
+
+  // Now update the touch remapping
+  #if !defined(DRV_TOUCH_NONE)
+    pGui->nSwapXY = TOUCH_ROTATION_SWAPXY(pGui->nRotation);
+    pGui->nFlipX = TOUCH_ROTATION_FLIPX(pGui->nRotation);
+    pGui->nFlipY = TOUCH_ROTATION_FLIPY(pGui->nRotation);
+  #endif // !DRV_TOUCH_NONE
+
+  // Mark the current page ask requiring redraw
+  // if the rotation value changed
+  if (bChange) {
+    gslc_PageRedrawSet( pGui, true );
+  }
+
+  return true;
+}
+
+
+// =======================================================================
+// Private Functions
+// =======================================================================
+
+
+// Convert from RGB struct to native screen format
+// TODO: Use 32bit return type?
+uint16_t gslc_DrvAdaptColorToRaw(gslc_tsColor nCol)
+{
+  uint16_t nColRaw = 0;
+
+  // Default to RGB565
+  nColRaw |= (((nCol.r & 0xF8) >> 3) << 11); // Mask: 1111 1000 0000 0000
+  nColRaw |= (((nCol.g & 0xFC) >> 2) <<  5); // Mask: 0000 0111 1110 0000
+  nColRaw |= (((nCol.b & 0xF8) >> 3) <<  0); // Mask: 0000 0000 0001 1111
+
+  return nColRaw;
+}
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // Compiler guard for requested driver

--- a/src/GUIslice_drv_utft.h
+++ b/src/GUIslice_drv_utft.h
@@ -1,0 +1,643 @@
+#ifndef _GUISLICE_DRV_UTFT_H_
+#define _GUISLICE_DRV_UTFT_H_
+
+// =======================================================================
+// GUIslice library (driver layer for UTFT)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file GUIslice_drv_utft.h
+/// \brief GUIslice library (driver layer for UTFT)
+
+
+// =======================================================================
+// Driver Layer for UTFT
+// =======================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+#include "GUIslice.h"
+
+#include <stdio.h>
+
+
+// Determine characteristics for configured touch driver
+// - DRV_TOUCH_TYPE_EXTERNAL: TDrv* external touch APIs are enabled
+// - DRV_TOUCH_TYPE_RES:      Resistive overlay
+// - DRV_TOUCH_TYPE_CAP:      Capacitive overlay
+// - DRV_TOUCH_TYPE_ANALOG:   Analog input
+#if defined(DRV_TOUCH_URTOUCH)
+  #define DRV_TOUCH_TYPE_EXTERNAL
+  // Don't set DRV_TOUCH_TYPE_RES since URTouch provides its own calibration
+  //#define DRV_TOUCH_TYPE_RES         // Resistive
+#elif defined(DRV_TOUCH_INPUT)
+  #define DRV_TOUCH_TYPE_EXTERNAL
+#elif defined(DRV_TOUCH_NONE)
+#endif // DRV_TOUCH_*
+
+
+// =======================================================================
+// API support definitions
+// - These defines indicate whether the driver includes optimized
+//   support for various APIs. If a define is set to 0, then the
+//   GUIslice core emulation will be used instead.
+// - At the very minimum, the point draw routine must be available:
+//   gslc_DrvDrawPoint()
+// =======================================================================
+
+#define DRV_HAS_DRAW_POINT             1 ///< Support gslc_DrvDrawPoint()
+
+#define DRV_HAS_DRAW_POINTS            0 ///< Support gslc_DrvDrawPoints()
+#define DRV_HAS_DRAW_LINE              1 ///< Support gslc_DrvDrawLine()
+#define DRV_HAS_DRAW_RECT_FRAME        1 ///< Support gslc_DrvDrawFrameRect()
+#define DRV_HAS_DRAW_RECT_FILL         1 ///< Support gslc_DrvDrawFillRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FRAME  1 ///< Support gslc_DrvDrawFrameRoundRect()
+#define DRV_HAS_DRAW_RECT_ROUND_FILL   1 ///< Support gslc_DrvDrawFillRoundRect()
+#define DRV_HAS_DRAW_CIRCLE_FRAME      1 ///< Support gslc_DrvDrawFrameCircle()
+#define DRV_HAS_DRAW_CIRCLE_FILL       1 ///< Support gslc_DrvDrawFillCircle()
+#define DRV_HAS_DRAW_TRI_FRAME         0 ///< Support gslc_DrvDrawFrameTriangle()
+#define DRV_HAS_DRAW_TRI_FILL          0 ///< Support gslc_DrvDrawFillTriangle()
+#define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+
+#define DRV_OVERRIDE_TXT_ALIGN         0 ///< Driver provides text alignment
+
+// =======================================================================
+// Driver-specific members
+// =======================================================================
+typedef struct {
+  gslc_tsColor  nColBkgnd;      ///< Background color (if not image-based)
+
+  gslc_tsRect   rClipRect;      ///< Clipping rectangle
+
+} gslc_tsDriver;
+
+
+
+// =======================================================================
+// Public APIs to GUIslice core library
+// - These functions define the renderer / driver-dependent
+//   implementations for the core drawing operations within
+//   GUIslice.
+// =======================================================================
+
+
+// -----------------------------------------------------------------------
+// Configuration Functions
+// -----------------------------------------------------------------------
+
+///
+/// Initialize the SDL library
+/// - Performs clean startup workaround (if enabled)
+/// - Configures video mode
+/// - Initializes font support
+///
+/// PRE:
+/// - The environment variables should be configured before
+///   calling gslc_DrvInit(). This can be done with gslc_DrvInitEnv()
+///   or manually in user function.
+///
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return true if success, false if fail
+///
+bool gslc_DrvInit(gslc_tsGui* pGui);
+
+
+///
+/// Perform any touchscreen-specific initialization
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  acDev:       Device path to touchscreen
+///                          eg. "/dev/input/touchscreen"
+///
+/// \return true if successful
+///
+bool gslc_DrvInitTs(gslc_tsGui* pGui,const char* acDev);
+
+
+///
+/// Free up any members associated with the driver
+/// - Eg. renderers, windows, background surfaces, etc.
+///
+/// \param[in]  pGui:         Pointer to GUI
+///
+/// \return none
+///
+void gslc_DrvDestruct(gslc_tsGui* pGui);
+
+
+///
+/// Get the display driver name
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return String containing driver name
+///
+const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui);
+
+
+///
+/// Get the touch driver name
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return String containing driver name
+///
+const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui);
+
+// -----------------------------------------------------------------------
+// Image/surface handling Functions
+// -----------------------------------------------------------------------
+
+
+///
+/// Load a bitmap (*.bmp) and create a new image resource.
+/// Transparency is enabled by GSLC_BMP_TRANS_EN
+/// through use of color (GSLC_BMP_TRANS_RGB).
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  sImgRef:     Image reference
+///
+/// \return Image pointer (surface/texture) or NULL if error
+///
+void* gslc_DrvLoadImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef);
+
+
+///
+/// Configure the background to use a bitmap image
+/// - The background is used when redrawing the entire page
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  sImgRef:     Image reference
+///
+/// \return true if success, false if fail
+///
+bool gslc_DrvSetBkgndImage(gslc_tsGui* pGui,gslc_tsImgRef sImgRef);
+
+///
+/// Configure the background to use a solid color
+/// - The background is used when redrawing the entire page
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nCol:        RGB Color to use
+///
+/// \return true if success, false if fail
+///
+bool gslc_DrvSetBkgndColor(gslc_tsGui* pGui,gslc_tsColor nCol);
+
+///
+/// Set an element's normal-state image
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElem:       Pointer to Element to update
+/// \param[in]  sImgRef:     Image reference
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvSetElemImageNorm(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef);
+
+///
+/// Set an element's glow-state image
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElem:       Pointer to Element to update
+/// \param[in]  sImgRef:     Image reference
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvSetElemImageGlow(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsImgRef sImgRef);
+
+
+///
+/// Release an image surface
+///
+/// \param[in]  pvImg:          Void ptr to image
+///
+/// \return none
+///
+void gslc_DrvImageDestruct(void* pvImg);
+
+
+///
+/// Set the clipping rectangle for future drawing updates
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  pRect:         Rectangular region to constrain edits
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect);
+
+
+// -----------------------------------------------------------------------
+// Font handling Functions
+// -----------------------------------------------------------------------
+
+///
+/// Load a font from a resource and return pointer to it
+///
+/// \param[in]  eFontRefType:   Font reference type (GSLC_FONTREF_PTR for Arduino)
+/// \param[in]  pvFontRef:      Font reference pointer (Pointer to the GFXFont array)
+/// \param[in]  nFontSz:        Typeface size to use
+///
+/// \return Void ptr to driver-specific font if load was successful, NULL otherwise
+///
+const void* gslc_DrvFontAdd(gslc_teFontRefType eFontRefType,const void* pvFontRef,uint16_t nFontSz);
+
+///
+/// Release all fonts defined in the GUI
+///
+/// \param[in]  pGui:          Pointer to GUI
+///
+/// \return none
+///
+void gslc_DrvFontsDestruct(gslc_tsGui* pGui);
+
+
+///
+/// Get the extent (width and height) of a text string
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pFont:       Ptr to Font structure
+/// \param[in]  pStr:        String to display
+/// \param[in]  eTxtFlags:   Flags associated with text string
+/// \param[out] pnTxtX:      Ptr to offset X of text
+/// \param[out] pnTxtY:      Ptr to offset Y of text
+/// \param[out] pnTxtSzW:    Ptr to width of text
+/// \param[out] pnTxtSzH:    Ptr to height of text
+///
+/// \return true if success, false if failure
+///
+bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,
+        int16_t* pnTxtX,int16_t* pnTxtY,uint16_t* pnTxtSzW,uint16_t* pnTxtSzH);
+
+
+///
+/// Draw a text string at the given coordinate
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nTxtX:       X coordinate of top-left text string
+/// \param[in]  nTxtY:       Y coordinate of top-left text string
+/// \param[in]  pFont:       Ptr to Font
+/// \param[in]  pStr:        String to display
+/// \param[in]  eTxtFlags:   Flags associated with text string
+/// \param[in]  colTxt:      Color to draw text
+/// \param[in]  colBg:       unused in ADAGFX, defaults to black
+///
+/// \return true if success, false if failure
+///
+bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* pFont,const char* pStr,gslc_teTxtFlags eTxtFlags,gslc_tsColor colTxt,gslc_tsColor colBg);
+
+
+// -----------------------------------------------------------------------
+// Screen Management Functions
+// -----------------------------------------------------------------------
+
+///
+/// Force a page flip to occur. This generally copies active
+/// screen surface to the display.
+///
+/// \param[in]  pGui:        Pointer to GUI
+///
+/// \return none
+///
+void gslc_DrvPageFlipNow(gslc_tsGui* pGui);
+
+
+// -----------------------------------------------------------------------
+// Graphics Primitives Functions
+// -----------------------------------------------------------------------
+
+///
+/// Draw a point
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nX:          X coordinate of point
+/// \param[in]  nY:          Y coordinate of point
+/// \param[in]  nCol:        Color RGB value to draw
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawPoint(gslc_tsGui* pGui,int16_t nX,int16_t nY,gslc_tsColor nCol);
+
+///
+/// Draw a point
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  asPt:        Array of points to draw
+/// \param[in]  nNumPt:      Number of points in array
+/// \param[in]  nCol:        Color RGB value to draw
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawPoints(gslc_tsGui* pGui,gslc_tsPt* asPt,uint16_t nNumPt,gslc_tsColor nCol);
+
+///
+/// Draw a framed rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to frame
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to fill
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol);
+
+
+///
+/// Draw a framed rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to frame
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled rounded rectangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  rRect:       Rectangular region to fill
+/// \param[in]  nRadius:     Radius for rounded corners
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillRoundRect(gslc_tsGui* pGui,gslc_tsRect rRect,int16_t nRadius,gslc_tsColor nCol);
+
+
+
+///
+/// Draw a line
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nX0:         Line start (X coordinate)
+/// \param[in]  nY0:         Line start (Y coordinate)
+/// \param[in]  nX1:         Line finish (X coordinate)
+/// \param[in]  nY1:         Line finish (Y coordinate)
+/// \param[in]  nCol:        Color RGB value to draw
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawLine(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,gslc_tsColor nCol);
+
+
+///
+/// Draw a framed circle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nMidX:       Center of circle (X coordinate)
+/// \param[in]  nMidY:       Center of circle (Y coordinate)
+/// \param[in]  nRadius:     Radius of circle
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,uint16_t nRadius,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled circle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nMidX:       Center of circle (X coordinate)
+/// \param[in]  nMidY:       Center of circle (Y coordinate)
+/// \param[in]  nRadius:     Radius of circle
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillCircle(gslc_tsGui* pGui,int16_t nMidX,int16_t nMidY,uint16_t nRadius,gslc_tsColor nCol);
+
+
+///
+/// Draw a framed triangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nX0:         X Coordinate #1
+/// \param[in]  nY0:         Y Coordinate #1
+/// \param[in]  nX1:         X Coordinate #2
+/// \param[in]  nY1:         Y Coordinate #2
+/// \param[in]  nX2:         X Coordinate #3
+/// \param[in]  nY2:         Y Coordinate #3
+/// \param[in]  nCol:        Color RGB value to frame
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFrameTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
+        int16_t nX1,int16_t nY1,int16_t nX2,int16_t nY2,gslc_tsColor nCol);
+
+
+///
+/// Draw a filled triangle
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nX0:         X Coordinate #1
+/// \param[in]  nY0:         Y Coordinate #1
+/// \param[in]  nX1:         X Coordinate #2
+/// \param[in]  nY1:         Y Coordinate #2
+/// \param[in]  nX2:         X Coordinate #3
+/// \param[in]  nY2:         Y Coordinate #3
+/// \param[in]  nCol:        Color RGB value to fill
+///
+/// \return true if success, false if error
+///
+bool gslc_DrvDrawFillTriangle(gslc_tsGui* pGui,int16_t nX0,int16_t nY0,
+        int16_t nX1,int16_t nY1,int16_t nX2,int16_t nY2,gslc_tsColor nCol);
+
+
+///
+/// Copy all of source image to destination screen at specified coordinate
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nDstX:       Destination X coord for copy
+/// \param[in]  nDstY:       Destination Y coord for copy
+/// \param[in]  sImgRef:     Image reference
+///
+/// \return true if success, false if fail
+///
+bool gslc_DrvDrawImage(gslc_tsGui* pGui,int16_t nDstX,int16_t nDstY,gslc_tsImgRef sImgRef);
+
+
+///
+/// Draw a monochrome bitmap from a memory array
+/// - Draw from the bitmap buffer using the foreground color
+///   defined in the header (unset bits are transparent)
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nDstX:       Destination X coord for copy
+/// \param[in]  nDstY:       Destination Y coord for copy
+/// \param[in]  pBitmap:     Pointer to bitmap buffer
+/// \param[in]  bProgMem:    Bitmap is stored in Flash if true, RAM otherwise
+///
+/// \return none
+///
+void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY, const unsigned char *pBitmap,bool bProgMem);
+
+
+///
+/// Draw a color 24-bit depth bitmap from a memory array
+/// - Note that users must convert images from their native
+///   format (eg. BMP, PNG, etc.) into a C array. Please
+///   refer to the following guide for details:
+///   https://github.com/ImpulseAdventure/GUIslice/wiki/Display-Images-from-FLASH
+/// - The converted file (c array) can then be included in the sketch.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nDstX:       X coord for copy
+/// \param[in]  nDstY:       Y coord for copy
+/// \param[in]  pBitmap:     Pointer to bitmap buffer
+/// \param[in]  bProgMem:    Bitmap is stored in Flash if true, RAM otherwise
+///
+/// \return none
+///
+void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,const unsigned char* pBitmap,bool bProgMem);
+
+///
+/// Copy the background image to destination screen
+///
+/// \param[in]  pGui:        Pointer to GUI
+///
+/// \return true if success, false if fail
+///
+void gslc_DrvDrawBkgnd(gslc_tsGui* pGui);
+
+
+// -----------------------------------------------------------------------
+// Touch Functions (if using display driver library)
+// -----------------------------------------------------------------------
+
+///
+/// Perform any touchscreen-specific initialization
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  acDev:       Device path to touchscreen
+///                          eg. "/dev/input/touchscreen"
+///
+/// \return true if successful
+///
+bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev);
+
+
+///
+/// Get the last touch event from the internal touch handler
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[out] pnX:         Ptr to X coordinate of last touch event
+/// \param[out] pnY:         Ptr to Y coordinate of last touch event
+/// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
+/// \param[out] peInputEvent Indication of event type
+/// \param[out] pnInputVal   Additional data for event type
+///
+/// \return true if an event was detected or false otherwise
+///
+bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal);
+
+
+// -----------------------------------------------------------------------
+// Touch Functions (if using external touch driver library)
+// -----------------------------------------------------------------------
+
+
+#if defined(DRV_TOUCH_TYPE_EXTERNAL)
+///
+/// Perform any touchscreen-specific initialization
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  acDev:       Device path to touchscreen
+///                          eg. "/dev/input/touchscreen"
+///
+/// \return true if successful
+///
+bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev);
+
+
+///
+/// Get the last touch event from the SDL_Event handler
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[out] pnX:         Ptr to X coordinate of last touch event
+/// \param[out] pnY:         Ptr to Y coordinate of last touch event
+/// \param[out] pnPress:     Ptr to Pressure level of last touch event (0 for none, 1 for touch)
+/// \param[out] peInputEvent Indication of event type
+/// \param[out] pnInputVal   Additional data for event type
+///
+/// \return true if an event was detected or false otherwise
+///
+bool gslc_TDrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pnPress, gslc_teInputRawEvent* peInputEvent, int16_t* pnInputVal);
+
+#endif // DRV_TOUCH_*
+
+
+// -----------------------------------------------------------------------
+// Dynamic Screen rotation and Touch axes swap/flip functions
+// -----------------------------------------------------------------------
+
+///
+/// Change rotation, automatically adapt touchscreen axes swap/flip
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nRotation:   Screen Rotation value (0, 1, 2 or 3)
+///
+/// \return true if successful
+///
+bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation);
+
+
+// =======================================================================
+// Private Functions
+// - These functions are not included in the scope of APIs used by
+//   the core GUIslice library. Instead, these functions are used
+//   to support the operations within this driver layer.
+// =======================================================================
+
+uint16_t gslc_DrvAdaptColorToRaw(gslc_tsColor nCol);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_DRV_ADAGFX_H_

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.1.1"
+#define GUISLICE_VER "0.12.2.0"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
Add preliminary support for **UTFT** & **URTouch**:
- UTFT available from: [UTFT library by Henning Karlsen](http://www.rinkydinkelectronics.com/library.php?id=51). Note that the UTFT / URTouch library is not available via the Arduino IDE Library Manager.

The addition of UTFT enables GUIslice to support a large number of additional displays, including 8bit and 16bit parallel TFTs.

An example config has been provided for the **3.2" TFT w/ ILI9341 16-bit + MEGA shield** (also known as TFT_320QDT_9341 + TFT01 Mega Shield):
- `/configs/ard-shld-ili9341_16b_touch.h`

The URTouch library supports SW SPI interface to an XPT2046 touch controller. Note that the URTouch / URTouch_Calibration sketch must be run to define the touch calibration settings (which should be saved in URTouchCD.h).
