### PR TITLE
XGauge split to XProgress, XRadial, XRamp

### DIFF
--- a/examples/arduino/ex03_ard_btn_img/ex03_ard_btn_img.ino
+++ b/examples/arduino/ex03_ard_btn_img/ex03_ard_btn_img.ino
@@ -25,7 +25,7 @@
 
 // Ensure optional SD feature is enabled in the configuration
 #if !(GSLC_SD_EN)
-  #error "Config: GSLC_SD_EN required for this example but not enabled. Please update GUIslice_config."
+  #error "Config: GSLC_SD_EN required for this example but not enabled. Please update GUIslice config"
 #endif
 
 

--- a/examples/arduino/ex04_ard_ctrls/ex04_ard_ctrls.ino
+++ b/examples/arduino/ex04_ard_ctrls/ex04_ard_ctrls.ino
@@ -25,7 +25,7 @@
 // Include any extended elements
 #include "elem/XCheckbox.h"
 #include "elem/XSlider.h"
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 
 // To demonstrate additional fonts, uncomment the following line:
 //#define USE_EXTRA_FONTS
@@ -66,7 +66,7 @@ gslc_tsPage                 m_asPage[MAX_PAGE];
 gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
 
-gslc_tsXGauge               m_sXGauge,m_sXGauge1;
+gslc_tsXProgress            m_sXGauge,m_sXGauge1;
 gslc_tsXCheckbox            m_asXCheck[3];
 gslc_tsXSlider              m_sXSlider;
 
@@ -163,13 +163,13 @@ bool InitOverlays()
   // Create progress bar (horizontal)
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
     (gslc_tsRect){80,80,50,10},0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
   // Second progress bar (vertical)
   // - Demonstration of vertical bar with offset zero-pt showing both positive and negative range
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
     (gslc_tsRect){280,80,10,100},-25,75,-15,GSLC_COL_RED,true);
   gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_BLUE_DK3,GSLC_COL_BLACK,GSLC_COL_BLACK);
   m_pElemProgress1 = pElemRef; // Save for quick access
@@ -260,7 +260,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",m_nCount/5);
   gslc_ElemSetTxtStr(&m_gui,m_pElemCnt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,((m_nCount/1)%100));
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress,((m_nCount/1)%100));
 
   // NOTE: A more efficient method is to move the following
   //       code into the slider position callback function.
@@ -269,7 +269,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",nPos);
   gslc_ElemSetTxtStr(&m_gui,m_pElemSliderTxt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
 
 
   // Periodically call GUIslice update function

--- a/examples/arduino/ex05_ard_pages/ex05_ard_pages.ino
+++ b/examples/arduino/ex05_ard_pages/ex05_ard_pages.ino
@@ -22,7 +22,7 @@
 
 // Include any extended elements
 #include "elem/XCheckbox.h"
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 
 // Defines for resources
 
@@ -56,7 +56,7 @@ gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsElem                 m_asExtraElem[MAX_ELEM_PG_EXTRA_RAM];
 gslc_tsElemRef              m_asExtraElemRef[MAX_ELEM_PG_EXTRA];
 
-gslc_tsXGauge               m_sXGauge;
+gslc_tsXProgress            m_sXGauge;
 gslc_tsXCheckbox            m_asXCheck[3];
 
 
@@ -133,7 +133,7 @@ bool InitOverlays()
   // Create progress bar
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){40,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
     0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
@@ -219,7 +219,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",m_nCount);
   gslc_ElemSetTxtStr(&m_gui,pElemCnt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,pElemProgress,((m_nCount/2)%100));
+  gslc_ElemXProgressSetVal(&m_gui,pElemProgress,((m_nCount/2)%100));
 
   // Periodically call GUIslice update function
   gslc_Update(&m_gui);

--- a/examples/arduino/ex06_ard_callback/ex06_ard_callback.ino
+++ b/examples/arduino/ex06_ard_callback/ex06_ard_callback.ino
@@ -25,7 +25,7 @@
 
 // Include any extended elements
 #include "elem/XCheckbox.h"
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 
 #include <math.h>
 
@@ -63,7 +63,7 @@ gslc_tsPage                 m_asPage[MAX_PAGE];
 gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];   // Storage for all elements in RAM
 gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];    // References for all elements in GUI
 
-gslc_tsXGauge               m_sXGauge;
+gslc_tsXProgress            m_sXGauge;
 gslc_tsXCheckbox            m_asXCheck[1];
 
 
@@ -212,7 +212,7 @@ bool InitOverlays()
   // Create progress bar
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){80,80,50,10},
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){80,80,50,10},
     0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
@@ -338,7 +338,7 @@ void loop()
   gslc_ElemSetTxtStr(&m_gui,m_pElemDataZ,acTxt);
   gslc_ElemSetTxtCol(&m_gui,m_pElemDataZ,(m_fCoordY>50)?GSLC_COL_GREEN_LT2:GSLC_COL_RED_DK2);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,50+50*sin(m_nCount/5.0));
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress,50+50*sin(m_nCount/5.0));
 
   // -----------------------------------------------
 

--- a/examples/arduino/ex09_ard_radial/ex09_ard_radial.ino
+++ b/examples/arduino/ex09_ard_radial/ex09_ard_radial.ino
@@ -5,11 +5,8 @@
 // - https://github.com/ImpulseAdventure/GUIslice
 // - Example 09 (Arduino):
 //     Demonstrate radial and ramp controls
-//     NOTE: The radial and ramp controls are disabled by default, but can
-//           be enabled by GSLC_FEATURE_XGAUGE_RADIAL & GSLC_FEATURE_XGAUGE_RAMP
-//           in the user config.
 //     NOTE: The ramp control is intended only as a demonstration of
-//           a custom control and not intended to be used
+//           a custom control and not intended of use as-is
 //   - NOTE: This is the simple version of the example without
 //     optimizing for memory consumption. Therefore, it may not
 //     run on Arduino devices with limited memory. A "minimal"
@@ -25,16 +22,10 @@
 #include "GUIslice_drv.h"
 
 // Include any extended elements
-#include "elem/XGauge.h"
+#include "elem/XRadial.h"
+#include "elem/XRamp.h"
 #include "elem/XSlider.h"
 
-// Ensure optional features are enabled in the configuration
-#if !(GSLC_FEATURE_XGAUGE_RADIAL)
-  #error "Config: GSLC_FEATURE_XGAUGE_RADIAL required for this example but not enabled. Please update GUIslice_config."
-#endif
-#if !(GSLC_FEATURE_XGAUGE_RAMP)
-  #error "Config: GSLC_FEATURE_XGAUGE_RAMP required for this example but not enabled. Please update GUIslice_config."
-#endif
 
 // Defines for resources
 
@@ -65,7 +56,8 @@ gslc_tsPage                 m_asPage[MAX_PAGE];
 gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];   // Storage for all elements in RAM
 gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];    // References for all elements in GUI
 
-gslc_tsXGauge               m_sXRadial, m_sXRamp;
+gslc_tsXRadial              m_sXRadial;
+gslc_tsXRamp                m_sXRamp;
 gslc_tsXSlider              m_sXSlider;
 
 // Current RGB value for color box
@@ -104,11 +96,11 @@ bool CbSlideRadial(void* pvGui, void* pvElemRef, int16_t nPos)
 
     // Link slider to the radial control
     pElemRefTmp = gslc_PageFindElemById(pGui, E_PG_MAIN, E_RADIAL);
-    gslc_ElemXGaugeUpdate(pGui, pElemRefTmp, nVal);
+    gslc_ElemXRadialSetVal(pGui, pElemRefTmp, nVal);
 
     // Link slider to the ramp control
     pElemRefTmp = gslc_PageFindElemById(pGui, E_PG_MAIN, E_RAMP);
-    gslc_ElemXGaugeUpdate(pGui, pElemRefTmp, nVal);
+    gslc_ElemXRampSetVal(pGui, pElemRefTmp, nVal);
 
     // Link slider to the numerical display
     snprintf(acTxt, 8, "%u", nVal);
@@ -149,17 +141,15 @@ bool InitOverlays()
   pElemRef = gslc_ElemCreateBox(&m_gui, E_ELEM_BOX, E_PG_MAIN, (gslc_tsRect) { 10, 50, 300, 180 });
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
 
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_RADIAL, E_PG_MAIN, &m_sXRadial,
+  pElemRef = gslc_ElemXRadialCreate(&m_gui, E_RADIAL, E_PG_MAIN, &m_sXRadial,
     (gslc_tsRect) { 210, 140, 80, 80 }, 0, 100, 0, GSLC_COL_YELLOW, false);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
-  gslc_ElemXGaugeSetStyle(&m_gui, pElemRef, GSLCX_GAUGE_STYLE_RADIAL);
-  gslc_ElemXGaugeSetIndicator(&m_gui, pElemRef, GSLC_COL_YELLOW, 30, 3, true);
-  gslc_ElemXGaugeSetTicks(&m_gui, pElemRef, GSLC_COL_GRAY_LT1, 8, 5);
+  gslc_ElemXRadialSetIndicator(&m_gui, pElemRef, GSLC_COL_YELLOW, 30, 3, true);
+  gslc_ElemXRadialSetTicks(&m_gui, pElemRef, GSLC_COL_GRAY_LT1, 8, 5);
 
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_RAMP, E_PG_MAIN, &m_sXRamp,
+  pElemRef = gslc_ElemXRampCreate(&m_gui, E_RAMP, E_PG_MAIN, &m_sXRamp,
     (gslc_tsRect) { 80, 140, 100, 80 }, 0, 100, 50, GSLC_COL_YELLOW, false);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
-  gslc_ElemXGaugeSetStyle(&m_gui, pElemRef, GSLCX_GAUGE_STYLE_RAMP);
 
   pElemRef = gslc_ElemXSliderCreate(&m_gui, E_SLIDER, E_PG_MAIN, &m_sXSlider,
     (gslc_tsRect) { 20, 60, 140, 20 }, 0, 100, 50, 5, false);

--- a/examples/arduino/ex18_ard_compound/ex18_ard_compound.ino
+++ b/examples/arduino/ex18_ard_compound/ex18_ard_compound.ino
@@ -30,7 +30,7 @@
 #endif
 
 // Include any extended elements
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 #include "elem/XSelNum.h"
 
 // Defines for resources
@@ -66,7 +66,7 @@ gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsElem                 m_asExtraElem[MAX_ELEM_PG_EXTRA_RAM];
 gslc_tsElemRef              m_asExtraElemRef[MAX_ELEM_PG_EXTRA];
 
-gslc_tsXGauge               m_sXGauge;
+gslc_tsXProgress            m_sXGauge;
 gslc_tsXSelNum              m_sXSelNum[3];
 
 
@@ -150,7 +150,7 @@ bool InitOverlays()
   // Create progress bar
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){40,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
     0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
@@ -234,7 +234,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",m_nCount);
   gslc_ElemSetTxtStr(&m_gui,pElemCnt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,pElemProgress,((m_nCount/2)%100));
+  gslc_ElemXProgressSetVal(&m_gui,pElemProgress,((m_nCount/2)%100));
 
   // Periodically call GUIslice update function
   gslc_Update(&m_gui);

--- a/examples/arduino/ex21_ard_input_pin/ex21_ard_input_pin.ino
+++ b/examples/arduino/ex21_ard_input_pin/ex21_ard_input_pin.ino
@@ -23,7 +23,7 @@
 
 // Include any extended elements
 #include "elem/XCheckbox.h"
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 #include "elem/XSlider.h"
 
 #include <Adafruit_GFX.h>
@@ -80,7 +80,7 @@ gslc_tsPage                 m_asPage[MAX_PAGE];
 gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
 
-gslc_tsXGauge               m_sXGauge,m_sXGauge1;
+gslc_tsXProgress            m_sXGauge,m_sXGauge1;
 gslc_tsXCheckbox            m_asXCheck[3];
 gslc_tsXSlider              m_sXSlider;
 
@@ -158,13 +158,13 @@ bool InitOverlays()
   // Create progress bar (horizontal)
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
     (gslc_tsRect){80,80,50,10},0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
   // Second progress bar (vertical)
   // - Demonstration of vertical bar with offset zero-pt showing both positive and negative range
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
     (gslc_tsRect){280,80,10,100},-25,75,-15,GSLC_COL_RED,true);
   gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_BLUE_DK3,GSLC_COL_BLACK,GSLC_COL_BLACK);
   m_pElemProgress1 = pElemRef; // Save for quick access
@@ -260,7 +260,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",m_nCount/5);
   gslc_ElemSetTxtStr(&m_gui,m_pElemCnt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,((m_nCount/1)%100));
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress,((m_nCount/1)%100));
 
   // NOTE: A more efficient method is to move the following
   //       code into the slider position callback function.
@@ -269,7 +269,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",nPos);
   gslc_ElemSetTxtStr(&m_gui,m_pElemSliderTxt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
 
 
   // Periodically call GUIslice update function

--- a/examples/arduino/ex23_m5_input_btn/ex23_m5_input_btn.ino
+++ b/examples/arduino/ex23_m5_input_btn/ex23_m5_input_btn.ino
@@ -23,7 +23,7 @@
 
 // Include any extended elements
 #include "elem/XCheckbox.h"
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 #include "elem/XSlider.h"
 
 // Ensure config settings are correct for the sketch
@@ -60,7 +60,7 @@ gslc_tsPage                 m_asPage[MAX_PAGE];
 gslc_tsElem                 m_asPageElem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef              m_asPageElemRef[MAX_ELEM_PG_MAIN];
 
-gslc_tsXGauge               m_sXGauge,m_sXGauge1;
+gslc_tsXProgress            m_sXGauge,m_sXGauge1;
 gslc_tsXCheckbox            m_asXCheck[3];
 gslc_tsXSlider              m_sXSlider;
 
@@ -120,13 +120,13 @@ bool InitOverlays()
   // Create progress bar (horizontal)
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){20,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,
     (gslc_tsRect){80,80,50,10},0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
   // Second progress bar (vertical)
   // - Demonstration of vertical bar with offset zero-pt showing both positive and negative range
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS1,E_PG_MAIN,&m_sXGauge1,
     (gslc_tsRect){280,80,10,100},-25,75,-15,GSLC_COL_RED,true);
   gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_BLUE_DK3,GSLC_COL_BLACK,GSLC_COL_BLACK);
   m_pElemProgress1 = pElemRef; // Save for quick access
@@ -216,7 +216,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",m_nCount/5);
   gslc_ElemSetTxtStr(&m_gui,m_pElemCnt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress,((m_nCount/1)%100));
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress,((m_nCount/1)%100));
 
   // NOTE: A more efficient method is to move the following
   //       code into the slider position callback function.
@@ -225,7 +225,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",nPos);
   gslc_ElemSetTxtStr(&m_gui,m_pElemSliderTxt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
+  gslc_ElemXProgressSetVal(&m_gui,m_pElemProgress1,(nPos*80.0/100.0)-15);
 
 
   // Periodically call GUIslice update function

--- a/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
+++ b/examples/arduino/ex24_ard_tabs/ex24_ard_tabs.ino
@@ -23,7 +23,7 @@
 
 // Include any extended elements
 #include "elem/XCheckbox.h"
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 
 // Defines for resources
 
@@ -69,7 +69,7 @@ gslc_tsElemRef              m_asConfigElemRef[MAX_ELEM_PG_CONFIG];
 gslc_tsElem                 m_asAlertElem[MAX_ELEM_PG_ALERT_RAM];
 gslc_tsElemRef              m_asAlertElemRef[MAX_ELEM_PG_ALERT];
 
-gslc_tsXGauge               m_sXGauge;
+gslc_tsXProgress            m_sXGauge;
 gslc_tsXCheckbox            m_asXCheck[3];
 
 
@@ -197,7 +197,7 @@ bool InitOverlays()
   // Create progress bar
   pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 40, 120, 50, 10 },
     (char*)"Progress:", 0, E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_ELEM_PROGRESS, E_PG_MAIN, &m_sXGauge, (gslc_tsRect) { 100, 120, 50, 10 },
+  pElemRef = gslc_ElemXProgressCreate(&m_gui, E_ELEM_PROGRESS, E_PG_MAIN, &m_sXGauge, (gslc_tsRect) { 100, 120, 50, 10 },
     0, 100, 0, GSLC_COL_GREEN, false);
   m_pElemProgress = pElemRef; // Save for quick access
 
@@ -304,7 +304,7 @@ void loop()
     gslc_ElemSetTxtStr(&m_gui, m_pElemCnt, acTxt);
   }
 
-  gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress, ((m_nCount / 2) % 100));
+  gslc_ElemXProgressSetVal(&m_gui, m_pElemProgress, ((m_nCount / 2) % 100));
 
   // We can change or disable the global page as needed:
   //   gslc_SetPageGlobal(&m_gui, E_PG_BASE);    // Set to E_PG_BASE

--- a/examples/arduino/ex25_ard_popup/ex25_ard_popup.ino
+++ b/examples/arduino/ex25_ard_popup/ex25_ard_popup.ino
@@ -19,8 +19,10 @@
 //
 
 #include "GUIslice.h"
-#include "GUIslice_ex.h"
 #include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XProgress.h"
 
 
 // Determine whether to load Adafruit-GFX extra fonts or Teensy fonts
@@ -77,7 +79,7 @@ gslc_tsElem                     m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef                  m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsElem                     m_asPage2Elem[MAX_ELEM_PG_POPUP_RAM];
 gslc_tsElemRef                  m_asPage2ElemRef[MAX_ELEM_PG_POPUP];
-gslc_tsXGauge                   m_sXGauge[1];
+gslc_tsXProgress                m_sXGauge[1];
 
 #define MAX_STR                 100
 
@@ -176,7 +178,7 @@ bool InitGUI()
   m_pTxtStatus = pElemRef;
 
   // Create progress bar E_PROGRESS 
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS, E_PG_MAIN, &m_sXGauge[0],
+  pElemRef = gslc_ElemXProgressCreate(&m_gui, E_PROGRESS, E_PG_MAIN, &m_sXGauge[0],
     (gslc_tsRect) { 70, 68, 100, 20 }, 0, 100, 0, GSLC_COL_GREEN, false);
   m_pElemProgress = pElemRef;
 
@@ -273,7 +275,7 @@ void loop()
 
   // General counter
   m_nCount++;
-  gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress, ((m_nCount / 1) % 100));
+  gslc_ElemXProgressSetVal(&m_gui, m_pElemProgress, ((m_nCount / 1) % 100));
 
 
   // ------------------------------------------------

--- a/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
+++ b/examples/arduino/ex32_ard_spinner/ex32_ard_spinner.ino
@@ -31,7 +31,7 @@
 #endif
 
 // Include any extended elements
-#include "elem/XGauge.h"
+#include "elem/XProgress.h"
 #include "elem/XSpinner.h"
 
 // Defines for resources
@@ -71,7 +71,7 @@ gslc_tsElemRef              m_asMainElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsElem                 m_asExtraElem[MAX_ELEM_PG_EXTRA_RAM];
 gslc_tsElemRef              m_asExtraElemRef[MAX_ELEM_PG_EXTRA];
 
-gslc_tsXGauge               m_sXGauge;
+gslc_tsXProgress            m_sXGauge;
 gslc_tsXSpinner             m_sXSpinner[3];
 
 
@@ -185,7 +185,7 @@ bool InitOverlays()
   // Create progress bar
   pElemRef = gslc_ElemCreateTxt(&m_gui,GSLC_ID_AUTO,E_PG_MAIN,(gslc_tsRect){40,80,50,10},
     (char*)"Progress:",0,E_FONT_TXT);
-  pElemRef = gslc_ElemXGaugeCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
+  pElemRef = gslc_ElemXProgressCreate(&m_gui,E_ELEM_PROGRESS,E_PG_MAIN,&m_sXGauge,(gslc_tsRect){100,80,50,10},
     0,100,0,GSLC_COL_GREEN,false);
   m_pElemProgress = pElemRef; // Save for quick access
 
@@ -288,7 +288,7 @@ void loop()
   snprintf(acTxt,MAX_STR,"%u",m_nCount);
   gslc_ElemSetTxtStr(&m_gui,pElemCnt,acTxt);
 
-  gslc_ElemXGaugeUpdate(&m_gui,pElemProgress,((m_nCount/2)%100));
+  gslc_ElemXProgressSetVal(&m_gui,pElemProgress,((m_nCount/2)%100));
 
   // Periodically call GUIslice update function
   gslc_Update(&m_gui);

--- a/examples/arduino/ex40_ard_ctrls_small/ex40_ard_ctrls_small.ino
+++ b/examples/arduino/ex40_ard_ctrls_small/ex40_ard_ctrls_small.ino
@@ -18,9 +18,12 @@
 //
 
 #include "GUIslice.h"
-#include "GUIslice_ex.h"
 #include "GUIslice_drv.h"
 
+// Include any extended elements
+#include "elem/XCheckbox.h"
+#include "elem/XSlider.h"
+#include "elem/XProgress.h"
 
 // ------------------------------------------------
 // Enumerations for pages, elements, fonts, images
@@ -50,7 +53,7 @@ gslc_tsPage                     m_asPage[MAX_PAGE];
 gslc_tsElem                     m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef                  m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsXCheckbox                m_asXCheck[1];
-gslc_tsXGauge                   m_sXGauge[2];
+gslc_tsXProgress                m_sXGauge[2];
 gslc_tsXSlider                  m_sXSlider[1];
 
 #define MAX_STR                 100
@@ -111,7 +114,7 @@ bool CbSlidePos(void* pvGui, void* pvElemRef, int16_t nPos)
     // Fetch the slider position (0..100)
     nVal = gslc_ElemXSliderGetPos(pGui, pElemRef);
     // Update the right progress bar
-    gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress2, nVal);
+    gslc_ElemXProgressSetVal(&m_gui, m_pElemProgress2, nVal);
     break;
   default:
     break;
@@ -148,11 +151,11 @@ bool InitGUI()
   gslc_ElemXSliderSetPosFunc(&m_gui, m_pElemSlider1, &CbSlidePos);
 
   // Create progress bar E_PROGRESS1 
-  m_pElemProgress1 = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS1, E_PG_MAIN, &m_sXGauge[0],
+  m_pElemProgress1 = gslc_ElemXProgressCreate(&m_gui, E_PROGRESS1, E_PG_MAIN, &m_sXGauge[0],
     (gslc_tsRect) { 10, 60, 10, 50 }, 0, 100, 0, GSLC_COL_GREEN, true);
 
   // Create progress bar E_PROGRESS2 
-  m_pElemProgress2 = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS2, E_PG_MAIN, &m_sXGauge[1],
+  m_pElemProgress2 = gslc_ElemXProgressCreate(&m_gui, E_PROGRESS2, E_PG_MAIN, &m_sXGauge[1],
     (gslc_tsRect) { 30, 60, 10, 50 }, 0, 100, 0, GSLC_COL_RED, true);
 
   pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 50, 60, 15, 12 },
@@ -223,7 +226,7 @@ void loop()
   m_nCount++;
 
   // Update left progress bar
-  gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress1, m_nCount % 100);
+  gslc_ElemXProgressSetVal(&m_gui, m_pElemProgress1, m_nCount % 100);
 
   // Update counter text
   snprintf(m_acTxt, 10, "%d", (m_nCount / 10) % 10000);

--- a/examples/arduino/ex41_ard_ctrls_small_input/ex41_ard_ctrls_small_input.ino
+++ b/examples/arduino/ex41_ard_ctrls_small_input/ex41_ard_ctrls_small_input.ino
@@ -19,9 +19,12 @@
 //
 
 #include "GUIslice.h"
-#include "GUIslice_ex.h"
 #include "GUIslice_drv.h"
 
+// Include any extended elements
+#include "elem/XCheckbox.h"
+#include "elem/XSlider.h"
+#include "elem/XProgress.h"
 
 // ------------------------------------------------
 // Enumerations for pages, elements, fonts, images
@@ -51,7 +54,7 @@ gslc_tsPage                     m_asPage[MAX_PAGE];
 gslc_tsElem                     m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
 gslc_tsElemRef                  m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
 gslc_tsXCheckbox                m_asXCheck[1];
-gslc_tsXGauge                   m_sXGauge[2];
+gslc_tsXProgress                m_sXGauge[2];
 gslc_tsXSlider                  m_sXSlider[1];
 
 #define MAX_INPUT_MAP       5
@@ -115,7 +118,7 @@ bool CbSlidePos(void* pvGui, void* pvElemRef, int16_t nPos)
     // Fetch the slider position (0..100)
     nVal = gslc_ElemXSliderGetPos(pGui, pElemRef);
     // Update the right progress bar
-    gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress2, nVal);
+    gslc_ElemXProgressSetVal(&m_gui, m_pElemProgress2, nVal);
     break;
   default:
     break;
@@ -152,11 +155,11 @@ bool InitGUI()
   gslc_ElemXSliderSetPosFunc(&m_gui, m_pElemSlider1, &CbSlidePos);
 
   // Create progress bar E_PROGRESS1 
-  m_pElemProgress1 = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS1, E_PG_MAIN, &m_sXGauge[0],
+  m_pElemProgress1 = gslc_ElemXProgressCreate(&m_gui, E_PROGRESS1, E_PG_MAIN, &m_sXGauge[0],
     (gslc_tsRect) { 10, 60, 10, 50 }, 0, 100, 0, GSLC_COL_GREEN, true);
 
   // Create progress bar E_PROGRESS2 
-  m_pElemProgress2 = gslc_ElemXGaugeCreate(&m_gui, E_PROGRESS2, E_PG_MAIN, &m_sXGauge[1],
+  m_pElemProgress2 = gslc_ElemXProgressCreate(&m_gui, E_PROGRESS2, E_PG_MAIN, &m_sXGauge[1],
     (gslc_tsRect) { 30, 60, 10, 50 }, 0, 100, 0, GSLC_COL_RED, true);
 
   pElemRef = gslc_ElemCreateTxt(&m_gui, GSLC_ID_AUTO, E_PG_MAIN, (gslc_tsRect) { 50, 60, 15, 12 },
@@ -237,7 +240,7 @@ void loop()
   m_nCount++;
 
   // Update left progress bar
-  gslc_ElemXGaugeUpdate(&m_gui, m_pElemProgress1, m_nCount % 100);
+  gslc_ElemXProgressSetVal(&m_gui, m_pElemProgress1, m_nCount % 100);
 
   // Update counter text
   snprintf(m_acTxt, 10, "%d", (m_nCount / 10) % 10000);

--- a/examples/arduino_min/ex03_ardmin_btn_img/ex03_ardmin_btn_img.ino
+++ b/examples/arduino_min/ex03_ardmin_btn_img/ex03_ardmin_btn_img.ino
@@ -30,7 +30,7 @@
 
 // Ensure optional SD feature is enabled in the configuration
 #if !(GSLC_SD_EN)
-  #error "Config: GSLC_SD_EN required for this example but not enabled. Please update GUIslice_config."
+  #error "Config: GSLC_SD_EN required for this example but not enabled. Please update GUIslice config"
 #endif
 
 

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2410,21 +2410,21 @@ gslc_tsElem* gslc_GetElemFromRefD(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, in
 void* gslc_GetXDataFromRef(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nType, int16_t nLineNum)
 {
   if (pElemRef == NULL) {
-    GSLC_DEBUG2_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pElemRef is NULL\n", nType, nLineNum);
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pElemRef is NULL\n", nType, nLineNum);
     return NULL;
   }
   gslc_tsElem* pElem = gslc_GetElemFromRef(pGui, pElemRef);
   if (pElem == NULL) {
-    GSLC_DEBUG2_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pElem is NULL\n", nType, nLineNum);
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pElem is NULL\n", nType, nLineNum);
     return NULL;
   }
   if (pElem->nType != nType) {
-    GSLC_DEBUG2_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) Elem type mismatch\n", nType, nLineNum);
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) Elem type mismatch\n", nType, nLineNum);
     return NULL;
   }
   void* pXData = pElem->pXData;
   if (pXData == NULL) {
-    GSLC_DEBUG2_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pXData is NULL\n", nType, nLineNum);
+    GSLC_DEBUG_PRINT("ERROR: GetXDataFromRef(Type %d, Line %d) pXData is NULL\n", nType, nLineNum);
     return NULL;
   }
   return pXData;

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -4887,8 +4887,8 @@ void gslc_CollectSetEventFunc(gslc_tsGui* pGui,gslc_tsCollect* pCollect,GSLC_CB_
 //   has provided a relatively lightweight fixed-point representation
 //   using the following 16-bit LUT (8-bit index).
 // - At this point in time, the LUT is only used by GUIslice for sin/cos
-//   in supporting the XGauge Radial controls (enabled by GSLC_FEATURE_XGAUGE_RADIAL)
-// - The LUT consumes approx 514 bytes of FLASH memory
+//   in supporting the XRadial controls
+// - The LUT consumes approx 514 bytes of FLASH memory. FIXME: Ensure in FLASH!
 uint16_t  m_nLUTSinF0X16[257] = {
   0x0000,0x0192,0x0324,0x04B6,0x0648,0x07DA,0x096C,0x0AFD,0x0C8F,0x0E21,0x0FB2,0x1143,0x12D5,0x1465,0x15F6,0x1787,
   0x1917,0x1AA7,0x1C37,0x1DC6,0x1F56,0x20E5,0x2273,0x2402,0x258F,0x271D,0x28AA,0x2A37,0x2BC3,0x2D4F,0x2EDB,0x3066,

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.23"
+#define GUISLICE_VER "0.12.2.24"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.24"
+#define GUISLICE_VER "0.12.2.25"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.25"
+#define GUISLICE_VER "0.12.2.26"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.22"
+#define GUISLICE_VER "0.12.2.23"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.26"
+#define GUISLICE_VER "0.12.2.27"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XGauge.c
+++ b/src/elem/XGauge.c
@@ -110,6 +110,7 @@ gslc_tsElemRef* gslc_ElemXGaugeCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t n
   sElem.colElemFillGlow   = GSLC_COL_BLACK;
   sElem.colElemFrame      = GSLC_COL_GRAY;
   sElem.colElemFrameGlow  = GSLC_COL_GRAY;
+  GSLC_DEBUG_PRINT("NOTE: XGauge has been replaced by XProgress/XRadial/XRamp\n","");
   if (nPage != GSLC_PAGE_NONE) {
     pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
     return pElemRef;

--- a/src/elem/XProgress.c
+++ b/src/elem/XProgress.c
@@ -1,0 +1,365 @@
+// =======================================================================
+// GUIslice library (extensions)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XProgress.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XProgress.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: Progress Bar
+// - Basic progress bar with support for vertical / horizontal orientation and
+//   fill direction. Also provides an indicator of negative regions, depending
+//   on the configured range.
+// ============================================================================
+
+// Create a gauge element and add it to the GUI element list
+// - Defines default styling for the element
+// - Defines callback for redraw but does not track touch/click
+gslc_tsElemRef* gslc_ElemXProgressCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXProgress* pXData,gslc_tsRect rElem,
+  int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXProgressCreate";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_PROGRESS,rElem,NULL,0,GSLC_FONT_NONE);
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_CLICK_EN;  // Element is not "clickable"
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_GLOW_EN;
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+  pXData->nMin            = nMin;
+  pXData->nMax            = nMax;
+  pXData->nVal            = nVal;
+  pXData->bVert           = bVert;
+  pXData->bFlip           = false;
+  pXData->colGauge        = colGauge;
+  sElem.pXData            = (void*)(pXData);
+  sElem.pfuncXDraw        = &gslc_ElemXProgressDraw;
+  sElem.pfuncXTouch       = NULL;           // No need to track touches
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_GRAY;
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+// Update the gauge control's current position
+void gslc_ElemXProgressSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXProgressSetVal";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsXProgress*  pGauge  = (gslc_tsXProgress*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_PROGRESS,__LINE__);
+
+  // Update the data element
+  int16_t nValOld = pGauge->nVal;
+  pGauge->nVal = nVal;
+
+  // Element needs redraw
+  if (nVal != nValOld) {
+    // We only need an incremental redraw
+    // NOTE: If the user configures the indicator to be
+    //       long enough that it overlaps some of the gauge indicators
+    //       then a full redraw should be done instead.
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+  }
+
+}
+
+// Update the gauge's fill direction
+// - Setting bFlip causes the gauge to be filled in the reverse direction
+//   to the default
+// - Default fill direction for horizontal gauges: left-to-right
+// - Default fill direction for vertical gauges: bottom-to-top
+void gslc_ElemXProgressSetFlip(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFlip)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXProgressSetFlip";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+
+  // Fetch the element's extended data structure
+  gslc_tsXProgress*  pGauge  = (gslc_tsXProgress*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_PROGRESS,__LINE__);
+
+  pGauge->bFlip = bFlip;
+
+  // Mark for redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+
+}
+
+
+// Redraw the gauge
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+bool gslc_ElemXProgressDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXProgressDraw";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return false;
+  }
+
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui      = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef  = (gslc_tsElemRef*)(pvElemRef);
+
+  // Fetch the element's extended data structure
+  gslc_tsXProgress*  pGauge  = (gslc_tsXProgress*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_PROGRESS,__LINE__);
+
+  gslc_ElemXProgressDrawHelp(pGui,pElemRef,eRedraw);
+
+  // Save as "last state" to support incremental erase/redraw
+  pGauge->nValLast      = pGauge->nVal;
+  pGauge->bValLastValid = true;
+
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  return true;
+}
+
+
+bool gslc_ElemXProgressDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw)
+{
+  gslc_tsElem*       pElem   = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXProgress*  pGauge  = (gslc_tsXProgress*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_PROGRESS,__LINE__);
+
+  gslc_tsRect   rTmp;           // Temporary rect for drawing
+  gslc_tsRect   rGauge;         // Filled portion of gauge
+  gslc_tsRect   rEmpty;         // Empty portion of gauge
+  uint16_t      nElemW,nElemH;
+  int16_t       nElemX0,nElemY0,nElemX1,nElemY1;
+  int16_t       nGaugeX0,nGaugeY0,nGaugeX1,nGaugeY1;
+
+  nElemX0 = pElem->rElem.x;
+  nElemY0 = pElem->rElem.y;
+  nElemX1 = pElem->rElem.x + pElem->rElem.w - 1;
+  nElemY1 = pElem->rElem.y + pElem->rElem.h - 1;
+  nElemW  = pElem->rElem.w;
+  nElemH  = pElem->rElem.h;
+
+  bool    bVert = pGauge->bVert;
+  bool    bFlip = pGauge->bFlip;
+  int16_t nMax  = pGauge->nMax;
+  int16_t nMin  = pGauge->nMin;
+  int16_t nRng  = pGauge->nMax - pGauge->nMin;
+
+  uint32_t nScl = 1;
+  int16_t nGaugeMid = 0;
+  int16_t nLen = 0;
+  int16_t nTmp = 0;
+  int32_t nTmpL = 0;
+
+  if (nRng == 0) {
+    GSLC_DEBUG2_PRINT("ERROR: ElemXProgressDraw() Zero gauge range [%d,%d]\n",nMin,nMax);
+    return false;
+  }
+
+  if (bVert) {
+    nScl = nElemH*32768/nRng;
+  } else {
+    nScl = nElemW*32768/nRng;
+  }
+
+  // Calculate the control midpoint/zeropoint (for display purposes)
+  nTmpL = -((int32_t)nMin * (int32_t)nScl / 32768);
+  nGaugeMid = (int16_t)nTmpL;
+
+
+  // Calculate the length of the bar
+  // - Use long mult/divide to avoid need for floating point
+  nTmpL = (int32_t)(pGauge->nVal) * (int32_t)(nScl) / 32768;
+  nLen  = (int16_t)(nTmpL);
+
+  // Define the gauge's fill rectangle region
+  // depending on the orientation (bVert) and whether
+  // the current position is negative or positive.
+  if (nLen >= 0) {
+    if (bVert) {
+      nGaugeY0 = nElemY0 + nGaugeMid;
+      nGaugeY1 = nElemY0 + nGaugeMid + nLen;
+    } else {
+      nGaugeX0 = nElemX0 + nGaugeMid;
+      nGaugeX1 = nElemX0 + nGaugeMid + nLen;
+    }
+  } else {
+    if (bVert) {
+      nGaugeY0 = nElemY0 + nGaugeMid + nLen;
+      nGaugeY1 = nElemY0 + nGaugeMid;
+    } else {
+      nGaugeX0 = nElemX0 + nGaugeMid + nLen;
+      nGaugeX1 = nElemX0 + nGaugeMid;
+    }
+  }
+  if (bVert) {
+    nGaugeX0 = nElemX0;
+    nGaugeX1 = nElemX1;
+  } else {
+    nGaugeY0 = nElemY0;
+    nGaugeY1 = nElemY1;
+  }
+
+
+  // Clip the region
+  nGaugeX0 = (nGaugeX0 < nElemX0)? nElemX0 : nGaugeX0;
+  nGaugeY0 = (nGaugeY0 < nElemY0)? nElemY0 : nGaugeY0;
+  nGaugeX1 = (nGaugeX1 > nElemX1)? nElemX1 : nGaugeX1;
+  nGaugeY1 = (nGaugeY1 > nElemY1)? nElemY1 : nGaugeY1;
+
+  // Support flipping of gauge directionality
+  // - The bFlip flag reverses the fill direction
+  // - Vertical gauges are flipped by default
+
+  if (bVert && !bFlip) {
+    nTmp      = nElemY0+(nElemY1-nGaugeY1);  // nTmp will be swapped into nGaugeY0
+    nGaugeY1  = nElemY1-(nGaugeY0-nElemY0);
+    nGaugeY0  = nTmp;
+    nGaugeMid = nElemH-nGaugeMid-1;
+  } else if (!bVert && bFlip) {
+    nTmp      = nElemX0+(nElemX1-nGaugeX1);  // nTmp will be swapped into nGaugeX0
+    nGaugeX1  = nElemX1-(nGaugeX0-nElemX0);
+    nGaugeX0  = nTmp;
+    nGaugeMid = nElemW-nGaugeMid-1;
+  }
+
+  #ifdef DBG_LOG
+  //printf("Gauge: nMin=%4d nMax=%4d nRng=%d nVal=%4d fScl=%6.3f nGaugeMid=%4d RectX=%4d RectW=%4d\n",
+  //  nMin,nMax,nRng,pGauge->nGaugeVal,fScl,nGaugeMid,rGauge.x,rGauge.w);
+  #endif
+
+  // Draw a frame around the gauge
+  // - Only draw this during full redraw
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    gslc_DrawFrameRect(pGui, pElem->rElem, pElem->colElemFrame);
+  }
+
+  // To avoid flicker, we only erase the portion of the gauge
+  // that isn't "filled". Determine the gauge empty region and erase it
+  // There are two empty regions (one in negative and one in positive)
+  int16_t nEmptyPos;
+  if (bVert) {
+    // Empty Region #1 (negative)
+    nEmptyPos = (nGaugeY0 > nElemY1) ? nElemY1 : nGaugeY0;
+    rEmpty = (gslc_tsRect){nElemX0,nElemY0,nElemX1-nElemX0+1,nEmptyPos-nElemY0+1};
+    rTmp = gslc_ExpandRect(rEmpty,-1,-1);
+    gslc_DrawFillRect(pGui,rTmp,pElem->colElemFill);
+    // Empty Region #2 (positive)
+    nEmptyPos = (nGaugeY1 < nElemY0) ? nElemY0 : nGaugeY1;
+    rEmpty = (gslc_tsRect){nElemX0,nEmptyPos,nElemX1-nElemX0+1,nElemY1-nEmptyPos+1};
+    rTmp = gslc_ExpandRect(rEmpty,-1,-1);
+    gslc_DrawFillRect(pGui,rTmp,pElem->colElemFill);
+  } else {
+    // Empty Region #1 (negative)
+    nEmptyPos = (nGaugeX0 > nElemX1) ? nElemX1 : nGaugeX0;
+    rEmpty = (gslc_tsRect){nElemX0,nElemY0,nEmptyPos-nElemX0+1,nElemY1-nElemY0+1};
+    rTmp = gslc_ExpandRect(rEmpty,-1,-1);
+    gslc_DrawFillRect(pGui, rTmp, pElem->colElemFill);
+    // Empty Region #2 (positive)
+    nEmptyPos = (nGaugeX1 < nElemX0) ? nElemX0 : nGaugeX1;
+    rEmpty = (gslc_tsRect){nEmptyPos,nElemY0,nElemX1-nEmptyPos+1,nElemY1-nElemY0+1};
+    rTmp = gslc_ExpandRect(rEmpty,-1,-1);
+    gslc_DrawFillRect(pGui, rTmp, pElem->colElemFill);
+  }
+
+  // Draw the gauge fill region
+  rGauge = (gslc_tsRect){nGaugeX0,nGaugeY0,nGaugeX1-nGaugeX0+1,nGaugeY1-nGaugeY0+1};
+  rTmp = gslc_ExpandRect(rGauge,-1,-1);
+  gslc_DrawFillRect(pGui,rTmp,pGauge->colGauge);
+
+
+  // Draw the midpoint line
+  if (bVert) {
+    if (nElemY0 + nGaugeMid < nElemY1) {
+      gslc_DrawLine(pGui, nElemX0, nElemY0 + nGaugeMid, nElemX1, nElemY0 + nGaugeMid, pElem->colElemFrame);
+    }
+  } else {
+    if (nElemX0 + nGaugeMid < nElemX1) {
+      gslc_DrawLine(pGui, nElemX0 + nGaugeMid, nElemY0, nElemX0 + nGaugeMid, nElemY1, pElem->colElemFrame);
+    }
+  }
+
+
+
+  return true;
+}
+
+// ============================================================================

--- a/src/elem/XProgress.h
+++ b/src/elem/XProgress.h
@@ -1,0 +1,285 @@
+#ifndef _GUISLICE_EX_XPROGRESS_H_
+#define _GUISLICE_EX_XPROGRESS_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: Progress Bar
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XProgress.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+// ============================================================================
+// Extended Element: Progress Bar
+// - Basic progress bar with support for vertical / horizontal orientation and
+//   fill direction. Also provides an indicator of negative regions, depending
+//   on the configured range.
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_PROGRESS GSLC_TYPE_BASE_EXTEND + 60
+
+
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+/// Extended data for Gauge element
+typedef struct {
+  // Range config
+  int16_t             nMin;           ///< Minimum control value
+  int16_t             nMax;           ///< Maximum control value
+
+  // Current value
+  int16_t             nVal;           ///< Current control value
+  // Previous value
+  int16_t             nValLast;       ///< Last value
+  bool                bValLastValid;  ///< Last value valid?
+
+  // Appearance config
+  gslc_tsColor        colGauge;       ///< Color of gauge fill bar
+  bool                bVert;          ///< Vertical if true, else Horizontal
+  bool                bFlip;          ///< Reverse direction of gauge
+
+} gslc_tsXProgress;
+
+
+///
+/// Create a Progress Bar Element
+/// - Draws a gauge element that represents a proportion (nVal)
+///   between nMin and nMax.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining gauge size
+/// \param[in]  nMin:        Minimum value of gauge for nVal comparison
+/// \param[in]  nMax:        Maximum value of gauge for nVal comparison
+/// \param[in]  nVal:        Starting value of gauge
+/// \param[in]  colGauge:    Color for the gauge indicator
+/// \param[in]  bVert:       Flag to indicate vertical vs horizontal action
+///                          (true = vertical, false = horizontal)
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXProgressCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXProgress* pXData,gslc_tsRect rElem,int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert);
+
+
+///
+/// Update a Gauge element's current value
+/// - Note that min & max values are assigned in create()
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nVal:        New value to show in gauge
+///
+/// \return none
+///
+void gslc_ElemXProgressSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal);
+
+
+///
+/// Set a Gauge element's fill direction
+/// - Setting bFlip reverses the default fill direction
+/// - Default fill direction for horizontal gauges: left-to-right
+/// - Default fill direction for vertical gauges: bottom-to-top
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  bFlip:       If set, reverse direction of fill from default
+///
+/// \return none
+///
+void gslc_ElemXProgressSetFlip(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFlip);
+
+
+///
+/// Draw a gauge element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element reference (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXProgressDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+
+///
+/// Helper function to draw a gauge with style: progress bar
+/// - Called from gslc_ElemXProgressDraw()
+///
+/// \param[in]  pGui:        Ptr to GUI
+/// \param[in]  pElemRef:    Ptr to Element reference
+/// \param[in]  eRedraw:     Redraw status
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXProgressDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw);
+
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+/// \def gslc_ElemXProgressCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,
+///      nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_)
+///
+/// Create a Gauge Element in Flash
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Unique element ID to assign
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  nX:          X coordinate of element
+/// \param[in]  nY:          Y coordinate of element
+/// \param[in]  nW:          Width of element
+/// \param[in]  nH:          Height of element
+/// \param[in]  nMin_:       Minimum value of gauge for nVal comparison
+/// \param[in]  nMax_:       Maximum value of gauge for nVal comparison
+/// \param[in]  nVal_:       Starting value of gauge
+/// \param[in]  colFrame_:   Color for the gauge frame
+/// \param[in]  colFill_:    Color for the gauge background fill
+/// \param[in]  colGauge_:   Color for the gauge indicator
+/// \param[in]  bVert_:      Flag to indicate vertical vs horizontal action
+///                          (true = vertical, false = horizontal)
+///
+/// \return none
+///
+
+
+#if (GSLC_USE_PROGMEM)
+
+
+#define gslc_ElemXProgressCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
+    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXProgress sGauge##nElemId;                           \
+  sGauge##nElemId.nMin = nMin_;                                   \
+  sGauge##nElemId.nMax = nMax_;                                   \
+  sGauge##nElemId.nVal = nVal_;                                   \
+  sGauge##nElemId.nValLast = nVal_;                               \
+  sGauge##nElemId.bValLastValid = false;                          \
+  sGauge##nElemId.colGauge = colGauge_;                           \
+  sGauge##nElemId.bVert = bVert_;                                 \
+  sGauge##nElemId.bFlip = false;                                  \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_PROGRESS,                                           \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,                                         \
+      colFrame_,colFill_,colFrame_,colFill_,                      \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sGauge##nElemId),                                  \
+      NULL,                                                       \
+      &gslc_ElemXProgressDraw,                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_PROG | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#else
+
+
+#define gslc_ElemXProgressCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
+    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXProgress sGauge##nElemId;                           \
+  sGauge##nElemId.nMin = nMin_;                                   \
+  sGauge##nElemId.nMax = nMax_;                                   \
+  sGauge##nElemId.nVal = nVal_;                                   \
+  sGauge##nElemId.nValLast = nVal_;                               \
+  sGauge##nElemId.bValLastValid = false;                          \
+  sGauge##nElemId.colGauge = colGauge_;                           \
+  sGauge##nElemId.bVert = bVert_;                                 \
+  sGauge##nElemId.bFlip = false;                                  \
+  static const gslc_tsElem sElem##nElemId = {                     \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_PROGRESS,                                           \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,                                         \
+      colFrame_,colFill_,colFrame_,colFill_,                      \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sGauge##nElemId),                                  \
+      NULL,                                                       \
+      &gslc_ElemXProgressDraw,                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_CONST | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XPROGRESS_H_
+

--- a/src/elem/XRadial.c
+++ b/src/elem/XRadial.c
@@ -1,0 +1,364 @@
+// =======================================================================
+// GUIslice library (extensions)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XRadial.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XRadial.h"
+
+#include <stdio.h>
+
+#include <math.h>   // For sin/cos
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: Radial Gauge
+// - A circular gauge that can be used to show direction or other
+//   rotational values. Tick marks can be optionally drawn
+//   around the gauge.
+// - Size, color and fill of the needle can be configured.
+// ============================================================================
+
+// Create a radial gauge element and add it to the GUI element list
+// - Defines default styling for the element
+// - Defines callback for redraw but does not track touch/click
+gslc_tsElemRef* gslc_ElemXRadialCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXRadial* pXData,gslc_tsRect rElem,
+  int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialCreate";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_RADIAL,rElem,NULL,0,GSLC_FONT_NONE);
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_CLICK_EN;  // Element is not "clickable"
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_GLOW_EN;
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+  pXData->nMin            = nMin;
+  pXData->nMax            = nMax;
+  pXData->nVal            = nVal;
+  pXData->bVert           = bVert;
+  pXData->bFlip           = false;
+  pXData->colGauge        = colGauge;
+  pXData->colTick         = GSLC_COL_GRAY;
+  pXData->nTickCnt        = 8;
+  pXData->nTickLen        = 5;
+  pXData->nIndicLen       = 10;     // Dummy default to be overridden
+  pXData->nIndicTip       = 3;      // Dummy default to be overridden
+  pXData->bIndicFill      = false;
+  sElem.pXData            = (void*)(pXData);
+  sElem.pfuncXDraw        = &gslc_ElemXRadialDraw;
+  sElem.pfuncXTouch       = NULL;           // No need to track touches
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_GRAY;
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+
+void gslc_ElemXRadialSetIndicator(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colGauge,
+    uint16_t nIndicLen,uint16_t nIndicTip,bool bIndicFill)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialSetIndicator";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsXRadial*  pGauge  = (gslc_tsXRadial*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RADIAL,__LINE__);
+
+  // Update the config
+  pGauge->colGauge    = colGauge;
+  pGauge->nIndicLen   = nIndicLen;
+  pGauge->nIndicTip   = nIndicTip;
+  pGauge->bIndicFill  = bIndicFill;
+
+  // Just in case we were called at runtime, mark as needing redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXRadialSetTicks(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colTick,uint16_t nTickCnt,uint16_t nTickLen)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialSetTicks";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsXRadial*  pGauge  = (gslc_tsXRadial*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RADIAL,__LINE__);
+
+  // Update the config
+  pGauge->colTick   = colTick;
+  pGauge->nTickCnt  = nTickCnt;
+  pGauge->nTickLen  = nTickLen;
+
+  // Just in case we were called at runtime, mark as needing redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+// Update the gauge control's current position
+void gslc_ElemXRadialSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialSetVal";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsXRadial*  pGauge  = (gslc_tsXRadial*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RADIAL,__LINE__);
+
+  // Update the data element
+  int16_t nValOld = pGauge->nVal;
+  pGauge->nVal = nVal;
+
+  // Element needs redraw
+  if (nVal != nValOld) {
+    // We only need an incremental redraw
+    // NOTE: If the user configures the indicator to be
+    //       long enough that it overlaps some of the gauge indicators
+    //       then a full redraw should be done instead.
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+  }
+
+}
+
+// Update the gauge's rotation direction
+// - Setting bFlip reverses the rotation direction
+// - Default rotation is clockwise. When bFlip is set, uses counter-clockwise
+void gslc_ElemXRadialSetFlip(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFlip)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialSetFlip";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+
+  // Fetch the element's extended data structure
+  gslc_tsXRadial*  pGauge  = (gslc_tsXRadial*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RADIAL,__LINE__);
+  if (pGauge == NULL) {
+    GSLC_DEBUG2_PRINT("ERROR: gslc_ElemXRadialSetFlip(%s) pXData is NULL\n","");
+    return;
+  }
+  pGauge->bFlip = bFlip;
+
+  // Mark for redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+
+}
+
+
+// Redraw the gauge
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+bool gslc_ElemXRadialDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialDraw";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return false;
+  }
+
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui      = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef  = (gslc_tsElemRef*)(pvElemRef);
+
+  // Fetch the element's extended data structure
+  gslc_tsXRadial*  pGauge  = (gslc_tsXRadial*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RADIAL,__LINE__);
+
+  gslc_ElemXRadialDrawRadial(pGui,pElemRef,eRedraw);
+
+  // Save as "last state" to support incremental erase/redraw
+  pGauge->nValLast      = pGauge->nVal;
+  pGauge->bValLastValid = true;
+
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  return true;
+}
+
+
+void gslc_ElemXRadialDrawRadialHelp(gslc_tsGui* pGui,int16_t nX,int16_t nY,uint16_t nArrowLen,uint16_t nArrowSz,int16_t n64Ang,bool bFill,gslc_tsColor colFrame)
+{
+  int16_t   nTipX,nTipY;
+  int16_t   nBaseX1,nBaseY1,nBaseX2,nBaseY2;
+  int16_t   nTipBaseX,nTipBaseY;
+
+  gslc_PolarToXY(nArrowLen,n64Ang,&nTipX,&nTipY);
+  gslc_PolarToXY(nArrowLen-nArrowSz,n64Ang,&nTipBaseX,&nTipBaseY);
+  gslc_PolarToXY(nArrowSz,n64Ang-90*64,&nBaseX1,&nBaseY1);
+  gslc_PolarToXY(nArrowSz,n64Ang+90*64,&nBaseX2,&nBaseY2);
+
+  // FIXME: There appears to be a wrapping bug in the trigonometry
+  //        calculations associated with the bottom-right corner
+  //        of the pointer body when angles approach 359 degrees.
+
+  if (!bFill) {
+    // Framed
+    gslc_DrawLine(pGui,nX+nBaseX1,nY+nBaseY1,nX+nBaseX1+nTipBaseX,nY+nBaseY1+nTipBaseY,colFrame);
+    gslc_DrawLine(pGui,nX+nBaseX2,nY+nBaseY2,nX+nBaseX2+nTipBaseX,nY+nBaseY2+nTipBaseY,colFrame);
+    gslc_DrawLine(pGui,nX+nBaseX1+nTipBaseX,nY+nBaseY1+nTipBaseY,nX+nTipX,nY+nTipY,colFrame);
+    gslc_DrawLine(pGui,nX+nBaseX2+nTipBaseX,nY+nBaseY2+nTipBaseY,nX+nTipX,nY+nTipY,colFrame);
+    gslc_DrawLine(pGui,nX+nBaseX1,nY+nBaseY1,nX+nBaseX2,nY+nBaseY2,colFrame);
+
+  } else {
+    // Filled
+    gslc_tsPt asPt[4];
+
+    // Main body of pointer
+    asPt[0] = (gslc_tsPt){nX+nBaseX1,nY+nBaseY1};
+    asPt[1] = (gslc_tsPt){nX+nBaseX1+nTipBaseX,nY+nBaseY1+nTipBaseY};
+    asPt[2] = (gslc_tsPt){nX+nBaseX2+nTipBaseX,nY+nBaseY2+nTipBaseY};
+    asPt[3] = (gslc_tsPt){nX+nBaseX2,nY+nBaseY2};
+    gslc_DrawFillQuad(pGui,asPt,colFrame);
+
+    // Tip of pointer
+    asPt[0] = (gslc_tsPt){nX+nBaseX1+nTipBaseX,nY+nBaseY1+nTipBaseY};
+    asPt[1] = (gslc_tsPt){nX+nTipX,nY+nTipY};
+    asPt[2] = (gslc_tsPt){nX+nBaseX2+nTipBaseX,nY+nBaseY2+nTipBaseY};
+    gslc_DrawFillTriangle(pGui,asPt[0].x,asPt[0].y,asPt[1].x,asPt[1].y,asPt[2].x,asPt[2].y,colFrame);
+
+  }
+
+}
+
+bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw)
+{
+  gslc_tsElem*    pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXRadial*  pGauge  = (gslc_tsXRadial*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RADIAL,__LINE__);
+
+  uint16_t      nElemW,nElemH,nElemRad;
+  int16_t       nElemX0,nElemY0,nElemX1,nElemY1;
+  int16_t       nElemMidX,nElemMidY;
+  nElemX0   = pElem->rElem.x;
+  nElemY0   = pElem->rElem.y;
+  nElemX1   = pElem->rElem.x + pElem->rElem.w - 1;
+  nElemY1   = pElem->rElem.y + pElem->rElem.h - 1;
+  nElemMidX = (nElemX0+nElemX1)/2;
+  nElemMidY = (nElemY0+nElemY1)/2;
+  nElemW    = pElem->rElem.w;
+  nElemH    = pElem->rElem.h;
+  nElemRad  = (nElemW>=nElemH)? nElemH/2 : nElemW/2;
+
+  int16_t   nMax            = pGauge->nMax;
+  int16_t   nMin            = pGauge->nMin;
+  int16_t   nRng            = pGauge->nMax - pGauge->nMin;
+  int16_t   nVal            = pGauge->nVal;
+  int16_t   nValLast        = pGauge->nValLast;
+  bool      bValLastValid   = pGauge->bValLastValid;
+  uint16_t  nTickLen        = pGauge->nTickLen;
+  uint16_t  nTickAng        = 360 / pGauge->nTickCnt;
+  uint16_t  nArrowLen       = pGauge->nIndicLen;
+  uint16_t  nArrowSize      = pGauge->nIndicTip;
+  bool      bFill           = pGauge->bIndicFill;
+
+  int16_t   n64Ang,n64AngLast;
+  int16_t   nInd;
+
+
+  if (nRng == 0) {
+    GSLC_DEBUG2_PRINT("ERROR: ElemXRadialDraw() Zero range [%d,%d]\n",nMin,nMax);
+    return false;
+  }
+
+  // Support reversing of direction
+  // TODO: Clean up excess integer typecasting
+  if (pGauge->bFlip) {
+    n64Ang      = (int32_t)(nMax - nVal    )* 360*64 /nRng;
+    n64AngLast  = (int32_t)(nMax - nValLast)* 360*64 /nRng;
+  } else {
+    n64Ang      = (int32_t)(nVal     - nMin)* 360*64 /nRng;
+    n64AngLast  = (int32_t)(nValLast - nMin)* 360*64 /nRng;
+  }
+
+  // Clear old
+  if (bValLastValid) {
+    gslc_ElemXRadialDrawRadialHelp(pGui,nElemMidX,nElemMidY,nArrowLen,nArrowSize,n64AngLast,bFill,pElem->colElemFill);
+  }
+
+  // Draw frame
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    gslc_DrawFillCircle(pGui,nElemMidX,nElemMidY,nElemRad,pElem->colElemFill);  // Erase first
+    gslc_DrawFrameCircle(pGui,nElemMidX,nElemMidY,nElemRad,pElem->colElemFrame);
+    for (nInd=0;nInd<360;nInd+=nTickAng) {
+      gslc_DrawLinePolar(pGui,nElemMidX,nElemMidY,nElemRad-nTickLen,nElemRad,nInd*64,pGauge->colTick);
+    }
+  }
+
+  // Draw pointer
+  gslc_ElemXRadialDrawRadialHelp(pGui,nElemMidX,nElemMidY,nArrowLen,nArrowSize,n64Ang,bFill,pGauge->colGauge);
+
+  return true;
+}
+
+
+// ============================================================================

--- a/src/elem/XRadial.h
+++ b/src/elem/XRadial.h
@@ -1,0 +1,332 @@
+#ifndef _GUISLICE_EX_XRADIAL_H_
+#define _GUISLICE_EX_XRADIAL_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: Radial control
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XRadial.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+// ============================================================================
+// Extended Element: Radial Gauge
+// - A circular gauge that can be used to show direction or other
+//   rotational values. Tick marks can be optionally drawn
+//   around the gauge.
+// - Size, color and fill of the needle can be configured.
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_RADIAL GSLC_TYPE_BASE_EXTEND + 61
+
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+/// Extended data for Gauge element
+typedef struct {
+  // Range config
+  int16_t             nMin;           ///< Minimum control value
+  int16_t             nMax;           ///< Maximum control value
+
+  // Current value
+  int16_t             nVal;           ///< Current control value
+  // Previous value
+  int16_t             nValLast;       ///< Last value
+  bool                bValLastValid;  ///< Last value valid?
+
+  // Appearance config
+  gslc_tsColor        colGauge;       ///< Color of gauge fill bar
+  gslc_tsColor        colTick;        ///< Color of gauge tick marks
+  uint16_t            nTickCnt;       ///< Number of gauge tick marks
+  uint16_t            nTickLen;       ///< Length of gauge tick marks
+  bool                bVert;          ///< Vertical if true, else Horizontal
+  bool                bFlip;          ///< Reverse direction of gauge
+  uint16_t            nIndicLen;      ///< Indicator length
+  uint16_t            nIndicTip;      ///< Size of tip at end of indicator
+  bool                bIndicFill;     ///< Fill the indicator if true
+
+} gslc_tsXRadial;
+
+
+///
+/// Create a Radial Gauge Element
+/// - Draws a gauge element that represents a proportion (nVal)
+///   between nMin and nMax.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining gauge size
+/// \param[in]  nMin:        Minimum value of gauge for nVal comparison
+/// \param[in]  nMax:        Maximum value of gauge for nVal comparison
+/// \param[in]  nVal:        Starting value of gauge
+/// \param[in]  colGauge:    Color for the gauge indicator
+/// \param[in]  bVert:       Flag to indicate vertical vs horizontal action
+///                          (true = vertical, false = horizontal)
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXRadialCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXRadial* pXData,gslc_tsRect rElem,int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert);
+
+
+
+///
+/// Configure the appearance of the Gauge indicator
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  colGauge:    Color of the indicator
+/// \param[in]  nIndicLen:   Length of the indicator
+/// \param[in]  nIndicTip:   Size of the indicator tip
+/// \param[in]  bIndicFill:  Fill in the indicator if true
+///
+/// \return none
+///
+void gslc_ElemXRadialSetIndicator(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colGauge,
+        uint16_t nIndicLen,uint16_t nIndicTip,bool bIndicFill);
+
+
+///
+/// Configure the appearance of the Gauge ticks
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  colTick:     Color of the gauge ticks
+/// \param[in]  nTickCnt:    Number of ticks to draw around / along gauge
+/// \param[in]  nTickLen:    Length of the tick marks to draw
+///
+/// \return none
+///
+void gslc_ElemXRadialSetTicks(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_tsColor colTick,uint16_t nTickCnt,uint16_t nTickLen);
+
+
+///
+/// Update a Gauge element's current value
+/// - Note that min & max values are assigned in create()
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nVal:        New value to show in gauge
+///
+/// \return none
+///
+void gslc_ElemXRadialSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal);
+
+
+///
+/// Set a Gauge element's rotation direction
+/// - Setting bFlip reverses the rotation direction
+/// - Default rotation is clockwise. When bFlip is set, uses counter-clockwise
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  bFlip:       If set, reverse direction of rotation from default
+///
+/// \return none
+///
+void gslc_ElemXRadialSetFlip(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bFlip);
+
+
+///
+/// Draw a gauge element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element reference (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXRadialDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+
+///
+/// Helper function to draw a gauge with style: radial
+/// - Called from gslc_ElemXRadialDraw()
+///
+/// \param[in]  pGui:        Ptr to GUI
+/// \param[in]  pElemRef:    Ptr to Element reference
+/// \param[in]  eRedraw:     Redraw status
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw);
+
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+/// \def gslc_ElemXRadialCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,
+///      nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_)
+///
+/// Create a Gauge Element in Flash
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Unique element ID to assign
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  nX:          X coordinate of element
+/// \param[in]  nY:          Y coordinate of element
+/// \param[in]  nW:          Width of element
+/// \param[in]  nH:          Height of element
+/// \param[in]  nMin_:       Minimum value of gauge for nVal comparison
+/// \param[in]  nMax_:       Maximum value of gauge for nVal comparison
+/// \param[in]  nVal_:       Starting value of gauge
+/// \param[in]  colFrame_:   Color for the gauge frame
+/// \param[in]  colFill_:    Color for the gauge background fill
+/// \param[in]  colGauge_:   Color for the gauge indicator
+/// \param[in]  bVert_:      Flag to indicate vertical vs horizontal action
+///                          (true = vertical, false = horizontal)
+///
+/// \return none
+///
+
+
+#if (GSLC_USE_PROGMEM)
+
+
+#define gslc_ElemXRadialCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
+    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXRadial sGauge##nElemId;                           \
+  sGauge##nElemId.nMin = nMin_;                                   \
+  sGauge##nElemId.nMax = nMax_;                                   \
+  sGauge##nElemId.nVal = nVal_;                                   \
+  sGauge##nElemId.nValLast = nVal_;                               \
+  sGauge##nElemId.bValLastValid = false;                          \
+  sGauge##nElemId.colGauge = colGauge_;                           \
+  sGauge##nElemId.colTick = GSLC_COL_GRAY;                        \
+  sGauge##nElemId.nTickCnt = 8;                                   \
+  sGauge##nElemId.nTickLen = 5;                                   \
+  sGauge##nElemId.bVert = bVert_;                                 \
+  sGauge##nElemId.bFlip = false;                                  \
+  sGauge##nElemId.nIndicLen = 10;                                 \
+  sGauge##nElemId.nIndicTip = 3;                                  \
+  sGauge##nElemId.bIndicFill = false;                             \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_RADIAL,                                           \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,                                         \
+      colFrame_,colFill_,colFrame_,colFill_,                      \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sGauge##nElemId),                                  \
+      NULL,                                                       \
+      &gslc_ElemXRadialDraw,                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_PROG | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#else
+
+
+#define gslc_ElemXRadialCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
+    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXRadial sGauge##nElemId;                           \
+  sGauge##nElemId.nMin = nMin_;                                   \
+  sGauge##nElemId.nMax = nMax_;                                   \
+  sGauge##nElemId.nVal = nVal_;                                   \
+  sGauge##nElemId.nValLast = nVal_;                               \
+  sGauge##nElemId.bValLastValid = false;                          \
+  sGauge##nElemId.colGauge = colGauge_;                           \
+  sGauge##nElemId.colTick = GSLC_COL_GRAY;                        \
+  sGauge##nElemId.nTickCnt = 8;                                   \
+  sGauge##nElemId.nTickLen = 5;                                   \
+  sGauge##nElemId.bVert = bVert_;                                 \
+  sGauge##nElemId.bFlip = false;                                  \
+  sGauge##nElemId.nIndicLen = 10;                                 \
+  sGauge##nElemId.nIndicTip = 3;                                  \
+  sGauge##nElemId.bIndicFill = false;                             \
+  static const gslc_tsElem sElem##nElemId = {                     \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_RADIAL,                                           \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,                                         \
+      colFrame_,colFill_,colFrame_,colFill_,                      \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sGauge##nElemId),                                  \
+      NULL,                                                       \
+      &gslc_ElemXRadialDraw,                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_CONST | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XRADIAL_H_
+

--- a/src/elem/XRamp.c
+++ b/src/elem/XRamp.c
@@ -1,0 +1,300 @@
+// =======================================================================
+// GUIslice library (extensions)
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XRamp.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+#include "elem/XRamp.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+
+// ============================================================================
+// Extended Element: Ramp Gauge
+// - Demonstration of a gradient ramp (green-yellow-red) visual
+//   control similar to certain linear tachometers.
+// - The ramp rises up and to the right according to the
+//   current value.
+// - Note that this element is mainly intended as a demonstration
+//   example. Additional APIs would be recommended to make it
+//   more configurable.
+// ============================================================================
+
+// Create a gauge element and add it to the GUI element list
+// - Defines default styling for the element
+// - Defines callback for redraw but does not track touch/click
+gslc_tsElemRef* gslc_ElemXRampCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXRamp* pXData,gslc_tsRect rElem,
+  int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRampCreate";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_RAMP,rElem,NULL,0,GSLC_FONT_NONE);
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_CLICK_EN;  // Element is not "clickable"
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_GLOW_EN;
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+  pXData->nMin            = nMin;
+  pXData->nMax            = nMax;
+  pXData->nVal            = nVal;
+  sElem.pXData            = (void*)(pXData);
+  sElem.pfuncXDraw        = &gslc_ElemXRampDraw;
+  sElem.pfuncXTouch       = NULL;           // No need to track touches
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_GRAY;
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+
+// Update the gauge control's current position
+void gslc_ElemXRampSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRampSetVal";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  gslc_tsXRamp*  pGauge  = (gslc_tsXRamp*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RAMP,__LINE__);
+
+  // Update the data element
+  int16_t nValOld = pGauge->nVal;
+  pGauge->nVal = nVal;
+
+  // Element needs redraw
+  if (nVal != nValOld) {
+    // We only need an incremental redraw
+    // NOTE: If the user configures the indicator to be
+    //       long enough that it overlaps some of the gauge indicators
+    //       then a full redraw should be done instead.
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+  }
+
+}
+
+
+// Redraw the gauge
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+bool gslc_ElemXRampDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  if ((pvGui == NULL) || (pvElemRef == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXRampDraw";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return false;
+  }
+
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui      = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef  = (gslc_tsElemRef*)(pvElemRef);
+
+  // Fetch the element's extended data structure
+  gslc_tsXRamp*  pGauge  = (gslc_tsXRamp*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RAMP,__LINE__);
+
+  gslc_ElemXRampDrawHelp(pGui,pElemRef,eRedraw);
+
+  // Save as "last state" to support incremental erase/redraw
+  pGauge->nValLast      = pGauge->nVal;
+  pGauge->bValLastValid = true;
+
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  return true;
+}
+
+
+bool gslc_ElemXRampDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw)
+{
+  gslc_tsElem*   pElem   = gslc_GetElemFromRef(pGui,pElemRef);
+  gslc_tsXRamp*  pGauge  = (gslc_tsXRamp*)gslc_GetXDataFromRef(pGui,pElemRef,GSLC_TYPEX_RAMP,__LINE__);
+
+  uint16_t      nElemW,nElemH;
+  int16_t       nElemX0,nElemY1;
+  nElemX0   = pElem->rElem.x;
+  nElemY1   = pElem->rElem.y + pElem->rElem.h - 1;
+  nElemW    = pElem->rElem.w;
+  nElemH    = pElem->rElem.h;
+
+  int16_t   nMax            = pGauge->nMax;
+  int16_t   nMin            = pGauge->nMin;
+  int16_t   nRng            = pGauge->nMax - pGauge->nMin;
+  int16_t   nVal            = pGauge->nVal;
+  int16_t   nValLast        = pGauge->nValLast;
+  bool      bValLastValid   = pGauge->bValLastValid;
+  int16_t   nInd;
+
+  if (nRng == 0) {
+    GSLC_DEBUG2_PRINT("ERROR: gslc_ElemXRampDrawHelp() Zero range [%d,%d]\n",nMin,nMax);
+    return false;
+  }
+
+  uint32_t  nSclFX;
+  uint16_t  nHeight;
+  int32_t   nHeightTmp;
+  uint16_t  nHeightBot;
+  uint16_t  nX;
+  uint16_t  nColInd;
+
+  // Calculate region to draw or clear
+  bool      bModeErase;
+  int16_t   nValStart;
+  int16_t   nValEnd;
+  if ((eRedraw == GSLC_REDRAW_INC) && (!bValLastValid)) {
+    // - If the request was incremental (GSLC_REDRAW_INC) but
+    //   the last value wasn't marked as valid (!bValLastValid)
+    //   then we want to force a full redraw.
+    // - We don't expect to enter here since bValLastValid
+    //   should always be set after we perform our first
+    //   redraw.
+    eRedraw = GSLC_REDRAW_FULL;
+  }
+  if (eRedraw == GSLC_REDRAW_FULL) {
+    // If we haven't drawn anything before, draw full range from zero
+    bModeErase  = false;
+    nValStart   = 0;
+    nValEnd     = nVal;
+  } else {
+    if (nVal >= nValLast) {
+      // As we are advancing the control, we just draw the new range
+      bModeErase  = false;
+      nValStart   = nValLast;
+      nValEnd     = nVal;
+    } else {
+      // Since we are retracting the control, we erase the new range
+      bModeErase  = true;
+      nValStart   = nVal;
+      nValEnd     = nValLast;
+    }
+  }
+
+  // Calculate the scaled gauge position
+  // - TODO: Also support reversing of direction
+  int16_t   nPosXStart,nPosXEnd;
+  nPosXStart  = (nValStart - nMin)*nElemW/nRng;
+  nPosXEnd    = (nValEnd   - nMin)*nElemW/nRng;
+
+  nSclFX = (uint32_t)nElemH*32767/(nElemW*nElemW);
+
+  for (nX=nPosXStart;nX<nPosXEnd;nX++) {
+    nInd = nElemW-nX;
+    nHeightTmp = nSclFX * nInd*nInd /32767;
+    nHeight = nElemH-nHeightTmp;
+    if (nHeight >= 20) {
+      nHeightBot = nHeight-20;
+    } else {
+      nHeightBot = 0;
+    }
+    gslc_tsColor  nCol;
+    uint16_t      nSteps = 10;
+    uint16_t      nGap = 3;
+
+    if (nSteps == 0) {
+      nColInd = nX*1000/nElemW;
+      nCol = gslc_ColorBlend3(GSLC_COL_GREEN,GSLC_COL_YELLOW,GSLC_COL_RED,500,nColInd);
+    } else {
+      uint16_t  nBlockLen,nSegLen,nSegInd,nSegOffset,nSegStart;
+      nBlockLen = (nElemW-(nSteps-1)*nGap)/nSteps;
+      nSegLen = nBlockLen + nGap;
+      nSegInd = nX/nSegLen;
+      nSegOffset = nX % nSegLen;
+      nSegStart = nSegInd * nSegLen;
+
+      if (nSegOffset <= nBlockLen) {
+        // Inside block
+        nColInd = (uint32_t)nSegStart*1000/nElemW;
+        nCol = gslc_ColorBlend3(GSLC_COL_GREEN,GSLC_COL_YELLOW,GSLC_COL_RED,500,nColInd);
+
+      } else {
+        // Inside gap
+        // - No draw
+        nCol = pElem->colElemFill;
+      }
+
+    }
+
+    if (bModeErase) {
+      nCol = pElem->colElemFill;
+    }
+    gslc_DrawLine(pGui,nElemX0+nX,nElemY1-nHeightBot,nElemX0+nX,nElemY1-nHeight,nCol);
+
+  }
+
+  return true;
+}
+
+
+// ============================================================================

--- a/src/elem/XRamp.h
+++ b/src/elem/XRamp.h
@@ -1,0 +1,262 @@
+#ifndef _GUISLICE_EX_XRAMP_H_
+#define _GUISLICE_EX_XRAMP_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: Ramp gauge
+// - Calvin Hass
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XRamp.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+// ============================================================================
+// Extended Element: Ramp Gauge
+// - Demonstration of a gradient ramp (green-yellow-red) visual
+//   control similar to certain linear tachometers.
+// - The ramp rises up and to the right according to the
+//   current value.
+// - Note that this element is mainly intended as a demonstration
+//   example. Additional APIs would be recommended to make it
+//   more configurable.
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_RAMP GSLC_TYPE_BASE_EXTEND + 62
+
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+/// Extended data for Gauge element
+typedef struct {
+  // Range config
+  int16_t             nMin;           ///< Minimum control value
+  int16_t             nMax;           ///< Maximum control value
+
+  // Current value
+  int16_t             nVal;           ///< Current control value
+  // Previous value
+  int16_t             nValLast;       ///< Last value
+  bool                bValLastValid;  ///< Last value valid?
+
+  // Appearance config
+
+} gslc_tsXRamp;
+
+
+///
+/// Create a Ramp Gauge Element
+/// - Draws a gauge element that represents a proportion (nVal)
+///   between nMin and nMax.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining gauge size
+/// \param[in]  nMin:        Minimum value of gauge for nVal comparison
+/// \param[in]  nMax:        Maximum value of gauge for nVal comparison
+/// \param[in]  nVal:        Starting value of gauge
+/// \param[in]  colGauge:    Color for the gauge indicator
+/// \param[in]  bVert:       Flag to indicate vertical vs horizontal action
+///                          (true = vertical, false = horizontal)
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXRampCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXRamp* pXData,gslc_tsRect rElem,int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert);
+
+
+
+///
+/// Update a Gauge element's current value
+/// - Note that min & max values are assigned in create()
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nVal:        New value to show in gauge
+///
+/// \return none
+///
+void gslc_ElemXRampSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal);
+
+
+
+///
+/// Draw a gauge element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element reference (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXRampDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+
+///
+/// Helper function to draw a gauge with style: ramp
+/// - Called from gslc_ElemXRampDraw()
+///
+/// \param[in]  pGui:        Ptr to GUI
+/// \param[in]  pElemRef:    Ptr to Element reference
+/// \param[in]  eRedraw:     Redraw status
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXRampDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawType eRedraw);
+
+// ============================================================================
+
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+/// \def gslc_ElemXRampCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,
+///      nMin_,nMax_,nVal_,colFrame_,colFill_)
+///
+/// Create a Gauge Element in Flash
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Unique element ID to assign
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  nX:          X coordinate of element
+/// \param[in]  nY:          Y coordinate of element
+/// \param[in]  nW:          Width of element
+/// \param[in]  nH:          Height of element
+/// \param[in]  nMin_:       Minimum value of gauge for nVal comparison
+/// \param[in]  nMax_:       Maximum value of gauge for nVal comparison
+/// \param[in]  nVal_:       Starting value of gauge
+/// \param[in]  colFrame_:   Color for the gauge frame
+/// \param[in]  colFill_:    Color for the gauge background fill
+///
+/// \return none
+///
+
+
+#if (GSLC_USE_PROGMEM)
+
+
+#define gslc_ElemXRampCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
+    nMin_,nMax_,nVal_,colFrame_,colFill_) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXRamp sGauge##nElemId;                           \
+  sGauge##nElemId.nMin = nMin_;                                   \
+  sGauge##nElemId.nMax = nMax_;                                   \
+  sGauge##nElemId.nVal = nVal_;                                   \
+  sGauge##nElemId.nValLast = nVal_;                               \
+  sGauge##nElemId.bValLastValid = false;                          \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_RAMP,                                           \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,                                         \
+      colFrame_,colFill_,colFrame_,colFill_,                      \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sGauge##nElemId),                                  \
+      NULL,                                                       \
+      &gslc_ElemXRampDraw,                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_PROG | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#else
+
+
+#define gslc_ElemXRampCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
+    nMin_,nMax_,nVal_,colFrame_,colFill_) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXRamp sGauge##nElemId;                           \
+  sGauge##nElemId.nMin = nMin_;                                   \
+  sGauge##nElemId.nMax = nMax_;                                   \
+  sGauge##nElemId.nVal = nVal_;                                   \
+  sGauge##nElemId.nValLast = nVal_;                               \
+  sGauge##nElemId.bValLastValid = false;                          \
+  static const gslc_tsElem sElem##nElemId = {                     \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_RAMP,                                           \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      GSLC_GROUP_ID_NONE,                                         \
+      colFrame_,colFill_,colFrame_,colFill_,                      \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sGauge##nElemId),                                  \
+      NULL,                                                       \
+      &gslc_ElemXRampDraw,                                       \
+      NULL,                                                       \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_CONST | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XRAMP_H_
+


### PR DESCRIPTION
- The **XGauge** originally combined a progress bar, radial gauge and ramp gauge
  in a single element codebase, with a style API to select between them
- This update splits out these elements to enable better customization of
  each individual control type.

**Migration notes**:
- It is strongly recommended that users migrate from the XGauge element to
  the replacement element types.
- The general steps involve replacing XGauge with XProgress / XRadial / XRamp as needed.
- The following shows the [code changes](https://github.com/ImpulseAdventure/GUIslice/commit/52e91c6d85519fe39b9ac1d04b911f7fef336c64) for the `ex09_ard_radial` example:
```c++
//#include "elem/XGauge.h" // OLD
#include "elem/XRadial.h"  // NEW
#include "elem/XRamp.h"    // NEW
...
//gslc_tsXGauge             m_sXRadial, m_sXRamp; // OLD
gslc_tsXRadial              m_sXRadial;           // NEW
gslc_tsXRamp                m_sXRamp;             // NEW
...
//pElemRef = gslc_ElemXGaugeCreate(...); // OLD
pElemRef = gslc_ElemXRampCreate(...);    // NEW
pElemRef = gslc_ElemXRadialCreate(...);  // NEW
...
//gslc_ElemXGaugeUpdate(...);                    // OLD
gslc_ElemXRadialSetVal(pGui, pElemRefTmp, nVal); // NEW
gslc_ElemXRampSetVal(pGui, pElemRefTmp, nVal);   // NEW
```
- The `gslc_ElemXGaugeSetStyle()` call is no longer used.
- There is no longer any need to enable `GSLC_FEATURE_XGAUGE_RADIAL` or `GSLC_FEATURE_XGAUGE_RAMP` in the config
- The examples have been updated to reflect the revised API. Please refer to example `ex09_ard_radial` or `ex04_ard_ctrls` for guidance.
