### PR TITLE
Add support for element X & Y text margins

### DIFF
--- a/examples/arduino/ex30_ard_listbox/ex30_ard_listbox.ino
+++ b/examples/arduino/ex30_ard_listbox/ex30_ard_listbox.ino
@@ -146,7 +146,6 @@ bool InitOverlays()
     (gslc_tsRect) { 60, 50, 160, 160 }, E_FONT_EXTRA, m_pXListboxBuf, 50, XLISTBOX_SEL_NONE);
   gslc_ElemXListboxSetSize(&m_gui, pElemRef, 4, 2);
   gslc_ElemXListboxItemsSetSize(&m_gui, pElemRef, XLISTBOX_SIZE_AUTO, XLISTBOX_SIZE_AUTO);
-  gslc_ElemXListboxItemsSetTxtMargin(&m_gui, pElemRef, 5, 0); // Provide additional margin from left side
   gslc_ElemXListboxAddItem(&m_gui, pElemRef, "Red");
   gslc_ElemXListboxAddItem(&m_gui, pElemRef, "Orange");
   gslc_ElemXListboxAddItem(&m_gui, pElemRef, "Yellow");
@@ -158,6 +157,7 @@ bool InitOverlays()
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_BLUE_DK3, GSLC_COL_GRAY_DK3, GSLC_COL_GREEN_DK1);
   gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_WHITE);
+  gslc_ElemSetTxtMarginXY(&m_gui, pElemRef, 5, 0); // Provide additional margin from left side
   m_pElemListbox = pElemRef; // Save for quick access
 
 

--- a/examples/arduino/ex31_ard_listbox/ex31_ard_listbox.ino
+++ b/examples/arduino/ex31_ard_listbox/ex31_ard_listbox.ino
@@ -239,12 +239,12 @@ bool InitGUI()
     m_pXListboxBuf, sizeof(m_pXListboxBuf), 0);
   gslc_ElemXListboxItemsSetSize(&m_gui, pElemRef, XLISTBOX_SIZE_AUTO, XLISTBOX_SIZE_AUTO);
   gslc_ElemXListboxSetSize(&m_gui, pElemRef, 5, 1); // 5 rows, 1 column
-  gslc_ElemXListboxItemsSetTxtMargin(&m_gui, pElemRef, 5, 0); // Provide additional margin from left side
   gslc_ElemXListboxSetSelFunc(&m_gui, pElemRef, &CbListBox);
   gslc_ElemSetFrameEn(&m_gui, pElemRef, true);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_GRAY, GSLC_COL_BLACK, GSLC_COL_BLUE_DK3);
   gslc_ElemSetTxtCol(&m_gui, pElemRef, GSLC_COL_BLUE_LT3);
   gslc_ElemSetGlowCol(&m_gui, pElemRef, GSLC_COL_GRAY, GSLC_COL_BLUE_DK3, GSLC_COL_WHITE);
+  gslc_ElemSetTxtMarginXY(&m_gui, pElemRef, 5, 0); // Provide additional margin from left side
   m_pElemListbox = pElemRef;
 
   // Create vertical scrollbar for textbox

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2992,10 +2992,11 @@ bool gslc_ElemDrawByRef(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRedrawT
   // Draw text string if defined
   if (pElem->pStrBuf) {
     gslc_tsColor  colTxt    = (bGlowNow)? pElem->colElemTextGlow : pElem->colElemText;
-    int16_t       nMargin   = pElem->nTxtMargin;
+    int8_t        nMarginX  = pElem->nTxtMarginX;
+    int8_t        nMarginY  = pElem->nTxtMarginY;
 
     gslc_DrawTxtBase(pGui, pElem->pStrBuf, pElem->rElem, pElem->pTxtFont, pElem->eTxtFlags,
-      pElem->eTxtAlign, colTxt, colBg, nMargin, nMargin);
+      pElem->eTxtAlign, colTxt, colBg, nMarginX, nMarginY);
   }
 
   // --------------------------------------------------------------------------
@@ -3105,7 +3106,18 @@ void gslc_ElemSetTxtMargin(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,unsigned nM
   gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
   if (!pElem) return;
 
-  pElem->nTxtMargin        = nMargin;
+  pElem->nTxtMarginX       = nMargin;
+  pElem->nTxtMarginY       = nMargin;
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemSetTxtMarginXY(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int8_t nMarginX,int8_t nMarginY)
+{
+  gslc_tsElem* pElem = gslc_GetElemFromRefD(pGui, pElemRef, __LINE__);
+  if (!pElem) return;
+
+  pElem->nTxtMarginX       = nMarginX;
+  pElem->nTxtMarginY       = nMarginY;
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
 
@@ -3404,7 +3416,8 @@ void gslc_ElemSetStyleFrom(gslc_tsGui* pGui,gslc_tsElemRef* pElemRefSrc,gslc_tsE
   pElemDest->colElemText      = pElemSrc->colElemText;
   pElemDest->colElemTextGlow  = pElemSrc->colElemTextGlow;
   pElemDest->eTxtAlign        = pElemSrc->eTxtAlign;
-  pElemDest->nTxtMargin       = pElemSrc->nTxtMargin;
+  pElemDest->nTxtMarginX      = pElemSrc->nTxtMarginX;
+  pElemDest->nTxtMarginY      = pElemSrc->nTxtMarginY;
   pElemDest->pTxtFont         = pElemSrc->pTxtFont;
 
   // pXData
@@ -4513,7 +4526,8 @@ void gslc_ResetElem(gslc_tsElem* pElem)
   pElem->colElemText      = GSLC_COL_WHITE;
   pElem->colElemTextGlow  = GSLC_COL_WHITE;
   pElem->eTxtAlign        = GSLC_ALIGN_MID_MID;
-  pElem->nTxtMargin       = 0;
+  pElem->nTxtMarginX      = 0;
+  pElem->nTxtMarginY      = 0;
   pElem->pTxtFont         = NULL;
 
   pElem->pXData           = NULL;

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -629,7 +629,8 @@ typedef struct gslc_tsElem {
   gslc_tsColor        colElemText;      ///< Color of overlay text
   gslc_tsColor        colElemTextGlow;  ///< Color of overlay text when glowing
   int8_t              eTxtAlign;        ///< Alignment of overlay text
-  uint8_t             nTxtMargin;       ///< Margin of overlay text within rect region
+  int8_t              nTxtMarginX;      ///< Margin of overlay text within rect region (x offset)
+  int8_t              nTxtMarginY;      ///< Margin of overlay text within rect region (y offset)
   gslc_tsFont*        pTxtFont;         ///< Ptr to Font for overlay text
 
   // Extended data elements
@@ -1954,6 +1955,17 @@ void gslc_ElemSetTxtAlign(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,unsigned nAl
 ///
 void gslc_ElemSetTxtMargin(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,unsigned nMargin);
 
+/// Set the margin around of a textual element (X & Y offsets can be different)
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nMarginX:    Number of pixels gap to offset text horizontally
+/// \param[in]  nMarginY:    Number of pixels gap to offset text vertically
+///
+/// \return none
+///
+void gslc_ElemSetTxtMarginXY(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int8_t nMarginX,int8_t nMarginY);
+
 ///
 /// Update the text string associated with an Element
 ///
@@ -2524,6 +2536,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       nAlignTxt,                                                  \
       0,                                                          \
+      0,                                                          \
       pFont,                                                      \
       NULL,                                                       \
       NULL,                                                       \
@@ -2554,6 +2567,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       colTxt,                                                     \
       nAlignTxt,                                                  \
+      0,                                                          \
       0,                                                          \
       pFont,                                                      \
       NULL,                                                       \
@@ -2586,6 +2600,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       NULL,                                                       \
       NULL,                                                       \
@@ -2614,6 +2629,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       NULL,                                                       \
@@ -2647,6 +2663,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       nAlignTxt,                                                  \
       0,                                                          \
+      0,                                                          \
       pFont,                                                      \
       (void*)extraData,                                           \
       NULL,                                                       \
@@ -2677,6 +2694,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       colTxt,                                                     \
       nAlignTxt,                                                  \
+      0,                                                          \
       0,                                                          \
       pFont,                                                      \
       (void*)extraData,                                           \
@@ -2713,6 +2731,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       nAlignTxt,                                                  \
       0,                                                          \
+      0,                                                          \
       pFont,                                                      \
       NULL,                                                       \
       NULL,                                                       \
@@ -2743,6 +2762,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       colTxt,                                                     \
       nAlignTxt,                                                  \
+      0,                                                          \
       0,                                                          \
       pFont,                                                      \
       NULL,                                                       \
@@ -2775,6 +2795,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       NULL,                                                       \
       NULL,                                                       \
@@ -2803,6 +2824,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       NULL,                                                       \
@@ -2835,6 +2857,7 @@ void gslc_InputMapAdd(gslc_tsGui* pGui,gslc_teInputRawEvent eInputEvent,int16_t 
       colTxt,                                                     \
       colTxt,                                                     \
       nAlignTxt,                                                  \
+      0,                                                          \
       0,                                                          \
       pFont,                                                      \
       (void*)extraData,                                           \

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.31"
+#define GUISLICE_VER "0.12.2.32"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.30"
+#define GUISLICE_VER "0.12.2.31"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XCheckbox.h
+++ b/src/elem/XCheckbox.h
@@ -230,6 +230,7 @@ bool gslc_ElemXCheckboxTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       (void*)(&sCheckbox##nElemId),                               \
       NULL,                                                       \
@@ -267,6 +268,7 @@ bool gslc_ElemXCheckboxTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       (void*)(&sCheckbox##nElemId),                               \

--- a/src/elem/XGauge.h
+++ b/src/elem/XGauge.h
@@ -323,6 +323,7 @@ bool gslc_ElemXGaugeDrawRamp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRe
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \
       NULL,                                                       \
@@ -372,6 +373,7 @@ bool gslc_ElemXGaugeDrawRamp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRe
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \

--- a/src/elem/XListbox.c
+++ b/src/elem/XListbox.c
@@ -166,18 +166,6 @@ void gslc_ElemXListboxSetMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8
   gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
 }
 
-void gslc_ElemXListboxItemsSetTxtMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH)
-{
-  gslc_tsXListbox* pListbox = (gslc_tsXListbox*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_LISTBOX, __LINE__);
-  if (!pListbox) return;
-
-  pListbox->nItemMarginW = nMarginW;
-  pListbox->nItemMarginH = nMarginH;
-  pListbox->bNeedRecalc = true;
-  // Mark as needing full redraw
-  gslc_ElemSetRedraw(pGui, pElemRef, GSLC_REDRAW_FULL);
-}
-
 
 void gslc_ElemXListboxItemsSetSize(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nItemW, int16_t nItemH)
 {
@@ -365,8 +353,6 @@ gslc_tsElemRef* gslc_ElemXListboxCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t
   pXData->nItemH          = 30;
   pXData->nItemGap        = 2;
   pXData->colGap          = GSLC_COL_BLACK;
-  pXData->nItemMarginW    = 0;
-  pXData->nItemMarginH    = 0;
   pXData->nItemCurSelLast = XLISTBOX_SEL_NONE;
   sElem.pXData            = (void*)(pXData);
   // Specify the custom drawing callback
@@ -544,9 +530,8 @@ bool gslc_ElemXListboxDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw
 
       // Draw the aligned text string (by default it is GSLC_ALIGN_MID_LEFT)
       gslc_DrawTxtBase(pGui, acStr, rItemRect, pElem->pTxtFont, eTxtFlags,
-        pElem->eTxtAlign, colTxt, colFill, pListbox->nItemMarginW, pListbox->nItemMarginH);
+        pElem->eTxtAlign, colTxt, colFill, pElem->nTxtMarginX, pElem->nTxtMarginY);
     }
-
 
   }
 

--- a/src/elem/XListbox.h
+++ b/src/elem/XListbox.h
@@ -82,8 +82,6 @@ typedef struct {
   int16_t         nItemH;         ///< Height of listbox item
   int8_t          nItemGap;       ///< Gap between listbox items
   gslc_tsColor    colGap;         ///< Gap color
-  int8_t          nItemMarginW;   ///< Text margin inside listbox items (X offset)
-  int8_t          nItemMarginH;   ///< Text margin inside listbox items (Y offset)
   bool            bItemAutoSizeW; ///< Enable auto-sizing of items (in width)
   bool            bItemAutoSizeH; ///< Enable auto-sizing of items (in height)
 
@@ -144,19 +142,6 @@ void gslc_ElemXListboxSetSize(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t
 /// \return none
 ///
 void gslc_ElemXListboxSetMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH);
-
-///
-/// Configure the text margin inside the listbox items
-/// - Defines the region bewteen the listbox item and the text labels
-///
-/// \param[in]  pGui:          Pointer to GUI
-/// \param[in]  pElemRef:      Ptr to Element Reference to update
-/// \param[in]  nMarginW:      Set the margin (horizontal) inside the item (0 for none)
-/// \param[in]  nMarginH:      Set the margin (horizontal) inside the item (0 for none)
-///
-/// \return none
-///
-void gslc_ElemXListboxItemsSetTxtMargin(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nMarginW, int8_t nMarginH);
 
 ///
 /// Configure the size of the listbox items

--- a/src/elem/XProgress.h
+++ b/src/elem/XProgress.h
@@ -223,6 +223,7 @@ bool gslc_ElemXProgressDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \
       NULL,                                                       \
@@ -265,6 +266,7 @@ bool gslc_ElemXProgressDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \

--- a/src/elem/XRadial.h
+++ b/src/elem/XRadial.h
@@ -264,6 +264,7 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \
       NULL,                                                       \
@@ -312,6 +313,7 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \

--- a/src/elem/XRamp.h
+++ b/src/elem/XRamp.h
@@ -203,6 +203,7 @@ bool gslc_ElemXRampDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRed
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \
       NULL,                                                       \
@@ -242,6 +243,7 @@ bool gslc_ElemXRampDrawHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_teRed
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       (void*)(&sGauge##nElemId),                                  \

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -251,17 +251,18 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
   // Draw text string if defined
   if (pElem->pStrBuf) {
     gslc_tsColor  colTxt    = (bGlowNow)? pElem->colElemTextGlow : pElem->colElemText;
-    int16_t       nMargin   = pElem->nTxtMargin;
+    int8_t        nMarginX  = pElem->nTxtMarginX;
+    int8_t        nMarginY  = pElem->nTxtMarginY;
 
     // Erase old string content using "background" color
     if (strlen(pXRingGauge->acStrLast) != 0) {
       gslc_DrawTxtBase(pGui, pXRingGauge->acStrLast, pElem->rElem, pElem->pTxtFont, pElem->eTxtFlags,
-        pElem->eTxtAlign, colBg, GSLC_COL_BLACK, nMargin, nMargin);
+        pElem->eTxtAlign, colBg, GSLC_COL_BLACK, nMarginX, nMarginY);
     }
 
     // Draw new string content
     gslc_DrawTxtBase(pGui, pElem->pStrBuf, pElem->rElem, pElem->pTxtFont, pElem->eTxtFlags,
-      pElem->eTxtAlign, colTxt, GSLC_COL_BLACK, nMargin, nMargin);
+      pElem->eTxtAlign, colTxt, GSLC_COL_BLACK, nMarginX, nMarginY);
 
     // Save a copy of the new string content so we can support future erase
     strncpy(pXRingGauge->acStrLast, pElem->pStrBuf, XRING_STR_MAX);

--- a/src/elem/XSlider.h
+++ b/src/elem/XSlider.h
@@ -246,6 +246,7 @@ bool gslc_ElemXSliderTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
       0,                                                          \
+      0,                                                          \
       NULL,                                                       \
       (void*)(&sSlider##nElemId),                                 \
       NULL,                                                       \
@@ -291,6 +292,7 @@ bool gslc_ElemXSliderTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16
       GSLC_COL_WHITE,                                             \
       GSLC_COL_WHITE,                                             \
       GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
       0,                                                          \
       NULL,                                                       \
       (void*)(&sSlider##nElemId),                                 \

--- a/src/elem/XTemplate.c
+++ b/src/elem/XTemplate.c
@@ -214,10 +214,11 @@ bool gslc_ElemXTemplateDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedra
   // Draw text string if defined
   if (pElem->pStrBuf) {
     gslc_tsColor  colTxt    = (bGlowNow)? pElem->colElemTextGlow : pElem->colElemText;
-    int16_t       nMargin   = pElem->nTxtMargin;
+    int8_t        nMarginX  = pElem->nTxtMarginX;
+    int8_t        nMarginY  = pElem->nTxtMarginY;
 
     gslc_DrawTxtBase(pGui, pElem->pStrBuf, pElem->rElem, pElem->pTxtFont, pElem->eTxtFlags,
-      pElem->eTxtAlign, colTxt, colBg, nMargin, nMargin);
+      pElem->eTxtAlign, colTxt, colBg, nMarginX, nMarginY);
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
This enhancement supports the ability to have a different text margin horizontally and vertically. Previously, the `ElemSetTxtMargin()` API accepted a single nMargin parameter, which was used to provide inner spacing offsets for both horizontal and vertical directions. The `ElemSetTxtMarginXY()` enables a different offset to be provided for each direction.

- Adds `ElemSetTxtMarginXY()` with parameters for X & Y margins
- Replaces `tsElem.nTxtMargin` with `nTxtMarginX`, `nTxtMarginY`

**Migration Notes**
- Core element structure change implies an update to FLASH `ElemCreate*_P()` initializers
- If users have created their own custom elements that include a FLASH-based version (ie. `ElemCreate*_P()`), then a minor update to the `sElem##nElemId` initializer will be needed. This change is to account for the splitting of the Element nTxtMargin field into nTxtMarginX and nTxtMarginY.
- For these custom FLASH-based elements, the following shows the necessary change, which amounts to inserting an extra `0,` in the initializer list after the `GSLC_ALIGN_*` field:
![image](https://user-images.githubusercontent.com/8510097/62007877-81147600-b107-11e9-953e-a378e9fc9e44.png)
