### PR TITLE
Add access to native display/touch driver APIs

### DIFF
--- a/configs/ard-shld-generic1_35_touch1.h
+++ b/configs/ard-shld-generic1_35_touch1.h
@@ -1,0 +1,377 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration #???) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: MCUFRIEND
+//   - Touch:   Simple Analog (Resistive)
+//   - Wiring:  Shield (pinout defined by mcufriend_kbv library)
+//
+//   - Example display:
+//     - 3.5" TFT LCD Shield (Generic 480x320 ILI9486)
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a shield, no additional
+//   wiring is required to support the GUI operation
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX           // Adafruit-GFX library
+  #define DRV_DISP_ADAGFX_MCUFRIEND // prenticedavid/MCUFRIEND_kbv
+  #define DRV_TOUCH_ADA_SIMPLE      // Adafruit_TouchScreen touch driver
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     10     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+  // -----------------------------------------------------------------------------
+  // SECTION 4: Touch Handling
+  // - Documentation for configuring touch support can be found at:
+  //   https://github.com/ImpulseAdventure/GUIslice/wiki/Configure-Touch-Support
+  // -----------------------------------------------------------------------------
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4A: Update your pin connections here
+  // - These values should come from the diag_ard_touch_calib sketch output
+  // - Please update the values to the right of ADATOUCH_PIN_* accordingly
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Set the pinout for the 4-wire resistive touchscreen
+  // - These settings describe the wiring between the MCU and the
+  //   resistive touch overlay.
+  // - MCUFRIEND shields vary widely in the pin connectivity, so
+  //   it is important to ensure that the connections are correct.
+  //
+  // - The diag_ard_touch_detect sketch can be used to detect the
+  //   pin connections (on Arduino devices) for your specific shield.
+  //
+  // - A number of example pin connections for common MCUFRIEND
+  //   shields have been provided in SECTION 4C, each marked with their
+  //   corresponding MCUFRIEND ID.
+  // - Many MCUFRIEND displays support the reading of an internal ID.
+  // - When the diagnostic sketches are run on MCUFRIEND displays,
+  //   the MCUFRIEND ID is reported.
+
+  // - Definition of the pinout configuration options:
+  //     ADATOUCH_PIN_YP      // "Y+": Must be an analog pin
+  //     ADATOUCH_PIN_XM      // "X-": Must be an analog pin
+  //     ADATOUCH_PIN_YM      // "Y-": Can be a digital pin
+  //     ADATOUCH_PIN_XP      // "X+": Can be a digital pin
+
+  // Pin connections from diag_ard_touch_detect:
+
+  // - mcufriend 3.5" red
+  // - DRV_TOUCH_ADA_SIMPLE [320x480]: (MCUFRIEND ID=0x1581) (XP=6,XM=56,YP=55,YM=7) [TESTED]
+  #define ADATOUCH_PIN_YP   A1
+  #define ADATOUCH_PIN_XM   A2
+  #define ADATOUCH_PIN_YM   7
+  #define ADATOUCH_PIN_XP   6
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4B: Update your calibration settings here
+  // - These values should come from the diag_ard_touch_calib sketch output
+  // - Please update the values to the right of ADATOUCH_X/Y_MIN/MAX_* accordingly
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Calibration settings from diag_ard_touch_calib:
+  #define ADATOUCH_X_MIN    905
+  #define ADATOUCH_X_MAX    164
+  #define ADATOUCH_Y_MIN    954
+  #define ADATOUCH_Y_MAX    152
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
+
+  // Touch overlay resistance value
+  // - In most cases, this value can be left as-is
+  #define ADATOUCH_RX       300   // "rxplate"
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4C: Example pin configurations
+  // - This section lists a number of configurations detected from
+  //   various displays, along with the MCUFRIEND ID reported by the
+  //   display itself. If your particular display reports an ID that
+  //   matches one of the configurations below, you may be able to
+  //   copy the corresponding values to SECTION 4A/4B.
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // MCUFRIEND_ID == 0x1520:
+  //#define ADATOUCH_PIN_YP   A1
+  //#define ADATOUCH_PIN_XM   A2
+  //#define ADATOUCH_PIN_YM   7
+  //#define ADATOUCH_PIN_XP   6
+  //#define ADATOUCH_X_MIN    893
+  //#define ADATOUCH_X_MAX    104
+  //#define ADATOUCH_Y_MIN    99
+  //#define ADATOUCH_Y_MAX    892
+
+  // MCUFRIEND_ID == 0x1581:
+  // - mcufriend 3.5" red
+  // - DRV_TOUCH_ADA_SIMPLE [320x480]: (MCUFRIEND ID=0x1581) (XP=6,XM=56,YP=55,YM=7) [TESTED]
+  //#define ADATOUCH_PIN_YP   A1
+  //#define ADATOUCH_PIN_XM   A2
+  //#define ADATOUCH_PIN_YM   7
+  //#define ADATOUCH_PIN_XP   6
+  //#define ADATOUCH_X_MIN    905
+  //#define ADATOUCH_X_MAX    164
+  //#define ADATOUCH_Y_MIN    954
+  //#define ADATOUCH_Y_MAX    152
+
+  // MCUFRIEND_ID == 0x2053:
+  //#define ADATOUCH_PIN_YP   A2
+  //#define ADATOUCH_PIN_XM   A1
+  //#define ADATOUCH_PIN_YM   6
+  //#define ADATOUCH_PIN_XP   7
+  //#define ADATOUCH_X_MIN    138
+  //#define ADATOUCH_X_MAX    891
+  //#define ADATOUCH_Y_MIN    132
+  //#define ADATOUCH_Y_MAX    909
+
+  // MCUFRIEND_ID == 0x7783:
+  // - DRV_TOUCH_ADA_SIMPLE [240x320]: (MCUFRIEND ID=0x7783) (XP=7,XM=A1,YP=A2,YM=6) [TESTED]
+  //#define ADATOUCH_PIN_YP   A2
+  //#define ADATOUCH_PIN_XM   A1
+  //#define ADATOUCH_PIN_YM   6
+  //#define ADATOUCH_PIN_XP   7
+  //#define ADATOUCH_X_MIN    181
+  //#define ADATOUCH_X_MAX    937
+  //#define ADATOUCH_Y_MIN    934
+  //#define ADATOUCH_Y_MAX    219
+
+  // MCUFRIEND_ID == 0x7789:
+  //#define ADATOUCH_PIN_YP   A2
+  //#define ADATOUCH_PIN_XM   A1
+  //#define ADATOUCH_PIN_YM   7
+  //#define ADATOUCH_PIN_XP   6
+  //#define ADATOUCH_X_MIN    885
+  //#define ADATOUCH_X_MAX    148
+  //#define ADATOUCH_Y_MIN    111
+  //#define ADATOUCH_Y_MAX    902
+
+  // MCUFRIEND_ID == 0x8031:
+  //#define ADATOUCH_PIN_YP   A1
+  //#define ADATOUCH_PIN_XM   A2
+  //#define ADATOUCH_PIN_YM   7
+  //#define ADATOUCH_PIN_XP   6
+  //#define ADATOUCH_X_MIN    889
+  //#define ADATOUCH_X_MAX    151
+  //#define ADATOUCH_Y_MIN    121
+  //#define ADATOUCH_Y_MAX    886
+
+  // MCUFRIEND_ID == 0x9320:
+  //#define ADATOUCH_PIN_YP   A3
+  //#define ADATOUCH_PIN_XM   A2
+  //#define ADATOUCH_PIN_YM   9
+  //#define ADATOUCH_PIN_XP   8
+  //#define ADATOUCH_X_MIN    897
+  //#define ADATOUCH_X_MAX    122
+  //#define ADATOUCH_Y_MIN    944
+  //#define ADATOUCH_Y_MAX    141
+
+  // MCUFRIEND_ID == 0x9327:
+  //#define ADATOUCH_PIN_YP   A2
+  //#define ADATOUCH_PIN_XM   A1
+  //#define ADATOUCH_PIN_YM   6
+  //#define ADATOUCH_PIN_XP   7
+  //#define ADATOUCH_X_MIN    126
+  //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    106
+  //#define ADATOUCH_Y_MAX    966
+
+  // MCUFRIEND_ID == 0x9340:
+  // - DRV_TOUCH_ADA_SIMPLE [240x320]: (MCUFRIEND ID=0x9340) (XP=6,XM=A2,YP=A1,YM=7)  [TESTED]
+  //#define ADATOUCH_PIN_YP   A1
+  //#define ADATOUCH_PIN_XM   A2
+  //#define ADATOUCH_PIN_YM   7 
+  //#define ADATOUCH_PIN_XP   6 
+  //#define ADATOUCH_X_MIN    145
+  //#define ADATOUCH_X_MAX    905
+  //#define ADATOUCH_Y_MIN    937
+  //#define ADATOUCH_Y_MAX    165
+
+  // MCUFRIEND_ID == 0x9341:
+  // - DRV_TOUCH_ADA_SIMPLE [240x320]: (MCUFRIEND ID=0x9341) (XP=6,XM=A2,YP=A1,YM=7)  [TESTED]
+  //#define ADATOUCH_PIN_YP   A1
+  //#define ADATOUCH_PIN_XM   A2
+  //#define ADATOUCH_PIN_YM   7
+  //#define ADATOUCH_PIN_XP   6
+  //#define ADATOUCH_X_MIN    905
+  //#define ADATOUCH_X_MAX    187
+  //#define ADATOUCH_Y_MIN    950
+  //#define ADATOUCH_Y_MAX    202
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4D: Additional touch configuration
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Define pressure threshold for detecting a touch
+  #define ADATOUCH_PRESS_MIN  10
+  #define ADATOUCH_PRESS_MAX  4000
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               2   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XGAUGE_RADIAL  0   // XGauge control with radial support
+  #define GSLC_FEATURE_XGAUGE_RAMP    0   // XGauge control with ramp support
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 0=disable, 1=SD lib (HW SPI), 2=SdFat lib (SW SPI)
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    2
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default:pink)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/configs/esp-shld-adafruit_24_feather_touch-espi.h
+++ b/configs/esp-shld-adafruit_24_feather_touch-espi.h
@@ -1,0 +1,246 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration #???) for:
+//   - CPU:     ESP8266 / ESP32
+//   - Display: ILI9341 (via TFT_eSPI)
+//   - Touch:   STMPE610 (Resistive)
+//   - Wiring:  Shield
+//
+//   - Example display:
+//     - Adafruit TFT FeatherWing - 2.4" 320x240 Touchscreen for All Feathers
+//   - Example CPUs:
+//     - Adafruit HUZZAH      (ESP8266)
+//     - Adafruit HUZZAH32    (ESP-32)
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a shield, no additional
+//   wiring is required to support the GUI operation
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_TFT_ESPI         // bodmer/TFT_eSPI
+  #define DRV_DISP_ADAGFX_ILI9341   // Adafruit ILI9341
+  #define DRV_TOUCH_ADA_STMPE610    // Adafruit STMPE610 touch driver
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For TFT_eSPI, the display wiring is defined by TFT_eSPI's User_Setup.h
+
+
+  // SD Card
+  // - Decode based on platform
+#ifdef ESP8266
+  #define ADAGFX_PIN_SDCS     2     // SD card chip select (if GSLC_SD_EN=1)
+#elif ESP32
+  #define ADAGFX_PIN_SDCS     14    // SD card chip select (if GSLC_SD_EN=1)
+#endif
+
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+  // -----------------------------------------------------------------------------
+  // SECTION 4: Touch Handling
+  // - Documentation for configuring touch support can be found at:
+  //   https://github.com/ImpulseAdventure/GUIslice/wiki/Configure-Touch-Support
+  // -----------------------------------------------------------------------------
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4A: Update your pin connections here
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Select touch device wiring method by setting one of the following to 1, others to 0
+  #define ADATOUCH_SPI_HW 1  // Touch controller via hardware SPI (uses ADATOUCH_PIN_CS)
+
+  // - Decode based on platform
+#ifdef ESP8266
+  #define ADATOUCH_PIN_CS     16
+#elif ESP32
+  #define ADATOUCH_PIN_CS     32
+#endif
+
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4B: Update your calibration settings here
+  // - These values should come from the diag_ard_touch_calib sketch output
+  // - Please update the values to the right of ADATOUCH_X/Y_MIN/MAX_* accordingly
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Calibration settings from diag_ard_touch_calib:
+  #define ADATOUCH_X_MIN    3824
+  #define ADATOUCH_X_MAX    235
+  #define ADATOUCH_Y_MIN    191
+  #define ADATOUCH_Y_MAX    3725
+  // Certain touch controllers may swap X & Y coords
+  #define ADATOUCH_REMAP_YX 0
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4D: Additional touch configuration
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XGAUGE_RADIAL  0   // XGauge control with radial support
+  #define GSLC_FEATURE_XGAUGE_RAMP    0   // XGauge control with ramp support
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default:pink)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM 0
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -103,6 +103,15 @@ const char* gslc_GetNameTouch(gslc_tsGui* pGui)
   return gslc_DrvGetNameTouch(pGui);
 }
 
+void* gslc_GetDriverDisp(gslc_tsGui* pGui)
+{
+  return gslc_DrvGetDriverDisp(pGui);
+}
+
+void* gslc_GetDriverTouch(gslc_tsGui* pGui)
+{
+  return gslc_DrvGetDriverTouch(pGui);
+}
 
 
 bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxPage,gslc_tsFont* asFont,uint8_t nMaxFont)

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -838,6 +838,34 @@ const char* gslc_GetNameDisp(gslc_tsGui* pGui);
 const char* gslc_GetNameTouch(gslc_tsGui* pGui);
 
 ///
+/// Get the native display driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the display driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_GetDriverDisp(gslc_tsGui* pGui);
+
+///
+/// Get the native touch driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the touch driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_GetDriverTouch(gslc_tsGui* pGui);
+
+///
 /// Initialize the GUIslice library
 /// - Configures the primary screen surface(s)
 /// - Initializes font support

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -303,15 +303,18 @@ extern "C" {
   #else // No interface flag set
     #error "DRV_TOUCH_ADA_STMPE610 but no ADATOUCH_I2C_* or ADATOUCH_SPI_* set in config"
   #endif
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_ADA_FT6206)
   const char* m_acDrvTouch = "FT6206(I2C)";
   // Always use I2C
   Adafruit_FT6206 m_touch = Adafruit_FT6206();
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
   const char* m_acDrvTouch = "SIMPLE(Analog)";
   TouchScreen m_touch = TouchScreen(ADATOUCH_PIN_XP, ADATOUCH_PIN_YP, ADATOUCH_PIN_XM, ADATOUCH_PIN_YM, ADATOUCH_RX);
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_ADA_RA8875)
   const char* m_acDrvTouch = "RA8875(internal)";
@@ -322,11 +325,13 @@ extern "C" {
   XPT2046_DEFINE_DPICLASS;
   // XPT2046 driver from Arduino_STM32 by Serasidis (<XPT2046_touch.h>)
   XPT2046_touch m_touch(XPT2046_CS, XPT2046_spi); // Chip Select pin, SPI instance
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_XPT2046_PS)
   const char* m_acDrvTouch = "XPT2046_PS(SPI-HW)";
   // Use SPI, no IRQs
   XPT2046_Touchscreen m_touch(XPT2046_CS); // Chip Select pin
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_URTOUCH)
   #if defined(DRV_TOUCH_URTOUCH_OLD)
@@ -336,6 +341,7 @@ extern "C" {
     const char* m_acDrvTouch = "URTOUCH";
     URTouch m_touch(DRV_TOUCH_URTOUCH_INIT);
   #endif
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_HANDLER)
   const char* m_acDrvTouch = "Handler";
@@ -498,6 +504,10 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
   return true;
 }
 
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui)
+{
+	return (void*)(&m_disp);
+}
 
 void gslc_DrvDestruct(gslc_tsGui* pGui)
 {
@@ -1447,6 +1457,17 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
   // TODO
   // Perform any driver-specific touchscreen init here
   return true;
+}
+
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui)
+{
+  // As the touch driver instance is optional, we need to check for
+  // its existence before returning a pointer to it.
+  #if defined(DRV_TOUCH_INSTANCE)
+    return (void*)(&m_touch);
+  #else
+    return NULL;
+  #endif
 }
 
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -194,6 +194,34 @@ const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui);
 ///
 const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui);
 
+///
+/// Get the native display driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the display driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui);
+
+///
+/// Get the native touch driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the touch driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui);
+
 // -----------------------------------------------------------------------
 // Image/surface handling Functions
 // -----------------------------------------------------------------------

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -52,7 +52,6 @@
 extern "C" {
 #endif // __cplusplus
 
-
   // Define driver naming
   const char* m_acDrvDisp = "M5STACK";
   const char* m_acDrvTouch = "M5STACK(NONE)";
@@ -105,6 +104,10 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
   return true;
 }
 
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui)
+{
+  return (void*)(&m_disp);
+}
 
 void gslc_DrvDestruct(gslc_tsGui* pGui)
 {
@@ -870,6 +873,16 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
   return true;
 }
 
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui)
+{
+  // As the touch driver instance is optional, we need to check for
+  // its existence before returning a pointer to it.
+  #if defined(DRV_TOUCH_INSTANCE)
+    return (void*)(&m_touch);
+  #else
+    return NULL;
+  #endif
+}
 
 bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal)
 {

--- a/src/GUIslice_drv_m5stack.h
+++ b/src/GUIslice_drv_m5stack.h
@@ -168,6 +168,34 @@ const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui);
 ///
 const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui);
 
+///
+/// Get the native display driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the display driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui);
+
+///
+/// Get the native touch driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the touch driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui);
+
 // -----------------------------------------------------------------------
 // Image/surface handling Functions
 // -----------------------------------------------------------------------

--- a/src/GUIslice_drv_sdl.c
+++ b/src/GUIslice_drv_sdl.c
@@ -239,6 +239,10 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
   return true;
 }
 
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui)
+{
+  return (pGui->pvDriver);
+}
 
 void gslc_DrvDestruct(gslc_tsGui* pGui)
 {
@@ -267,7 +271,6 @@ const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui)
 {
   return m_acDrvTouch;
 }
-
 
 // -----------------------------------------------------------------------
 // Image/surface handling Functions
@@ -892,6 +895,10 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev)
   return true;
 }
 
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui)
+{
+  return NULL;
+}
 
 
 bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal)

--- a/src/GUIslice_drv_sdl.h
+++ b/src/GUIslice_drv_sdl.h
@@ -181,6 +181,35 @@ const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui);
 ///
 const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui);
 
+///
+/// Get the native display driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the display driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui);
+
+///
+/// Get the native touch driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the touch driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui);
+
+
 // -----------------------------------------------------------------------
 // Image/surface handling Functions
 // -----------------------------------------------------------------------

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -115,15 +115,18 @@ TFT_eSPI m_disp = TFT_eSPI();
   #else // No interface flag set
     #error "DRV_TOUCH_ADA_STMPE610 but no ADATOUCH_I2C_* or ADATOUCH_SPI_* set in config"
   #endif
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_ADA_FT6206)
   const char* m_acDrvTouch = "FT6206(I2C)";
   // Always use I2C
   Adafruit_FT6206 m_touch = Adafruit_FT6206();
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
   const char* m_acDrvTouch = "SIMPLE(Analog)";
   TouchScreen m_touch = TouchScreen(ADATOUCH_PIN_XP, ADATOUCH_PIN_YP, ADATOUCH_PIN_XM, ADATOUCH_PIN_YM, ADATOUCH_RX);
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_XPT2046_STM)
   const char* m_acDrvTouch = "XPT2046_STM(SPI-HW)";
@@ -131,11 +134,13 @@ TFT_eSPI m_disp = TFT_eSPI();
   XPT2046_DEFINE_DPICLASS;
   // XPT2046 driver from Arduino_STM32 by Serasidis (<XPT2046_touch.h>)
   XPT2046_touch m_touch(XPT2046_CS, XPT2046_spi); // Chip Select pin, SPI instance
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_XPT2046_PS)
   const char* m_acDrvTouch = "XPT2046_PS(SPI-HW)";
   // Use SPI, no IRQs
   XPT2046_Touchscreen m_touch(XPT2046_CS); // Chip Select pin
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_TFT_ESPI)
   const char* m_acDrvTouch = "TFT_eSPI(XPT2046)";
@@ -202,6 +207,10 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
   return true;
 }
 
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui)
+{
+  return (void*)(&m_disp);
+}
 
 void gslc_DrvDestruct(gslc_tsGui* pGui)
 {
@@ -1065,6 +1074,18 @@ void gslc_DrvDrawBkgnd(gslc_tsGui* pGui)
   }
   // ----- REFERENCE CODE end
 #endif // DRV_TOUCH_TFT_ESPI_FILTER
+
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui)
+{
+  // As the touch driver instance is optional, we need to check for
+  // its existence before returning a pointer to it.
+  #if defined(DRV_TOUCH_INSTANCE)
+    return (void*)(&m_touch);
+  #else
+    return NULL;
+  #endif
+}
+
 
 bool gslc_DrvInitTouch(gslc_tsGui* pGui, const char* acDev) {
   if (pGui == NULL) {

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -190,6 +190,34 @@ const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui);
 ///
 const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui);
 
+///
+/// Get the native display driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the display driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui);
+
+///
+/// Get the native touch driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the touch driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui);
+
 // -----------------------------------------------------------------------
 // Image/surface handling Functions
 // -----------------------------------------------------------------------

--- a/src/GUIslice_drv_utft.cpp
+++ b/src/GUIslice_drv_utft.cpp
@@ -74,8 +74,6 @@ extern "C" {
 // ------------------------------------------------------------------------
 #endif // DRV_DISP_*
 
-
-
 // ------------------------------------------------------------------------
 #if defined(DRV_TOUCH_URTOUCH)
   #if defined(DRV_TOUCH_URTOUCH_OLD)
@@ -85,6 +83,7 @@ extern "C" {
     const char* m_acDrvTouch = "URTOUCH";
     URTouch m_touch(DRV_TOUCH_URTOUCH_INIT);
   #endif
+  #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_INPUT)
   const char* m_acDrvTouch = "INPUT";
@@ -152,6 +151,10 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
   return true;
 }
 
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui)
+{
+  return (void*)(&m_disp);
+}
 
 void gslc_DrvDestruct(gslc_tsGui* pGui)
 {
@@ -923,6 +926,16 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
   return true;
 }
 
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui)
+{
+  // As the touch driver instance is optional, we need to check for
+  // its existence before returning a pointer to it.
+  #if defined(DRV_TOUCH_INSTANCE)
+    return (void*)(&m_touch);
+  #else
+    return NULL;
+  #endif
+}
 
 bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPress,gslc_teInputRawEvent* peInputEvent,int16_t* pnInputVal)
 {

--- a/src/GUIslice_drv_utft.h
+++ b/src/GUIslice_drv_utft.h
@@ -173,6 +173,34 @@ const char* gslc_DrvGetNameDisp(gslc_tsGui* pGui);
 ///
 const char* gslc_DrvGetNameTouch(gslc_tsGui* pGui);
 
+///
+/// Get the native display driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the display driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverDisp(gslc_tsGui* pGui);
+
+///
+/// Get the native touch driver instance
+/// - This can be useful to access special commands
+///   available in the selected driver.
+///
+/// \param[in]  pGui:      Pointer to GUI
+///
+/// \return Void pointer to the touch driver instance.
+///         This pointer should be typecast to the particular
+///         driver being used. If no driver was created then
+///         this function will return NULL.
+///
+void* gslc_DrvGetDriverTouch(gslc_tsGui* pGui);
+
 // -----------------------------------------------------------------------
 // Image/surface handling Functions
 // -----------------------------------------------------------------------

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.36"
+#define GUISLICE_VER "0.12.2.37"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.35"
+#define GUISLICE_VER "0.12.2.36"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XRingGauge.h
+++ b/src/elem/XRingGauge.h
@@ -43,7 +43,20 @@ extern "C" {
 
 // ============================================================================
 // Extended Element: XRingGauge
-// - NOTE: This element type is new and the APIs are subject to change
+// - Creates display element similar to a donut-chart.
+// - The element has an outer and inner radius to create a ring appearance.
+// - The ring has an angular range defined by SetAngleRange, which means that
+//   the ring can be configured to cover a full circle or just a portion of
+//   a circle.
+// - SetAngleRange defines the starting angle and direction of fill.
+// - When drawing the ring within the angular range, it is composed of
+//   an active region (the angular region from the start to the current
+//   position value) and an inactive region (from the current value to the
+//   end of the angular range). The inactive region can be hidden (by
+//   setting it to the background color).
+// - A text value can be drawn in the center of the ring, typically to
+//   show the current value. The color defined by SetColorBackground() is
+//   used when redrawing the text.
 // ============================================================================
 
 // Define unique identifier for extended element type
@@ -89,7 +102,8 @@ typedef struct {
 /// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
 /// \param[in]  nPage:       Page ID to attach element to
 /// \param[in]  pXData:      Ptr to extended element data structure
-/// \param[in]  rElem:       Rectangle coordinates defining element size
+/// \param[in]  rElem:       The square box that bounds the ring element. If a rectangular region is
+///                          provided, then the ring control will be centered in the long axis.
 /// \param[in]  pStrBuf:     String buffer to use for gauge inner text
 /// \param[in]  nStrBufMax:  Maximum length of string buffer (pStrBuf)
 /// \param[in]  nFontId:     Font ID to use for text display
@@ -98,7 +112,6 @@ typedef struct {
 ///
 gslc_tsElemRef* gslc_ElemXRingGaugeCreate(gslc_tsGui* pGui, int16_t nElemId, int16_t nPage,
   gslc_tsXRingGauge* pXData, gslc_tsRect rElem, char* pStrBuf, uint8_t nStrBufMax, int16_t nFontId);
-
 
 ///
 /// Draw the template element on the screen
@@ -114,24 +127,85 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 
 
 ///
-/// Set an XRingGauge element's current position
+/// Set an Ring Gauge current indicator value
 ///
-/// \param[in]  pGui:        Pointer to GUI
+/// Updates the current value of the ring gauge. The active region will be drawn up
+/// to the position defined by nVal within the value range defined by SetValRange(nMin,nMax).
+/// A SetVal() close to nMin will cause a very small active region to be drawn and a large
+/// remainder drawn in the inactive color, whereas a SetVal() close to nMax will cause a
+/// more complete active region to be drawn.When SetVal() equals nMax, the entire angular
+/// range will be drawn in the active color (and no inactive region).
+///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElemRef:    Pointer to Element reference
 /// \param[in]  nPos:        New position value
 ///
 /// \return none
 ///
+// TODO: Rename to ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos)
 void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos);
 
 /// \todo
+
+///
+/// Defines the angular range of the gauge, including both the active
+/// and inactive regions.
+///
+/// - nStart64 defines the angle at the beginning of the active region.
+/// - The current position marks the end of the active region and the
+///   beginning of the inactive region.
+/// - nRange64 defines the angular range from the start of the active
+///   region to the end of the inactive region. In most cases, a
+///   range of 360 degrees is used (nRange64 = 360*64).
+/// - All angles are measured in units of degrees / 64.
+/// - Angles are measured with 0 at the top, 90 * 64 towards the right,
+///   180 * 64 towards the bottom, 270 * 64 towards the left, etc.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nStart64:    TODO
+/// \param[in]  nRange64:    TODO
+/// \param[in]  bClockwise:  Defines the direction in which the active
+///                          region grows (true for clockwise)
+///
+/// \return none
+///
+// TODO: Add gslc_ElemXRingGaugeSetAngleRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nStart64, int16_t nRange64, bool bClockwise);
+
+
+/// Defines the range of values that may be passed into SetVal(), used to scale the input to SetVal(). Default is 0..100.
+// FIXME: Rename to gslc_ElemXRingGaugeSetValRange()?
 void gslc_ElemXRingGaugeSetRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax);
+
+
+/// Defines the thickness of the ring arcs. More specifically, it defines the reduction in radius from the outer radius to the inner radius in pixels.
+/// Default thickness is 10 pixels
 void gslc_ElemXRingGaugeSetThickness(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nThickness);
+
+/// Sets the quality of the ring drawing by defining the number of segments that are used when
+/// rendering a 360 degree gauge.The larger the number, the more segments are used and the smoother the curve.
+/// A larger ring gauge may need a higher quality number to maintain a smoothed curve appearance.
 void gslc_ElemXRingGaugeSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nSegments);
+
+/// Defines the color of the inactive region to be a flat (constant) color.
+/// The inactive color is often set to be the same as the background but it can
+/// be set to a different color to indicate the remainder of the value range that is yet to be filled.
+// FIXME: Rename to gslc_ElemXRingGaugeSetColorInactive()? API doc said SetColorInactiveFlat()
 void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive);
+
+/// Defines the color of the active region to be a flat (constant) color.
+// TODO: Rename to ElemXRingGaugeSetColorActiveFlat()?
 void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive);
+
+/// Defines the color of the active region to be a gradient using two color stops. The
+/// active region will be filled according to the proportion between nMin and nMax.
+/// The gradient is defined by a linear RGB blend between the two color stops(colStart and colEnd)
+// TODO: Rename to gslc_ElemXRingGaugeSetColorActiveGradient()?
 void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd);
+
+/// Defines the color of the background behind the gauge.
+/// This color is used when redrawing / updating the inner text field via SetTxtStr().
+// TODO: Add gslc_ElemXRingGaugeSetColorBackground(colBkgnd)
 
 // ============================================================================
 

--- a/src/elem/XRingGauge.h
+++ b/src/elem/XRingGauge.h
@@ -142,10 +142,8 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 ///
 /// \return none
 ///
-// TODO: Rename to ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos)
+// TODO: Consider rename to: ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos)
 void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos);
-
-/// \todo
 
 ///
 /// Defines the angular range of the gauge, including both the active
@@ -173,38 +171,93 @@ void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t
 // TODO: Add gslc_ElemXRingGaugeSetAngleRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nStart64, int16_t nRange64, bool bClockwise);
 
 
-/// Defines the range of values that may be passed into SetVal(), used to scale the input to SetVal(). Default is 0..100.
-// FIXME: Rename to gslc_ElemXRingGaugeSetValRange()?
+/// Defines the range of values that may be passed into SetVal(), used to
+/// scale the input to SetVal().
+/// - Default is 0..100.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nPosMin:     Minimum value
+/// \param[in]  nPosMax:     Maximum value
+///
+/// \return none
+///
+// TODO: Consider rename to gslc_ElemXRingGaugeSetValRange()
 void gslc_ElemXRingGaugeSetRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax);
 
 
-/// Defines the thickness of the ring arcs. More specifically, it defines the reduction in radius from the outer radius to the inner radius in pixels.
-/// Default thickness is 10 pixels
+/// Defines the thickness of the ring arcs. More specifically, it defines the reduction
+/// in radius from the outer radius to the inner radius in pixels.
+/// - Default thickness is 10 pixels
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nThickness:  Thickness of ring
+///
+/// \return none
+///
 void gslc_ElemXRingGaugeSetThickness(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int8_t nThickness);
 
 /// Sets the quality of the ring drawing by defining the number of segments that are used when
 /// rendering a 360 degree gauge.The larger the number, the more segments are used and the smoother the curve.
 /// A larger ring gauge may need a higher quality number to maintain a smoothed curve appearance.
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  nSegments:   Number of arc segments to render a complete circle. The
+///                          higher the value, the smoother the ring.
+///
+/// \return none
+///
 void gslc_ElemXRingGaugeSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, uint16_t nSegments);
 
 /// Defines the color of the inactive region to be a flat (constant) color.
 /// The inactive color is often set to be the same as the background but it can
 /// be set to a different color to indicate the remainder of the value range that is yet to be filled.
-// FIXME: Rename to gslc_ElemXRingGaugeSetColorInactive()? API doc said SetColorInactiveFlat()
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  colInactive: Color of inactive region
+///
+/// \return none
+///
+// TODO: Consider rename to gslc_ElemXRingGaugeSetColorInactive()
 void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive);
 
 /// Defines the color of the active region to be a flat (constant) color.
-// TODO: Rename to ElemXRingGaugeSetColorActiveFlat()?
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  colActive:   Color of active region
+///
+/// \return none
+///
+// TODO: Consider rename to ElemXRingGaugeSetColorActiveFlat()
 void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive);
 
 /// Defines the color of the active region to be a gradient using two color stops. The
 /// active region will be filled according to the proportion between nMin and nMax.
 /// The gradient is defined by a linear RGB blend between the two color stops(colStart and colEnd)
-// TODO: Rename to gslc_ElemXRingGaugeSetColorActiveGradient()?
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  colStart:    Starting color of gradient fill
+/// \param[in]  colEnd:      Ending color of gradient fill
+///
+/// \return none
+///
+// TODO: Consider rename to gslc_ElemXRingGaugeSetColorActiveGradient()
 void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd);
 
 /// Defines the color of the background behind the gauge.
-/// This color is used when redrawing / updating the inner text field via SetTxtStr().
+/// This color is used when redrawing / updating the inner text field via ElemSetTxtStr().
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  colBkgnd:    Color of background
+///
+/// \return none
+///
 // TODO: Add gslc_ElemXRingGaugeSetColorBackground(colBkgnd)
 
 // ============================================================================


### PR DESCRIPTION
This feature adds the ability to access the native touch / display driver API instances.

Specialized APIs in the display or touch driver libraries can now be accessed directly by using the `gslc_GetDriverDisp()` and `gslc_GetDriverTouch()` functions after the `gslc_Init()` call and adding the appropriate include. For example, in the case of the display driver:

![image](https://user-images.githubusercontent.com/8510097/62106004-eaf06500-b258-11e9-8bcb-cb35460d5977.png)

An external touch driver can be accessed similarly with `gslc_GetDriverTouch()`.


