### PR TITLE
XRingGauge enhancements

### DIFF
--- a/examples/arduino/ex09_ard_radial/ex09_ard_radial.ino
+++ b/examples/arduino/ex09_ard_radial/ex09_ard_radial.ino
@@ -142,7 +142,7 @@ bool InitOverlays()
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
 
   pElemRef = gslc_ElemXRadialCreate(&m_gui, E_RADIAL, E_PG_MAIN, &m_sXRadial,
-    (gslc_tsRect) { 210, 140, 80, 80 }, 0, 100, 0, GSLC_COL_YELLOW, false);
+    (gslc_tsRect) { 210, 140, 80, 80 }, 0, 100, 0, GSLC_COL_YELLOW);
   gslc_ElemSetCol(&m_gui, pElemRef, GSLC_COL_WHITE, GSLC_COL_BLACK, GSLC_COL_BLACK);
   gslc_ElemXRadialSetIndicator(&m_gui, pElemRef, GSLC_COL_YELLOW, 30, 3, true);
   gslc_ElemXRadialSetTicks(&m_gui, pElemRef, GSLC_COL_GRAY_LT1, 8, 5);

--- a/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
+++ b/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
@@ -126,13 +126,13 @@ void setup()
   static char m_str10[10] = "";
   pElemRef = gslc_ElemXRingGaugeCreate(&m_gui, E_ELEM_XRING, E_PG_MAIN, &m_sXRingGauge,
     (gslc_tsRect) { 80, 80, 100, 100 }, m_str10, 10, E_FONT_DIAL);
-  gslc_ElemXRingGaugeSetRange(&m_gui, pElemRef, 0, 100);
-  gslc_ElemXRingGaugeSetPos(&m_gui, pElemRef, 60); // Set initial value
+  gslc_ElemXRingGaugeSetValRange(&m_gui, pElemRef, 0, 100);
+  gslc_ElemXRingGaugeSetVal(&m_gui, pElemRef, 60); // Set initial value
   // The following are some additional config options available
   //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 15);
   //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
-  //gslc_ElemXRingGaugeSetRingColorFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
-  //gslc_ElemXRingGaugeSetRingColorGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
+  //gslc_ElemXRingGaugeSetColorActiveFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
+  //gslc_ElemXRingGaugeSetColorActiveGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
   m_pElemXRingGauge = pElemRef; // Save for quick access
 
    // Create slider
@@ -187,7 +187,7 @@ void loop()
   // No filtering enabled -- update the XRingGauge immediately
 
   // Update the XRingGauge position with the slider position
-  gslc_ElemXRingGaugeSetPos(&m_gui, m_pElemXRingGauge, m_nSliderPos);
+  gslc_ElemXRingGaugeSetVal(&m_gui, m_pElemXRingGauge, m_nSliderPos);
 
   // Update the XRingGauge text string with a percentage
   snprintf(acStr, 10, "%d%%", m_nSliderPos);
@@ -213,7 +213,7 @@ void loop()
   // Do we want to update the XRingGauge?
   if (bDoUpdate) {
     // Update the XRingGauge position with the slider position
-    gslc_ElemXRingGaugeSetPos(&m_gui, m_pElemXRingGauge, m_nSliderPos);
+    gslc_ElemXRingGaugeSetVal(&m_gui, m_pElemXRingGauge, m_nSliderPos);
 
     // Update the XRingGauge text string with a percentage
     snprintf(acStr, 10, "%d%%", m_nSliderPos);

--- a/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
+++ b/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
@@ -129,7 +129,11 @@ void setup()
   gslc_ElemXRingGaugeSetValRange(&m_gui, pElemRef, 0, 100);
   gslc_ElemXRingGaugeSetVal(&m_gui, pElemRef, 60); // Set initial value
   // The following are some additional config options available
-  //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 15);
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, 0, 360, true);    // Full circle 
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, -90, 180, true);  // Upper Semi-circle
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, 0, 90, true);     // Top-Right Quarter-circle
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, -135, 270, true); // Three-Quarter circle
+  //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 8);
   //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
   //gslc_ElemXRingGaugeSetColorActiveFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
   //gslc_ElemXRingGaugeSetColorActiveGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);

--- a/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
+++ b/examples/arduino/ex42_ard_ring/ex42_ard_ring.ino
@@ -135,6 +135,7 @@ void setup()
   //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, -135, 270, true); // Three-Quarter circle
   //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 8);
   //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
+  //gslc_ElemXRingGaugeSetColorInactive(&m_gui,pElemRef, GSLC_COL_GRAY_DK3);
   //gslc_ElemXRingGaugeSetColorActiveFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
   //gslc_ElemXRingGaugeSetColorActiveGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
   m_pElemXRingGauge = pElemRef; // Save for quick access

--- a/examples/linux/ex09_lnx_radial.c
+++ b/examples/linux/ex09_lnx_radial.c
@@ -147,7 +147,7 @@ bool InitOverlays()
   gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
 
   pElemRef = gslc_ElemXRadialCreate(&m_gui,E_RADIAL,E_PG_MAIN,&m_sXRadial,
-          (gslc_tsRect){210,140,80,80},0,100,0,GSLC_COL_YELLOW,false);
+          (gslc_tsRect){210,140,80,80},0,100,0,GSLC_COL_YELLOW);
   gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK);
   gslc_ElemXRadialSetIndicator(&m_gui,pElemRef,GSLC_COL_YELLOW,30,3,true);
   gslc_ElemXRadialSetTicks(&m_gui,pElemRef,GSLC_COL_GRAY_LT1,8,5);

--- a/examples/linux/ex42_lnx_ring.c
+++ b/examples/linux/ex42_lnx_ring.c
@@ -138,6 +138,7 @@ bool InitOverlays()
   //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, -135, 270, true); // Three-Quarter circle
   //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 8);
   //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
+  //gslc_ElemXRingGaugeSetColorInactive(&m_gui,pElemRef, GSLC_COL_GRAY_DK3);
   //gslc_ElemXRingGaugeSetColorActiveFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
   //gslc_ElemXRingGaugeSetColorActiveGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
   m_pElemXRingGauge = pElemRef; // Save for quick access

--- a/examples/linux/ex42_lnx_ring.c
+++ b/examples/linux/ex42_lnx_ring.c
@@ -129,13 +129,17 @@ bool InitOverlays()
   static char m_str10[10] = "";
   pElemRef = gslc_ElemXRingGaugeCreate(&m_gui, E_ELEM_XRING, E_PG_MAIN, &m_sXRingGauge,
     (gslc_tsRect) { 80, 80, 100, 100 }, m_str10, 10, E_FONT_DIAL);
-  gslc_ElemXRingGaugeSetRange(&m_gui, pElemRef, 0, 100);
-  gslc_ElemXRingGaugeSetPos(&m_gui, pElemRef, 60); // Set initial value
+  gslc_ElemXRingGaugeSetValRange(&m_gui, pElemRef, 0, 100);
+  gslc_ElemXRingGaugeSetVal(&m_gui, pElemRef, 60); // Set initial value
   // The following are some additional config options available
-  //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 15);
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, 0, 360, true);    // Full circle 
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, -90, 180, true);  // Upper Semi-circle
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, 0, 90, true);     // Top-Right Quarter-circle
+  //gslc_ElemXRingGaugeSetAngleRange(&m_gui, pElemRef, -135, 270, true); // Three-Quarter circle
+  //gslc_ElemXRingGaugeSetThickness(&m_gui,pElemRef, 8);
   //gslc_ElemXRingGaugeSetQuality(&m_gui,pElemRef, 72);
-  //gslc_ElemXRingGaugeSetRingColorFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
-  //gslc_ElemXRingGaugeSetRingColorGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
+  //gslc_ElemXRingGaugeSetColorActiveFlat(&m_gui,pElemRef, GSLC_COL_ORANGE);
+  //gslc_ElemXRingGaugeSetColorActiveGradient(&m_gui, pElemRef, GSLC_COL_BLUE_LT4, GSLC_COL_RED);
   m_pElemXRingGauge = pElemRef; // Save for quick access
 
    // Create slider
@@ -182,7 +186,7 @@ int main( int argc, char* args[] )
   while (!m_bQuit) {
   
     // Update the XRingGauge position with the slider position
-    gslc_ElemXRingGaugeSetPos(&m_gui, m_pElemXRingGauge, m_nSliderPos);
+    gslc_ElemXRingGaugeSetVal(&m_gui, m_pElemXRingGauge, m_nSliderPos);
 
     // Update the XRingGauge text string with a percentage
     snprintf(acStr, 10, "%d%%", m_nSliderPos);

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -1483,6 +1483,59 @@ void gslc_DrawFrameQuad(gslc_tsGui* pGui,gslc_tsPt* psPt,gslc_tsColor nCol);
 ///
 void gslc_DrawFillQuad(gslc_tsGui* pGui,gslc_tsPt* psPt,gslc_tsColor nCol);
 
+///
+/// Draw a gradient filled sector of a circle with support for inner and outer radius
+/// - Can be used to create a ring or pie chart
+/// - Note that the gradient fill is defined by both the color stops (cArcStart..cArcEnd) as well as
+///   a gradient angular range (nAngGradStart..nAngGradStart+nAngGradRange). This gradient angular
+///   range can be differeng from the drawing angular range (nAngSegStart..nAngSecEnd) to enable
+///   more advanced control styling / updates.
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  nQuality:      Number of segments used to depict a full circle.
+///                            The higher the value, the smoother the resulting
+///                            arcs. A value of 72 provides 360/72=5 degrees per
+///                            segment which is a reasonable compromise between
+///                            smoothness and performance.
+/// \param[in]  nMidX:         Midpoint X coordinate of circle
+/// \param[in]  nMidY:         Midpoint Y coordinate of circle
+/// \param[in]  nRad1:         Inner sector radius (0 for sector / pie, non-zero for ring)
+/// \param[in]  nRad2:         Outer sector radius. Delta from nRad1 defines ring thickness.
+/// \param[in]  cArcStart:     Start color for gradient fill (with angular range defined by nAngGradStart,nAngGradRange)
+/// \param[in]  cArcEnd:       End color for gradient fill
+/// \param[in]  nAngSecStart:  Angle of start of sector drawing (0 at top), measured in degrees.
+/// \param[in]  nAngSecEnd:    Angle of end of sector drawing (0 at top), measured in degrees.
+/// \param[in]  nAngGradStart: For gradient fill, defines the starting angle associated with the starting color (cArcStart)
+/// \param[in]  nAngGradRange: For gradient fill, defines the angular range associated with the start-to-end color range (cArcStart..cArcEnd)
+///
+/// \return none
+///
+void gslc_DrawFillGradSector(gslc_tsGui* pGui, int16_t nQuality, int16_t nMidX, int16_t nMidY, int16_t nRad1, int16_t nRad2,
+  gslc_tsColor cArcStart, gslc_tsColor cArcEnd, int16_t nAngSecStart, int16_t nAngSecEnd, int16_t nAngGradStart, int16_t nAngGradRange);
+
+///
+/// Draw a flat filled sector of a circle with support for inner and outer radius
+/// - Can be used to create a ring or pie chart
+///
+///
+/// \param[in]  pGui:          Pointer to GUI
+/// \param[in]  nQuality:      Number of segments used to depict a full circle.
+///                            The higher the value, the smoother the resulting
+///                            arcs. A value of 72 provides 360/72=5 degrees per
+///                            segment which is a reasonable compromise between
+///                            smoothness and performance.
+/// \param[in]  nMidX:         Midpoint X coordinate of circle
+/// \param[in]  nMidY:         Midpoint Y coordinate of circle
+/// \param[in]  nRad1:         Inner sector radius (0 for sector / pie, non-zero for ring)
+/// \param[in]  nRad2:         Outer sector radius. Delta from nRad1 defines ring thickness.
+/// \param[in]  cArc:          Color for flat fill
+/// \param[in]  nAngSecStart:  Angle of start of sector drawing (0 at top), measured in degrees.
+/// \param[in]  nAngSecEnd:    Angle of end of sector drawing (0 at top), measured in degrees.
+///
+/// \return none
+///
+void gslc_DrawFillSector(gslc_tsGui* pGui, int16_t nQuality, int16_t nMidX, int16_t nMidY, int16_t nRad1, int16_t nRad2,
+  gslc_tsColor cArc, int16_t nAngSecStart, int16_t nAngSecEnd);
 
 // -----------------------------------------------------------------------
 /// @}

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.40"
+#define GUISLICE_VER "0.12.2.41"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.43"
+#define GUISLICE_VER "0.12.2.44"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.45"
+#define GUISLICE_VER "0.12.2.46"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.42"
+#define GUISLICE_VER "0.12.2.43"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.44"
+#define GUISLICE_VER "0.12.2.45"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.39"
+#define GUISLICE_VER "0.12.2.40"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.12.2.41"
+#define GUISLICE_VER "0.12.2.42"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/elem/XRadial.c
+++ b/src/elem/XRadial.c
@@ -77,7 +77,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 // - Defines callback for redraw but does not track touch/click
 gslc_tsElemRef* gslc_ElemXRadialCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
   gslc_tsXRadial* pXData,gslc_tsRect rElem,
-  int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert)
+  int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge)
 {
   if ((pGui == NULL) || (pXData == NULL)) {
     static const char GSLC_PMEM FUNCSTR[] = "ElemXRadialCreate";
@@ -95,7 +95,6 @@ gslc_tsElemRef* gslc_ElemXRadialCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t 
   pXData->nMin            = nMin;
   pXData->nMax            = nMax;
   pXData->nVal            = nVal;
-  pXData->bVert           = bVert;
   pXData->bFlip           = false;
   pXData->colGauge        = colGauge;
   pXData->colTick         = GSLC_COL_GRAY;

--- a/src/elem/XRadial.h
+++ b/src/elem/XRadial.h
@@ -75,7 +75,6 @@ typedef struct {
   gslc_tsColor        colTick;        ///< Color of gauge tick marks
   uint16_t            nTickCnt;       ///< Number of gauge tick marks
   uint16_t            nTickLen;       ///< Length of gauge tick marks
-  bool                bVert;          ///< Vertical if true, else Horizontal
   bool                bFlip;          ///< Reverse direction of gauge
   uint16_t            nIndicLen;      ///< Indicator length
   uint16_t            nIndicTip;      ///< Size of tip at end of indicator
@@ -98,13 +97,11 @@ typedef struct {
 /// \param[in]  nMax:        Maximum value of gauge for nVal comparison
 /// \param[in]  nVal:        Starting value of gauge
 /// \param[in]  colGauge:    Color for the gauge indicator
-/// \param[in]  bVert:       Flag to indicate vertical vs horizontal action
-///                          (true = vertical, false = horizontal)
 ///
 /// \return Pointer to Element reference or NULL if failure
 ///
 gslc_tsElemRef* gslc_ElemXRadialCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
-  gslc_tsXRadial* pXData,gslc_tsRect rElem,int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge,bool bVert);
+  gslc_tsXRadial* pXData,gslc_tsRect rElem,int16_t nMin,int16_t nMax,int16_t nVal,gslc_tsColor colGauge);
 
 
 
@@ -201,7 +198,7 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
 //
 
 /// \def gslc_ElemXRadialCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,
-///      nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_)
+///      nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_)
 ///
 /// Create a Gauge Element in Flash
 ///
@@ -218,8 +215,6 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
 /// \param[in]  colFrame_:   Color for the gauge frame
 /// \param[in]  colFill_:    Color for the gauge background fill
 /// \param[in]  colGauge_:   Color for the gauge indicator
-/// \param[in]  bVert_:      Flag to indicate vertical vs horizontal action
-///                          (true = vertical, false = horizontal)
 ///
 /// \return none
 ///
@@ -229,7 +224,7 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
 
 
 #define gslc_ElemXRadialCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
-    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_) \
+    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_) \
   static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
     GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
   static gslc_tsXRadial sGauge##nElemId;                           \
@@ -242,7 +237,6 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
   sGauge##nElemId.colTick = GSLC_COL_GRAY;                        \
   sGauge##nElemId.nTickCnt = 8;                                   \
   sGauge##nElemId.nTickLen = 5;                                   \
-  sGauge##nElemId.bVert = bVert_;                                 \
   sGauge##nElemId.bFlip = false;                                  \
   sGauge##nElemId.nIndicLen = 10;                                 \
   sGauge##nElemId.nIndicTip = 3;                                  \
@@ -279,7 +273,7 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
 
 
 #define gslc_ElemXRadialCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,\
-    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_,bVert_) \
+    nMin_,nMax_,nVal_,colFrame_,colFill_,colGauge_) \
   static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
     GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_FILL_EN; \
   static gslc_tsXRadial sGauge##nElemId;                           \
@@ -292,7 +286,6 @@ bool gslc_ElemXRadialDrawRadial(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,gslc_t
   sGauge##nElemId.colTick = GSLC_COL_GRAY;                        \
   sGauge##nElemId.nTickCnt = 8;                                   \
   sGauge##nElemId.nTickLen = 5;                                   \
-  sGauge##nElemId.bVert = bVert_;                                 \
   sGauge##nElemId.bFlip = false;                                  \
   sGauge##nElemId.nIndicLen = 10;                                 \
   sGauge##nElemId.nIndicTip = 3;                                  \

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -161,6 +161,13 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 
   int16_t nVal = pXRingGauge->nPos;
   int16_t nValLast = pXRingGauge->nPosLast;
+  int16_t nPosMin = pXRingGauge->nPosMin;
+  int16_t nPosMax = pXRingGauge->nPosMax;
+  int16_t nPosRange = nPosMax - nPosMin;
+  if (nPosRange == 0) {
+    // Safeguard against div/0
+	  nPosRange = 1;
+  }
 
   gslc_tsColor colRingActive1 = pXRingGauge->colRing1;
   gslc_tsColor colRingActive2 = pXRingGauge->colRing2;
@@ -181,13 +188,12 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
   int16_t nX, nY;
 
   // Calculate segment ranges
-  // - TODO: Handle nPosMin, nPosMax
   // - TODO: Rewrite to use nDeg64PerSeg more effectively
   // - FIXME: Handle case with nDeg64PerSeg < 64 (ie. <1 degree)
   int16_t nStep64 = pXRingGauge->nDeg64PerSeg; // Trig functions work on 1/64 degree units
   int16_t nStepAng = nStep64 / 64;
-  uint32_t nValSegs = ((uint32_t)nVal * 360 / 100) / nStepAng; // Segment index of current value
-  uint32_t nLastSegs = ((uint32_t)nValLast * 360 / 100) / nStepAng; // Segment index of previous value
+  uint32_t nValSegs = ((uint32_t)(nVal-nPosMin) * 360 / nPosRange) / nStepAng; // Segment index of current value
+  uint32_t nLastSegs = ((uint32_t)(nValLast-nPosMin) * 360 / nPosRange) / nStepAng; // Segment index of previous value
   int16_t nMaxSegs = 360 / nStepAng; // Final segment index of circle
 
   // Determine whether we should draw the full range (full redraw)

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -96,7 +96,7 @@ gslc_tsElemRef* gslc_ElemXRingGaugeCreate(gslc_tsGui* pGui, int16_t nElemId, int
   pXData->nPosMax = 100;
   pXData->nThickness = 10;
 
-  pXData->nDeg64PerSeg = 5 * 64; // Defaul to 5 degree segments
+  pXData->nDeg64PerSeg = 5 * 64; // Default to 5 degree segments
   pXData->bGradient = false;
   pXData->nSegGap = 0;
   pXData->colRing1 = GSLC_COL_BLUE_LT4;
@@ -209,6 +209,7 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
   //GSLC_DEBUG2_PRINT("DBG: redraw inc=%d last=%d cur=%d segs %d..%d\n", bInc,nValLast,nVal,nSegStart, nSegEnd);
 
   // TODO: Consider drawing in reverse order if (nVal < nValLast)
+  //       Doing so will improve incremental redraw appearance
   for (uint16_t nSegInd = nSegStart; nSegInd < nSegEnd; nSegInd++) {
     nAng64Start = nSegInd * nStep64;
     nAng64End = nAng64Start + nStep64;
@@ -225,14 +226,14 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 
     // Adjust color depending on which segment we are rendering
     if (nSegInd < nValSegs) {
-		  if (pXRingGauge->bGradient) {
+      if (pXRingGauge->bGradient) {
         // Gradient coloring
-			  uint16_t nGradPos = 1000.0 * nSegInd / nMaxSegs;
-			  colStep = gslc_ColorBlend2(colRingActive1, colRingActive2, 500, nGradPos);
-		  } else {
+        uint16_t nGradPos = 1000.0 * nSegInd / nMaxSegs;
+        colStep = gslc_ColorBlend2(colRingActive1, colRingActive2, 500, nGradPos);
+      } else {
         // Flat coloring
-			  colStep = colRingActive1;
-		  }
+        colStep = colRingActive1;
+      }
     } else {
       colStep = colRingInactive;
     }
@@ -283,7 +284,7 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 
 }
 
-void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPos)
+void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPos)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
@@ -307,7 +308,7 @@ void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16
 
 }
 
-void gslc_ElemXRingGaugeSetRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax)
+void gslc_ElemXRingGaugeSetValRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
@@ -330,7 +331,7 @@ void gslc_ElemXRingGaugeSetThickness(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef,
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
 
-void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive)
+void gslc_ElemXRingGaugeSetColorActiveFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
@@ -343,7 +344,7 @@ void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElem
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
 }
 
-void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd)
+void gslc_ElemXRingGaugeSetColorActiveGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
@@ -357,7 +358,7 @@ void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* p
 }
 
 
-void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive)
+void gslc_ElemXRingGaugeSetColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -228,7 +228,7 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
     if (nSegInd < nValSegs) {
       if (pXRingGauge->bGradient) {
         // Gradient coloring
-        uint16_t nGradPos = 1000.0 * nSegInd / nMaxSegs;
+        uint16_t nGradPos = 1000 * nSegInd / nMaxSegs;
         colStep = gslc_ColorBlend2(colRingActive1, colRingActive2, 500, nGradPos);
       } else {
         // Flat coloring

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -92,19 +92,22 @@ gslc_tsElemRef* gslc_ElemXRingGaugeCreate(gslc_tsGui* pGui, int16_t nElemId, int
   sElem.nGroup            = GSLC_GROUP_ID_NONE;
 
   // Provide default config
-  pXData->nPosMin = 0;
-  pXData->nPosMax = 100;
+  pXData->nValMin = 0;
+  pXData->nValMax = 100;
+  pXData->nAngStart = 0;
+  pXData->nAngRange = 360;
   pXData->nThickness = 10;
 
-  pXData->nDeg64PerSeg = 5 * 64; // Default to 5 degree segments
+  pXData->nQuality = 72; // 360/72=5 degree segments
+
   pXData->bGradient = false;
   pXData->nSegGap = 0;
   pXData->colRing1 = GSLC_COL_BLUE_LT4;
   pXData->colRing2 = GSLC_COL_RED;
   pXData->colRingRemain = (gslc_tsColor) { 0, 0, 48 };
 
-  pXData->nPos = 0;
-  pXData->nPosLast = 0;
+  pXData->nVal = 0;
+  pXData->nValLast = 0;
   pXData->acStrLast[0] = 0;
 
 
@@ -134,7 +137,7 @@ gslc_tsElemRef* gslc_ElemXRingGaugeCreate(gslc_tsGui* pGui, int16_t nElemId, int
 // - Note that this redraw is for the entire element rect region
 // - The Draw function parameters use void pointers to allow for
 //   simpler callback function definition & scalability.
-bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+bool gslc_ElemXRingGaugeDraw(void* pvGui, void* pvElemRef, gslc_teRedrawType eRedraw)
 {
   gslc_tsGui* pGui = (gslc_tsGui*)pvGui;
   gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)pvElemRef;
@@ -147,33 +150,33 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
   // Init for default drawing
   // --------------------------------------------------------------------------
 
-  bool      bGlowEn,bGlowing,bGlowNow;
-  int16_t   nElemX,nElemY;
-  uint16_t  nElemW,nElemH;
+  bool      bGlowEn, bGlowing, bGlowNow;
+  int16_t   nElemX, nElemY;
+  uint16_t  nElemW, nElemH;
 
-  nElemX    = pElem->rElem.x;
-  nElemY    = pElem->rElem.y;
-  nElemW    = pElem->rElem.w;
-  nElemH    = pElem->rElem.h;
-  bGlowEn   = pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN; // Does the element support glow state?
-  bGlowing  = gslc_ElemGetGlow(pGui,pElemRef); // Element should be glowing (if enabled)
-  bGlowNow  = bGlowEn & bGlowing; // Element is currently glowing
+  nElemX = pElem->rElem.x;
+  nElemY = pElem->rElem.y;
+  nElemW = pElem->rElem.w;
+  nElemH = pElem->rElem.h;
+  bGlowEn = pElem->nFeatures & GSLC_ELEM_FEA_GLOW_EN; // Does the element support glow state?
+  bGlowing = gslc_ElemGetGlow(pGui, pElemRef); // Element should be glowing (if enabled)
+  bGlowNow = bGlowEn & bGlowing; // Element is currently glowing
 
-  int16_t nVal = pXRingGauge->nPos;
-  int16_t nValLast = pXRingGauge->nPosLast;
-  int16_t nPosMin = pXRingGauge->nPosMin;
-  int16_t nPosMax = pXRingGauge->nPosMax;
-  int16_t nPosRange = nPosMax - nPosMin;
-  if (nPosRange == 0) {
-    // Safeguard against div/0
-	  nPosRange = 1;
-  }
+  int16_t nVal = pXRingGauge->nVal;
+  int16_t nValLast = pXRingGauge->nValLast;
+  int16_t nValMin = pXRingGauge->nValMin;
+  int16_t nValMax = pXRingGauge->nValMax;
+  int16_t nValRange = (nValMax == nValMin)? 1 : (nValMax - nValMin); // Guard against div/0
+  int16_t nAngStart = pXRingGauge->nAngStart;
+  int16_t nAngRange = pXRingGauge->nAngRange;
+  //int16_t nAngEnd = nAngStart + nAngRange;
+  int16_t nQuality = pXRingGauge->nQuality;
 
   gslc_tsColor colRingActive1 = pXRingGauge->colRing1;
   gslc_tsColor colRingActive2 = pXRingGauge->colRing2;
   gslc_tsColor colRingInactive = pXRingGauge->colRingRemain;
+  bool bGradient = pXRingGauge->bGradient;
   gslc_tsColor colBg = pElem->colElemFill; // Background color used for text clearance
-  gslc_tsColor colStep;
 
   // Calculate the ring center and radius
   int16_t nMidX = nElemX + nElemW / 2;
@@ -183,72 +186,71 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 
   // --------------------------------------------------------------------------
 
-  gslc_tsPt anPts[4]; // Storage for points in segment quadrilaterla
-  int16_t nAng64Start,nAng64End;
-  int16_t nX, nY;
-
-  // Calculate segment ranges
-  // - TODO: Rewrite to use nDeg64PerSeg more effectively
-  // - FIXME: Handle case with nDeg64PerSeg < 64 (ie. <1 degree)
-  int16_t nStep64 = pXRingGauge->nDeg64PerSeg; // Trig functions work on 1/64 degree units
-  int16_t nStepAng = nStep64 / 64;
-  uint32_t nValSegs = ((uint32_t)(nVal-nPosMin) * 360 / nPosRange) / nStepAng; // Segment index of current value
-  uint32_t nLastSegs = ((uint32_t)(nValLast-nPosMin) * 360 / nPosRange) / nStepAng; // Segment index of previous value
-  int16_t nMaxSegs = 360 / nStepAng; // Final segment index of circle
-
   // Determine whether we should draw the full range (full redraw)
   // or a smaller, updated region (incremental redraw)
   bool bInc = (eRedraw == GSLC_REDRAW_INC) ? true : false;
-  int16_t nSegStart, nSegEnd;
+
+  int16_t nDrawStart;
+  int16_t nDrawVal;
+  int16_t nDrawEnd;
+
+  bool bDrawActive = false;
+  bool bDrawInactive = false;
   if (bInc) {
     if (nVal > nValLast) {
-      nSegStart = nLastSegs;
-      nSegEnd = nValSegs;
-    } else {
-      nSegStart = nValSegs;
-      nSegEnd = nLastSegs;
+      // Incremental redraw: adding value, so draw with active color
+      bDrawActive = true;
+      nDrawStart = (int32_t)(nValLast - nValMin) * nAngRange / nValRange;
+      nDrawVal = (int32_t)(nVal - nValMin) * nAngRange / nValRange;
+    }
+    else {
+      // Incremental redraw: reducing value, so draw with inactive color
+      bDrawInactive = true;
+      nDrawVal = (int32_t)(nVal - nValMin) * nAngRange / nValRange;
+      nDrawEnd = (int32_t)(nValLast - nValMin) * nAngRange / nValRange;
     }
   } else {
-    nSegStart = 0;
-    nSegEnd = nMaxSegs;
+    // Full redraw: draw both active and inactive regions
+    bDrawActive = true;
+    bDrawInactive = true;
+    nDrawStart = 0;
+    nDrawVal = (nVal - nValMin) * nAngRange / nValRange;
+    nDrawEnd = nAngRange;
   }
-  //GSLC_DEBUG2_PRINT("DBG: redraw inc=%d last=%d cur=%d segs %d..%d\n", bInc,nValLast,nVal,nSegStart, nSegEnd);
+  //GSLC_DEBUG2_PRINT("DBG: redraw inc=%d last=%d cur=%d segs %d..%d\n", bInc,nValLast,nVal,nAngStart, nAngEnd);
 
-  // TODO: Consider drawing in reverse order if (nVal < nValLast)
-  //       Doing so will improve incremental redraw appearance
-  for (uint16_t nSegInd = nSegStart; nSegInd < nSegEnd; nSegInd++) {
-    nAng64Start = nSegInd * nStep64;
-    nAng64End = nAng64Start + nStep64;
+  // Adjust for start of angular range
+  nDrawStart += nAngStart;
+  nDrawVal += nAngStart;
+  nDrawEnd += nAngStart;
 
-    // Convert polar coordinates into cartesian
-    gslc_PolarToXY(nRad1, nAng64Start, &nX, &nY);
-    anPts[0] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
-    gslc_PolarToXY(nRad2, nAng64Start, &nX, &nY);
-    anPts[1] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
-    gslc_PolarToXY(nRad2, nAng64End, &nX, &nY);
-    anPts[2] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
-    gslc_PolarToXY(nRad1, nAng64End, &nX, &nY);
-    anPts[3] = (gslc_tsPt) { nMidX + nX, nMidY + nY };
+  #if defined(DBG_REDRAW)
+  GSLC_DEBUG2_PRINT("\n\nRingDraw: Val=%d ValLast=%d PosMin=%d PosMax=%d Q=%d\n", nVal, nValLast, nValMin, nValMax, nQuality);
+  #endif
 
-    // Adjust color depending on which segment we are rendering
-    if (nSegInd < nValSegs) {
-      if (pXRingGauge->bGradient) {
-        // Gradient coloring
-        uint16_t nGradPos = 1000 * nSegInd / nMaxSegs;
-        colStep = gslc_ColorBlend2(colRingActive1, colRingActive2, 500, nGradPos);
-      } else {
-        // Flat coloring
-        colStep = colRingActive1;
-      }
+  if (bDrawActive) {
+    if (bGradient) {
+      #if defined(DBG_REDRAW)
+      GSLC_DEBUG2_PRINT("RingDraw:  ActiveG  start=%d end=%d astart=%d arange=%d\n", nDrawStart, nDrawVal,nAngStart,nAngRange);
+      #endif
+      gslc_DrawFillGradSector(pGui, nQuality, nMidX, nMidY,
+        nRad1, nRad2, colRingActive1, colRingActive2, nDrawStart, nDrawVal, nAngStart, nAngRange);
     } else {
-      colStep = colRingInactive;
+      #if defined(DBG_REDRAW)
+      GSLC_DEBUG2_PRINT("RingDraw:  Active   start=%d end=%d\n", nDrawStart, nDrawVal);
+      #endif
+      gslc_DrawFillSector(pGui, nQuality, nMidX, nMidY,
+        nRad1, nRad2, colRingActive1, nDrawStart, nDrawVal);
     }
+  }
 
-    // TODO: Support gapped regions between segments
-
-    // Draw the quadrilateral representing the circle segment
-    gslc_DrawFillQuad(pGui, anPts, colStep);
-
+  if (bDrawInactive) {
+    #if defined(DBG_REDRAW)
+    GSLC_DEBUG2_PRINT("RingDraw:  Inactive start=%d end=%d\n", nDrawEnd, nDrawVal);
+    #endif
+    // Since we are erasing, we will reverse the redraw direction (swap Val & End)
+    gslc_DrawFillSector(pGui, nQuality, nMidX, nMidY,
+      nRad1, nRad2, colRingInactive, nDrawEnd, nDrawVal);
   }
 
   // --------------------------------------------------------------------------
@@ -278,7 +280,7 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
   } // pStrBuf
 
   // Save the position to enable future incremental calculations
-  pXRingGauge->nPosLast = pXRingGauge->nPos;
+  pXRingGauge->nValLast = pXRingGauge->nVal;
 
 
   // --------------------------------------------------------------------------
@@ -290,23 +292,24 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 
 }
 
-void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPos)
+
+void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nVal)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
 
-  int16_t           nPosOld;
+  int16_t           nValOld;
 
   // Clip position
-  if (nPos < pXRingGauge->nPosMin) { nPos = pXRingGauge->nPosMin; }
-  if (nPos > pXRingGauge->nPosMax) { nPos = pXRingGauge->nPosMax; }
+  if (nVal < pXRingGauge->nValMin) { nVal = pXRingGauge->nValMin; }
+  if (nVal > pXRingGauge->nValMax) { nVal = pXRingGauge->nValMax; }
 
   // Update
-  nPosOld = pXRingGauge->nPos;
-  pXRingGauge->nPos = nPos;
+  nValOld = pXRingGauge->nVal;
+  pXRingGauge->nVal = nVal;
 
   // Only update if changed
-  if (nPos != nPosOld) {
+  if (nVal != nValOld) {
     // Mark for redraw
     // - Only need incremental redraw
     gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
@@ -314,13 +317,29 @@ void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16
 
 }
 
-void gslc_ElemXRingGaugeSetValRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax)
+void gslc_ElemXRingGaugeSetValRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nValMin, int16_t nValMax)
 {
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
 
-  pXRingGauge->nPosMin = nPosMin;
-  pXRingGauge->nPosMax = nPosMax;
+  pXRingGauge->nValMin = nValMin;
+  pXRingGauge->nValMax = nValMax;
+
+  // Mark for full redraw
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
+}
+
+void gslc_ElemXRingGaugeSetAngleRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nStart, int16_t nRange, bool bClockwise)
+{
+  gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
+  if (!pXRingGauge) return;
+
+  pXRingGauge->nAngStart = nStart;
+  pXRingGauge->nAngRange = nRange;
+
+  nRange = (nRange == 0) ? 1 : nRange; // Guard against div/0
+
+  // TODO: Support bClockwise
 
   // Mark for full redraw
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);
@@ -383,9 +402,8 @@ void gslc_ElemXRingGaugeSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, u
   gslc_tsXRingGauge* pXRingGauge = (gslc_tsXRingGauge*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_RING, __LINE__);
   if (!pXRingGauge) return;
 
-  // Convert from number of segments to degrees
-  uint16_t nDeg64PerSeg = 360 * 64 / nSegments;
-  pXRingGauge->nDeg64PerSeg = nDeg64PerSeg;
+  nSegments = (nSegments == 0) ? 72 : nSegments; // Guard against div/0 with default
+  pXRingGauge->nQuality = nSegments;
 
   // Mark for full redraw
   gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_FULL);

--- a/src/elem/XRingGauge.h
+++ b/src/elem/XRingGauge.h
@@ -142,8 +142,7 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 ///
 /// \return none
 ///
-// TODO: Consider rename to: ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos)
-void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos);
+void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos);
 
 ///
 /// Defines the angular range of the gauge, including both the active
@@ -161,8 +160,11 @@ void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElemRef:    Pointer to Element reference
-/// \param[in]  nStart64:    TODO
-/// \param[in]  nRange64:    TODO
+/// \param[in]  nStart64:    Define angle of start of active region (measured
+///                          in 1/64 of a degree)
+/// \param[in]  nRange64:    Define angular range from strt of active region
+///                          to end of the inactive region (measured in
+///                          1/64 of a degree).
 /// \param[in]  bClockwise:  Defines the direction in which the active
 ///                          region grows (true for clockwise)
 ///
@@ -182,8 +184,7 @@ void gslc_ElemXRingGaugeSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t
 ///
 /// \return none
 ///
-// TODO: Consider rename to gslc_ElemXRingGaugeSetValRange()
-void gslc_ElemXRingGaugeSetRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax);
+void gslc_ElemXRingGaugeSetValRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax);
 
 
 /// Defines the thickness of the ring arcs. More specifically, it defines the reduction
@@ -221,8 +222,7 @@ void gslc_ElemXRingGaugeSetQuality(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, u
 ///
 /// \return none
 ///
-// TODO: Consider rename to gslc_ElemXRingGaugeSetColorInactive()
-void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive);
+void gslc_ElemXRingGaugeSetColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colInactive);
 
 /// Defines the color of the active region to be a flat (constant) color.
 ///
@@ -232,8 +232,7 @@ void gslc_ElemXRingGaugeSetRingColorInactive(gslc_tsGui* pGui, gslc_tsElemRef* p
 ///
 /// \return none
 ///
-// TODO: Consider rename to ElemXRingGaugeSetColorActiveFlat()
-void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive);
+void gslc_ElemXRingGaugeSetColorActiveFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colActive);
 
 /// Defines the color of the active region to be a gradient using two color stops. The
 /// active region will be filled according to the proportion between nMin and nMax.
@@ -246,19 +245,7 @@ void gslc_ElemXRingGaugeSetRingColorFlat(gslc_tsGui* pGui, gslc_tsElemRef* pElem
 ///
 /// \return none
 ///
-// TODO: Consider rename to gslc_ElemXRingGaugeSetColorActiveGradient()
-void gslc_ElemXRingGaugeSetRingColorGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd);
-
-/// Defines the color of the background behind the gauge.
-/// This color is used when redrawing / updating the inner text field via ElemSetTxtStr().
-///
-/// \param[in]  pGui:        Pointer to GUI
-/// \param[in]  pElemRef:    Pointer to Element reference
-/// \param[in]  colBkgnd:    Color of background
-///
-/// \return none
-///
-// TODO: Add gslc_ElemXRingGaugeSetColorBackground(colBkgnd)
+void gslc_ElemXRingGaugeSetColorActiveGradient(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, gslc_tsColor colStart, gslc_tsColor colEnd);
 
 // ============================================================================
 

--- a/src/elem/XRingGauge.h
+++ b/src/elem/XRingGauge.h
@@ -73,11 +73,14 @@ extern "C" {
 /// Extended data for XRingGauge element
 typedef struct {
   // Config
-  int16_t           nPosMin;
-  int16_t           nPosMax;
+  int16_t           nValMin;
+  int16_t           nValMax;
+
+  int16_t           nAngStart;
+  int16_t           nAngRange;
 
   // Style config
-  uint16_t          nDeg64PerSeg;
+  int16_t           nQuality;
   int8_t            nThickness;
   bool              bGradient;
   uint8_t           nSegGap;
@@ -86,8 +89,8 @@ typedef struct {
   gslc_tsColor      colRingRemain;
 
   // State
-  int16_t           nPos;           ///< Current position value
-  int16_t           nPosLast;       ///< Previous position value
+  int16_t           nVal;           ///< Current position value
+  int16_t           nValLast;       ///< Previous position value
   char              acStrLast[XRING_STR_MAX];
 
   // Callbacks
@@ -138,39 +141,37 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElemRef:    Pointer to Element reference
-/// \param[in]  nPos:        New position value
+/// \param[in]  nVal:        New position value
 ///
 /// \return none
 ///
-void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nPos);
+void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nVal);
 
 ///
 /// Defines the angular range of the gauge, including both the active
 /// and inactive regions.
 ///
-/// - nStart64 defines the angle at the beginning of the active region.
+/// - nStart defines the angle at the beginning of the active region.
 /// - The current position marks the end of the active region and the
 ///   beginning of the inactive region.
-/// - nRange64 defines the angular range from the start of the active
+/// - nRange defines the angular range from the start of the active
 ///   region to the end of the inactive region. In most cases, a
-///   range of 360 degrees is used (nRange64 = 360*64).
-/// - All angles are measured in units of degrees / 64.
-/// - Angles are measured with 0 at the top, 90 * 64 towards the right,
-///   180 * 64 towards the bottom, 270 * 64 towards the left, etc.
+///   range of 360 degrees is used.
+/// - All angles are measured in units of degrees.
+/// - Angles are measured with 0 at the top, 90 towards the right,
+///   180 towards the bottom, 270 towards the left, etc.
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElemRef:    Pointer to Element reference
-/// \param[in]  nStart64:    Define angle of start of active region (measured
-///                          in 1/64 of a degree)
-/// \param[in]  nRange64:    Define angular range from strt of active region
-///                          to end of the inactive region (measured in
-///                          1/64 of a degree).
+/// \param[in]  nStart:      Define angle of start of active region (measured in degrees)
+/// \param[in]  nRange:      Define angular range from strt of active region
+///                          to end of the inactive region (measured in degrees)
 /// \param[in]  bClockwise:  Defines the direction in which the active
-///                          region grows (true for clockwise)
+///                          region grows (true for clockwise) [FORCED TRUE, FOR FUTURE IMPLEMENTATION]
 ///
 /// \return none
 ///
-// TODO: Add gslc_ElemXRingGaugeSetAngleRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nStart64, int16_t nRange64, bool bClockwise);
+void gslc_ElemXRingGaugeSetAngleRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nStart, int16_t nRange, bool bClockwise);
 
 
 /// Defines the range of values that may be passed into SetVal(), used to
@@ -179,12 +180,12 @@ void gslc_ElemXRingGaugeSetVal(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t
 ///
 /// \param[in]  pGui:        Pointer to GUI
 /// \param[in]  pElemRef:    Pointer to Element reference
-/// \param[in]  nPosMin:     Minimum value
-/// \param[in]  nPosMax:     Maximum value
+/// \param[in]  nValMin:     Minimum value
+/// \param[in]  nValMax:     Maximum value
 ///
 /// \return none
 ///
-void gslc_ElemXRingGaugeSetValRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nPosMin, int16_t nPosMax);
+void gslc_ElemXRingGaugeSetValRange(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, int16_t nValMin, int16_t nValMax);
 
 
 /// Defines the thickness of the ring arcs. More specifically, it defines the reduction


### PR DESCRIPTION
Numerous fixes and enhancements to the **XRingGauge**:
- Add API documentation
- Renamed APIs for consistency (breaking change, see migration notes below)
- Add `ElemXRingGaugeSetAngleRange()` to enable advanced appearance options
- Optimized redraw for performance / appearance
- Removed floating point usage in gradient computation

Example XRingGauge with partial angular range and gradient fill (ex42):
![image](https://user-images.githubusercontent.com/8510097/62497425-d0564880-b790-11e9-9cf2-98fbfb016703.png)

**Migration notes**
A breaking change was made to the XRingGauge APIs. In most cases, these changes only require minor search & replace updates to existing code:
- Rename `ElemXRingGaugeSetPos()` to `ElemXRingGaugeSetVal()`
- Rename `ElemXRingGaugeSetRange()` to `ElemXRingGaugeSetValRange()`
- Rename `ElemXRingGaugeSetRingColorInactive()` to `ElemXRingGaugeSetColorInactive()`
- Rename `ElemXRingGaugeSetRingColorFlat()` to `ElemXRingGaugeSetColorActiveFlat()`
- Rename `ElemXRingGaugeSetRingColorGradient()` to `ElemXRingGaugeSetColorActiveGradient()`

This PR also includes one breaking change to **XRadial**:
- Remove superfluous `bVert` parameter from `ElemXRadialCreate()`

