### PR TITLE
Add support for lexus2k/lcdgfx display driver suite

### DIFF
--- a/configs/ard-lcdgfx-notouch.h
+++ b/configs/ard-lcdgfx-notouch.h
@@ -1,0 +1,225 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: Defined by lcdgfx
+//   - Touch:   None
+//   - Wiring:  
+//
+//   - Example display:
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX           // Adafruit-GFX API mode
+
+  #define DRV_DISP_LCDGFX           // lexus2k/lcdgfx
+  // For lcdgfx library, we need to specify the display type
+  // - Ensure that one of the following display modes are selected (uncommented)
+  //   with the remaining lines commented out.
+  //#define DRV_DISP_LCDGFX_SH1106_128x64_I2C       // lexus2k/lcdgfx display: SH1106 128x64 (I2C)
+  //#define DRV_DISP_LCDGFX_SH1106_128x64_SPI       // lexus2k/lcdgfx display: SH1106 128x64 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x64_I2C      // lexus2k/lcdgfx display: SSD1306 128x64 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x64_SPI      // lexus2k/lcdgfx display: SSD1306 128x64 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x32_I2C      // lexus2k/lcdgfx display: SSD1306 128x32 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x32_SPI      // lexus2k/lcdgfx display: SSD1306_128x32 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1325_128x64_I2C      // lexus2k/lcdgfx display: SSD1325 128x64 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1325_128x64_SPI      // lexus2k/lcdgfx display: SSD1325 128x64 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1327_128x128_I2C     // lexus2k/lcdgfx display: SSD1327 128x128 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1327_128x128_SPI     // lexus2k/lcdgfx display: SSD1327 128x128 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1331_96x64x8_SPI     // lexus2k/lcdgfx display: SSD1331 128x128 8-bit (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1331_96x64x16_SPI    // lexus2k/lcdgfx display: SSD1331 128x128 16-bit (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1351_128x128_SPI     // lexus2k/lcdgfx display: SSD1351 128x128 (SPI)
+  //#define DRV_DISP_LCDGFX_ILI9163_128x128_SPI     // lexus2k/lcdgfx display: ILI9163 128x128 (SPI)
+  //#define DRV_DISP_LCDGFX_ST7735_128x160_SPI      // lexus2k/lcdgfx display: ST7735 128x160 (SPI)
+  #define DRV_DISP_LCDGFX_ILI9341_240x320_SPI     // lexus2k/lcdgfx display: ILI9341 240x320 (SPI)
+  //#define DRV_DISP_LCDGFX_PCD8544_84x48_SPI       // lexus2k/lcdgfx display: PCD8544 84x48 (SPI)
+
+  #define DRV_TOUCH_NONE            // No touch enabled
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For shields, the following pinouts are typically hardcoded
+  #define ADAGFX_PIN_CS       10    // Display chip select
+  #define ADAGFX_PIN_DC       9     // Display SPI data/command
+  #define ADAGFX_PIN_RST      0     // Display Reset
+
+  // Display interface type
+  //#define ADAGFX_SPI_HW       1	    // Display uses SPI interface: 1=hardware 0=software
+
+  // Display interface software SPI
+  // - Hardware SPI: the following definitions are unused
+  // - Software SPI: the following pins need to be defined
+  //#define ADAGFX_PIN_MOSI     11
+  //#define ADAGFX_PIN_MISO     12
+  //#define ADAGFX_PIN_CLK      13
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default: MAGENTA)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/configs/ard-lcdgfx-stmpe610.h
+++ b/configs/ard-lcdgfx-stmpe610.h
@@ -1,0 +1,264 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: Defined by lcdgfx
+//   - Touch:   STMPE610 (Resistive)
+//   - Wiring:  
+//
+//   - Example display:
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX           // Adafruit-GFX API mode
+
+  #define DRV_DISP_LCDGFX           // lexus2k/lcdgfx
+  // For lcdgfx library, we need to specify the display type
+  // - Ensure that one of the following display modes are selected (uncommented)
+  //   with the remaining lines commented out.
+  //#define DRV_DISP_LCDGFX_SH1106_128x64_I2C       // lexus2k/lcdgfx display: SH1106 128x64 (I2C)
+  //#define DRV_DISP_LCDGFX_SH1106_128x64_SPI       // lexus2k/lcdgfx display: SH1106 128x64 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x64_I2C      // lexus2k/lcdgfx display: SSD1306 128x64 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x64_SPI      // lexus2k/lcdgfx display: SSD1306 128x64 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x32_I2C      // lexus2k/lcdgfx display: SSD1306 128x32 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1306_128x32_SPI      // lexus2k/lcdgfx display: SSD1306_128x32 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1325_128x64_I2C      // lexus2k/lcdgfx display: SSD1325 128x64 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1325_128x64_SPI      // lexus2k/lcdgfx display: SSD1325 128x64 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1327_128x128_I2C     // lexus2k/lcdgfx display: SSD1327 128x128 (I2C)
+  //#define DRV_DISP_LCDGFX_SSD1327_128x128_SPI     // lexus2k/lcdgfx display: SSD1327 128x128 (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1331_96x64x8_SPI     // lexus2k/lcdgfx display: SSD1331 128x128 8-bit (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1331_96x64x16_SPI    // lexus2k/lcdgfx display: SSD1331 128x128 16-bit (SPI)
+  //#define DRV_DISP_LCDGFX_SSD1351_128x128_SPI     // lexus2k/lcdgfx display: SSD1351 128x128 (SPI)
+  //#define DRV_DISP_LCDGFX_ILI9163_128x128_SPI     // lexus2k/lcdgfx display: ILI9163 128x128 (SPI)
+  //#define DRV_DISP_LCDGFX_ST7735_128x160_SPI      // lexus2k/lcdgfx display: ST7735 128x160 (SPI)
+  #define DRV_DISP_LCDGFX_ILI9341_240x320_SPI     // lexus2k/lcdgfx display: ILI9341 240x320 (SPI)
+  //#define DRV_DISP_LCDGFX_PCD8544_84x48_SPI       // lexus2k/lcdgfx display: PCD8544 84x48 (SPI)
+
+  #define DRV_TOUCH_ADA_STMPE610    // Adafruit STMPE610 touch driver
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For shields, the following pinouts are typically hardcoded
+  #define ADAGFX_PIN_CS       10    // Display chip select
+  #define ADAGFX_PIN_DC       9     // Display SPI data/command
+  #define ADAGFX_PIN_RST      0     // Display Reset
+
+  // Display interface type
+  //#define ADAGFX_SPI_HW       1	    // Display uses SPI interface: 1=hardware 0=software
+
+  // Display interface software SPI
+  // - Hardware SPI: the following definitions are unused
+  // - Software SPI: the following pins need to be defined
+  //#define ADAGFX_PIN_MOSI     11
+  //#define ADAGFX_PIN_MISO     12
+  //#define ADAGFX_PIN_CLK      13
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+  // -----------------------------------------------------------------------------
+  // SECTION 4: Touch Handling
+  // - Documentation for configuring touch support can be found at:
+  //   https://github.com/ImpulseAdventure/GUIslice/wiki/Configure-Touch-Support
+  // -----------------------------------------------------------------------------
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4A: Update your pin connections here
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Select touch device wiring method by setting one of the following to 1, others to 0
+  #define ADATOUCH_I2C_HW 0  // Touch controller via hardware I2C (uses ADATOUCH_I2C_ADDR)
+  #define ADATOUCH_SPI_HW 1  // Touch controller via hardware SPI (uses ADATOUCH_PIN_CS)
+  #define ADATOUCH_SPI_SW 0  // Touch controller via software SPI [not yet supported]
+
+  // Touch bus & pinout
+  #define ADATOUCH_I2C_ADDR   0x41  // Touch device I2C address (for ADATOUCH_I2C_HW=1)
+  #define ADATOUCH_PIN_CS     8     // Touch device chip select (for ADATOUCH_SPI_HW=1)
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4B: Update your calibration settings here
+  // - These values should come from the diag_ard_touch_calib sketch output
+  // - Please update the values to the right of ADATOUCH_X/Y_MIN/MAX_* accordingly
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Calibration settings from diag_ard_touch_calib:
+  // DRV_TOUCH_ADA_STMPE610 [240x320]:
+  #define ADATOUCH_X_MIN    244
+  #define ADATOUCH_X_MAX    3858
+  #define ADATOUCH_Y_MIN    141
+  #define ADATOUCH_Y_MAX    3717
+  #define ADATOUCH_REMAP_YX 0    // Some touch controllers may swap X & Y coords
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4D: Additional touch configuration
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default: MAGENTA)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -95,6 +95,8 @@
     #include <Adafruit_RA8875.h>
   #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
     #include <MCUFRIEND_kbv.h>
+  #elif defined(DRV_DISP_LCDGFX)
+    #include <lcdgfx.h>
   #elif defined(DRV_DISP_WAVESHARE_ILI9486)
     // https://github.com/ImpulseAdventure/Waveshare_ILI9486
     #include <Waveshare_ILI9486_GFX.h>
@@ -290,6 +292,65 @@ extern "C" {
 #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
   const char* m_acDrvDisp = "ADA_MCUFRIEND";
   MCUFRIEND_kbv m_disp;
+
+// ------------------------------------------------------------------------
+#elif defined(DRV_DISP_LCDGFX)
+
+  // Support selection between multiple LCDGFX constructors
+  #if defined(DRV_DISP_LCDGFX_SH1106_128x64_I2C)
+  const char* m_acDrvDisp = "LCDGFX (SH1106_128x64_I2C)";
+  DisplaySH1106_128x64_I2C m_disp(-1);
+  #elif defined(DRV_DISP_LCDGFX_SH1106_128x64_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SH1106_128x64_SPI)";
+  DisplaySH1106_128x64_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1306_128x64_I2C)
+  const char* m_acDrvDisp = "LCDGFX (SSD1306_128x64_I2C)";
+  DisplaySSD1306_128x64_I2C m_disp(-1);
+  #elif defined(DRV_DISP_LCDGFX_SSD1306_128x64_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1306_128x64_SPI)";
+  DisplaySSD1306_128x64_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1306_128x32_I2C)
+  const char* m_acDrvDisp = "LCDGFX (SSD1306_128x32_I2C)";
+  DisplaySSD1306_128x32_I2C m_disp(-1);
+  #elif defined(DRV_DISP_LCDGFX_SSD1306_128x32_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1306_128x32_SPI)";
+  DisplaySSD1306_128x32_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1325_128x64_I2C)
+  const char* m_acDrvDisp = "LCDGFX (SSD1325_128x64_I2C)";
+  DisplaySSD1325_128x64_I2C m_disp(-1);
+  #elif defined(DRV_DISP_LCDGFX_SSD1325_128x64_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1325_128x64_SPI)";
+  DisplaySSD1325_128x64_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1327_128x128_I2C)
+  const char* m_acDrvDisp = "LCDGFX (SSD1327_128x128_I2C)";
+  DisplaySSD1327_128x128_I2C m_disp(-1);
+  #elif defined(DRV_DISP_LCDGFX_SSD1327_128x128_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1327_128x128_SPI)";
+  DisplaySSD1327_128x128_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1331_96x64x8_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1331_96x64x8_SPI)";
+  DisplaySSD1331_96x64x8_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1331_96x64x16_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1331_96x64x16_SPI)";
+  DisplaySSD1331_96x64x16_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_SSD1351_128x128_SPI)
+  const char* m_acDrvDisp = "LCDGFX (SSD1351_128x128x16_SPI)";
+  DisplaySSD1351_128x128x16_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_ILI9163_128x128_SPI)
+  const char* m_acDrvDisp = "LCDGFX (ILI9163_128x128x16_SPI)";
+  DisplayIL9163_128x128x16_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_ST7735_128x160_SPI)
+  const char* m_acDrvDisp = "LCDGFX (ST7735_128x160x16_SPI)";
+  DisplayST7735_128x160x16_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_ILI9341_240x320_SPI)
+  const char* m_acDrvDisp = "LCDGFX (ILI9341_240x32x16_SPI)";
+  DisplayILI9341_240x320x16_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #elif defined(DRV_DISP_LCDGFX_PCD8544_84x48_SPI)
+  const char* m_acDrvDisp = "LCDGFX (PCD8544_84x48_SPI)";
+  DisplayPCD8544_84x48_SPI m_disp(ADAGFX_PIN_RST, { -1,ADAGFX_PIN_CS,ADAGFX_PIN_DC,0,-1,-1 });
+  #else
+  #error "ERROR: LCDGFX driver: no display option (DRV_DISP_LCDGFX_*) selected in config"
+  #endif
 
 // ------------------------------------------------------------------------
 #elif defined(DRV_DISP_WAVESHARE_ILI9486)
@@ -498,6 +559,11 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
       #else
         m_disp.begin(identifier);
       #endif
+
+    #elif defined(DRV_DISP_LCDGFX)
+      m_disp.begin();
+      // Establish default font
+      m_disp.setFixedFont(ssd1306xled_font6x8);
 
     #elif defined(DRV_DISP_WAVESHARE_ILI9486)
       m_disp.begin();
@@ -741,6 +807,18 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
 
   return true;
 
+#elif defined(DRV_DISP_LCDGFX)
+  // TODO: Add support for user defined fonts
+  m_disp.setFixedFont(ssd1306xled_font6x8); // FIXME
+
+  *pnTxtSzW = m_disp.getFont().getTextSize(pStr,pnTxtSzH);
+
+  // No baseline info
+  *pnTxtX = 0;
+  *pnTxtY = 0;
+
+  return true;
+
 #else
 
   nTxtScale = pFont->nSize;
@@ -816,11 +894,21 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
   m_disp.cursorToXY(nTxtX,nTxtY);
   m_disp.setTextScale(nTxtScale);
 #elif defined(DRV_DISP_WAVESHARE_ILI9486)
-  // FIXME: Add support for user defined fonts
+  // TODO: Add support for user defined fonts
   m_disp.setFont();
   m_disp.setTextColor(nColRaw);
   m_disp.setCursor(nTxtX,nTxtY);
   m_disp.setTextSize(nTxtScale);
+#elif defined(DRV_DISP_LCDGFX)
+  // TODO: Add support for user defined fonts
+  m_disp.setFixedFont(ssd1306xled_font6x8);
+  m_disp.setColor(nColRaw);
+  // As LCDGFX doesn't support a setCursor() API to update the text
+  // coordinates, we will retain a static variable here.
+  static int16_t m_nTxtX; // Text cursor coordinate (X)
+  static int16_t m_nTxtY; // Text cursor coordinate (Y)
+  m_nTxtX = nTxtX;
+  m_nTxtY = nTxtY;
 #else
   m_disp.setFont((const GFXfont *)pFont->pvFont);
   m_disp.setTextColor(nColRaw);
@@ -912,6 +1000,15 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
       nCurPosX += m_disp.getTextLetterSpacing() * nTxtScale;
       m_disp.cursorToXY(nCurPosX,nCurPosY);
 
+    #elif defined(DRV_DISP_LCDGFX)
+      // Create dummy string for character render
+      char chStr[2];
+      chStr[0] = ch;
+      chStr[1] = 0;
+      m_disp.printFixed(m_nTxtX, m_nTxtY, chStr, STYLE_NORMAL);
+      // Advance the text cursor
+	  m_nTxtX += m_disp.getFont().getTextSize(chStr, NULL);
+
     #else
       // Call Adafruit-GFX for rendering
       // NOTE: This should automatically advance the "cursor" (current text position)
@@ -923,18 +1020,24 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
     // the Y cursor but reset the X cursor to 0. Therefore we need to
     // readjust the X cursor to our aligned bounding box.
     if (ch == '\n') {
+
       #if defined(DRV_DISP_ADAGFX_RA8875)
-      nCurPosY = m_disp.getCursorY();
-      if (bInternal8875Font) {
-        // TODO: Is getCursorY() supported in RA8875 mode?
-        m_disp.textSetCursor(nTxtX, nCurPosY);
-      }
+        nCurPosY = m_disp.getCursorY();
+        if (bInternal8875Font) {
+          // TODO: Is getCursorY() supported in RA8875 mode?
+          m_disp.textSetCursor(nTxtX, nCurPosY);
+        }
+
       #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)
-      nTxtY += m_disp.getFontHeight();
-      m_disp.cursorToXY(nTxtX,nTxtY);
+        nTxtY += m_disp.getFontHeight();
+        m_disp.cursorToXY(nTxtX,nTxtY);
+
+      #elif defined(DRV_DISP_LCDGFX)
+	    m_nTxtY += m_disp.getFont().getHeader().height;
+
       #else
-      nCurPosY = m_disp.getCursorY();
-      m_disp.setCursor(nTxtX,nCurPosY);
+        nCurPosY = m_disp.getCursorY();
+        m_disp.setCursor(nTxtX,nCurPosY);
       #endif
     }
 
@@ -953,6 +1056,8 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 #if defined(DRV_DISP_ADAGFX_ILI9341_T3)
   // TODO
 #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)
+  // TODO
+#elif defined(DRV_DISP_LCDGFX)
   // TODO
 #else
   m_disp.setFont();
@@ -987,12 +1092,24 @@ void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 
 inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, int16_t nColRaw)
 {
-  m_disp.drawPixel(nX,nY,nColRaw);
+  #if defined(DRV_DISP_LCDGFX)
+    NanoPoint p;
+    p.setPoint(nX, nY);
+    m_disp.setColor(nColRaw);
+    m_disp.putPixel(nX,nY);
+  #else
+    m_disp.drawPixel(nX,nY,nColRaw);
+  #endif
 }
 
 inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int16_t nColRaw)
 {
-  m_disp.drawLine(nX0,nY0,nX1,nY1,nColRaw);
+  #if defined(DRV_DISP_LCDGFX)
+    m_disp.setColor(nColRaw);
+    m_disp.drawLine(nX0,nY0,nX1,nY1);
+  #else
+    m_disp.drawLine(nX0,nY0,nX1,nY1,nColRaw);
+  #endif	
 }
 
 
@@ -1024,7 +1141,14 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
 #endif
 
   uint16_t nColRaw = gslc_DrvAdaptColorToRaw(nCol);
-  m_disp.fillRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
+  #if defined(DRV_DISP_LCDGFX)
+    NanoRect r;
+    r.setRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1);
+    m_disp.setColor(nColRaw);
+	  m_disp.fillRect(r);
+  #else
+    m_disp.fillRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
+  #endif
   return true;
 }
 
@@ -1073,7 +1197,14 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
   nY1 = rRect.y + rRect.h - 1;
   if (gslc_ClipLine(&pDriver->rClipRect, &nX0, &nY0, &nX1, &nY1)) { gslc_DrvDrawLine_base(nX0, nY0, nX1, nY1, nColRaw); }
 #else
-  m_disp.drawRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
+  #if defined(DRV_DISP_LCDGFX)
+    NanoRect r;
+    r.setRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1);
+    m_disp.setColor(nColRaw);
+	  m_disp.drawRect(r);
+  #else
+    m_disp.drawRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
+  #endif
 #endif
   return true;
 }
@@ -2402,6 +2533,15 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
     pGui->nDisp0W = m_disp.width();
     pGui->nDisp0H = m_disp.height();
     m_disp.setRotation(pGui->nRotation);
+    pGui->nDispW = m_disp.width();
+    pGui->nDispH = m_disp.height();
+
+  #elif defined(DRV_DISP_LCDGFX)
+    m_disp.getInterface().setRotation(0);
+    pGui->nDisp0W = m_disp.width();
+    pGui->nDisp0H = m_disp.height();
+    // It appears that LCDGFX rotation is 180 degrees offset from other libraries
+    m_disp.getInterface().setRotation((pGui->nRotation + 2) & 0x3);
     pGui->nDispW = m_disp.width();
     pGui->nDispH = m_disp.height();
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -120,10 +120,25 @@ extern "C" {
   #undef DRV_HAS_DRAW_TRI_FRAME
   #undef DRV_HAS_DRAW_TRI_FILL
 
-  #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0 ///< Support gslc_DrvDrawFrameRoundRect()
-  #define DRV_HAS_DRAW_RECT_ROUND_FILL   0 ///< Support gslc_DrvDrawFillRoundRect()
-  #define DRV_HAS_DRAW_TRI_FRAME         0 ///< Support gslc_DrvDrawFrameTriangle()
-  #define DRV_HAS_DRAW_TRI_FILL          0 ///< Support gslc_DrvDrawFillTriangle()
+  #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
+  #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
+  #define DRV_HAS_DRAW_TRI_FRAME         0
+  #define DRV_HAS_DRAW_TRI_FILL          0
+
+#elif defined(DRV_DISP_LCDGFX)
+  #undef DRV_HAS_DRAW_RECT_ROUND_FRAME
+  #undef DRV_HAS_DRAW_RECT_ROUND_FILL
+  #undef DRV_HAS_DRAW_CIRCLE_FRAME
+  #undef DRV_HAS_DRAW_CIRCLE_FILL
+  #undef DRV_HAS_DRAW_TRI_FRAME
+  #undef DRV_HAS_DRAW_TRI_FILL
+
+  #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
+  #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
+  #define DRV_HAS_DRAW_CIRCLE_FRAME      0
+  #define DRV_HAS_DRAW_CIRCLE_FILL       0
+  #define DRV_HAS_DRAW_TRI_FRAME         0
+  #define DRV_HAS_DRAW_TRI_FILL          0
 #endif
 
 


### PR DESCRIPTION
This update adds preliminary support for @lexus2k's [lcdgfx](https://github.com/lexus2k/lcdgfx) display library suite
- LCDGFX offers support for a wide range of color & monochrome displays (OLED)
- LCDGFX is a successor to the popular [lexus2k/ssd1306](https://github.com/lexus2k/ssd1306)

One nice feature of the LCDGFX library is its very low memory footprint, making it ideal for Arduino/AVR device targets (though it also supports ESP and Raspberry Pi). In my testing on an ILI9341 320x240 TFT display, I saw a significant reduction in FLASH / program memory consumption versus the standard Adafruit display libraries.

### GUIslice Configuration
LCDGFX is selected in the GUislice config with `DRV_DISP_LCDGFX`.

The individual display driver modes can be selected by uncommenting one of the `DRV_DISP_LCDGFX_*` lines in the example config.

Two example config files have been provided:
- `/configs/ard-lcdgfx-stmpe610.h` (Touch supported by resistive STMPE610)
- `/configs/ard-lcdgfx-notouch.h` (No touch support)

For SPI-based displays, only the following config options are necessary:
- `ADAGFX_PIN_CS` // SPI Display chip select
- `ADAGFX_PIN_DC` // SPI Display data/command
- `ADAGFX_PIN_RST` // Display Reset

### Supported Displays
Display drivers included in the LCDGFX library:
- sh1106 128x64
- ssd1306 128x64
- ssd1306 128x32
- ssd1325 128x64
- ssd1327 128x128
- ssd1331 96x64
- ssd1351 128x128
- il9163 128x128
- st7735 128x160
- ili9341 240x320
- pcd8544 84x48
