### PR TITLE
Add support for RA8876

### DIFF
--- a/configs/ard-adagfx-ra8876-notouch.h
+++ b/configs/ard-adagfx-ra8876-notouch.h
@@ -1,0 +1,195 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: RA8876 1024x600 SPI
+//   - Touch:   None
+//   - Wiring:  Custom breakout
+//              - Pinout:
+//
+//   - Example display:
+//     -
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a breakout board, customization
+//   of the Pinout in SECTION 2 will be required to match your display.
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX           // Adafruit-GFX library
+  #define DRV_DISP_ADAGFX_RA8876    // xlatb/ra8876 library
+  #define DRV_TOUCH_NONE            // No touch enabled
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For shields, the following pinouts are typically hardcoded
+  #define ADAGFX_PIN_CS       10    // Display chip select
+  #define ADAGFX_PIN_RST      9     // Display Reset
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default: MAGENTA)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/configs/ard-adagfx-ra8876-notouch.h
+++ b/configs/ard-adagfx-ra8876-notouch.h
@@ -78,8 +78,8 @@ extern "C" {
   // -----------------------------------------------------------------------------
 
   // For shields, the following pinouts are typically hardcoded
-  #define ADAGFX_PIN_CS       10    // Display chip select
-  #define ADAGFX_PIN_RST      9     // Display Reset
+  #define ADAGFX_PIN_CS       11    // Display chip select
+  #define ADAGFX_PIN_RST      0     // Display Reset
 
   // SD Card
   #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -97,6 +97,7 @@ extern "C" {
   //#include "../configs/ard-adagfx-ili9341-xpt2046.h"
   //#include "../configs/ard-adagfx-pcd8544-notouch.h"
   //#include "../configs/ard-adagfx-ra8875-notouch.h"
+  //#include "../configs/ard-adagfx-ra8876-notouch.h"
   //#include "../configs/ard-adagfx-ssd1306-notouch.h"
   //#include "../configs/ard-adagfx-st7735-notouch.h"
   //#include "../configs/due-adagfx-ili9341-ft6206.h"

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -58,15 +58,18 @@
 
   // Now configure specific display driver for Adafruit-GFX
   #if defined(DRV_DISP_ADAGFX_ILI9341)
+    // https://github.com/adafruit/Adafruit_ILI9341
     #include <Adafruit_ILI9341.h>
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_ILI9341_8BIT)
     #include <Adafruit_TFTLCD.h>
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_ILI9341_T3)
+    // https://github.com/PaulStoffregen/ILI9341_t3
     #include <ILI9341_t3.h>
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)
+    // https://github.com/marekburiak/ILI9341_due
     #include <ILI9341_due.h>
     #include <SPI.h>
     // Include the "SystemFont5x7" so that we can provide a
@@ -74,28 +77,39 @@
     // one explicitly.
     #include <SystemFont5x7.h>
   #elif defined(DRV_DISP_ADAGFX_SSD1306)
+    // https://github.com/adafruit/Adafruit_SSD1306
     #include <Adafruit_SSD1306.h>
     // TODO: Select either SPI or I2C. For now, assume SPI
     #include <SPI.h>
     #include <Wire.h>
   #elif defined(DRV_DISP_ADAGFX_ST7735)
+    // https://github.com/adafruit/Adafruit-ST7735-Library
     #include <Adafruit_ST7735.h>
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_HX8347)
+    // https://github.com/prenticedavid/HX8347D_kbv
     #include <HX8347D_kbv.h>
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_HX8357)
+    // https://github.com/adafruit/Adafruit_HX8357_Library
     #include <Adafruit_HX8357.h>
     // TODO: Select either SPI or I2C. For now, assume SPI
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_PCD8544)
+    // https://github.com/adafruit/Adafruit-PCD8544-Nokia-5110-LCD-library
     #include <Adafruit_PCD8544.h>
     #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_RA8875)
+    // https://github.com/adafruit/Adafruit_RA8875
     #include <Adafruit_RA8875.h>
+  #elif defined(DRV_DISP_ADAGFX_RA8876)
+    // https://github.com/xlatb/ra8876
+    #include <RA8876.h>
   #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
+    // https://github.com/prenticedavid/MCUFRIEND_kbv
     #include <MCUFRIEND_kbv.h>
   #elif defined(DRV_DISP_LCDGFX)
+    // https://github.com/lexus2k/lcdgfx
     #include <lcdgfx.h>
   #elif defined(DRV_DISP_WAVESHARE_ILI9486)
     // https://github.com/ImpulseAdventure/Waveshare_ILI9486
@@ -153,13 +167,16 @@
 // Load touch drivers
 // ------------------------------------------------------------------------
 #if defined(DRV_TOUCH_ADA_STMPE610)
+  // https://github.com/adafruit/Adafruit_STMPE610
   #include <SPI.h>
   #include <Wire.h>
   #include "Adafruit_STMPE610.h"
 #elif defined(DRV_TOUCH_ADA_FT6206)
+  // https://github.com/adafruit/Adafruit_FT6206_Library
   #include <Wire.h>
   #include "Adafruit_FT6206.h"
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
+  // https://github.com/adafruit/Adafruit_TouchScreen
   #include <stdint.h>
   #include <TouchScreen.h>
 #elif defined(DRV_TOUCH_XPT2046_STM)
@@ -167,6 +184,7 @@
   //       Arduino_STM32/STM32F1/libraries/Serasidis_XPT2046_touch/src/XPT2046_touch.h
   #include <XPT2046_touch.h>
 #elif defined(DRV_TOUCH_XPT2046_PS)
+  // https://github.com/PaulStoffregen/XPT2046_Touchscreen
   #include <XPT2046_Touchscreen.h>
 #elif defined(DRV_TOUCH_URTOUCH)
   #if defined(DRV_TOUCH_URTOUCH_OLD)
@@ -287,6 +305,11 @@ extern "C" {
 #elif defined(DRV_DISP_ADAGFX_RA8875)
   const char* m_acDrvDisp = "ADA_RA8875(SPI-HW)";
   Adafruit_RA8875 m_disp(ADAGFX_PIN_CS, ADAGFX_PIN_RST);
+
+// ------------------------------------------------------------------------
+#elif defined(DRV_DISP_ADAGFX_RA8876)
+  const char* m_acDrvDisp = "ADA_RA8876(SPI-HW)";
+  RA8876 m_disp(ADAGFX_PIN_CS, ADAGFX_PIN_RST);
 
 // ------------------------------------------------------------------------
 #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
@@ -548,6 +571,12 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
       m_disp.PWM1out(255);
       m_disp.graphicsMode(); // Go back to graphics mode
 
+    #elif defined(DRV_DISP_ADAGFX_RA8876)
+      m_disp.init();
+      //pinMode(RA8876_BACKLIGHT, OUTPUT);  // Set backlight pin to OUTPUT mode
+      //digitalWrite(RA8876_BACKLIGHT, HIGH);  // Turn on backlight
+      m_disp.clearScreen(0);
+
     #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
       uint16_t identifier = m_disp.readID();
       // Support override for MCUFRIEND ID auto-detection
@@ -800,6 +829,32 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
   m_disp.setFixedFont(ssd1306xled_font6x8); // FIXME
 
   *pnTxtSzW = m_disp.getFont().getTextSize(pStr,pnTxtSzH);
+  // FIXME: Add *pnTxtSzH
+
+  // No baseline info
+  *pnTxtX = 0;
+  *pnTxtY = 0;
+
+  return true;
+
+#elif defined(DRV_DISP_ADAGFX_RA8876)
+
+  // TODO: Add support for user defined fonts
+  // TODO: Support FLASH strings, custom font dimensions
+  // - For now, hardcode assumption of 8x16 built-in "embedded" font
+  int16_t nFontSel = RA8876_FONT_SIZE_16;
+
+  nTxtScale = pFont->nSize;
+  if ((nTxtScale >= 1) && (nTxtScale <= 3)) {
+    // Convert text scale into embedded font
+    nFontSel = RA8876_FONT_SIZE_16 + (nTxtScale-1);
+    nTxtScale = 1;
+  }
+  m_disp.selectInternalFont((enum FontSize) nFontSel);
+  m_disp.setTextScale(1);
+
+  *pnTxtSzW = strlen(pStr) * nTxtScale * ((nFontSel+2)*4);
+  *pnTxtSzH =                nTxtScale * ((nFontSel+2)*8);
 
   // No baseline info
   *pnTxtX = 0;
@@ -903,6 +958,20 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
   static int16_t m_nTxtY; // Text cursor coordinate (Y)
   m_nTxtX = nTxtX;
   m_nTxtY = nTxtY;
+#elif defined(DRV_DISP_ADAGFX_RA8876)
+  // TODO: Add support for user defined fonts
+  // - For now, select between 3 embedded fonts using text scale param
+  int16_t nFontSel = RA8876_FONT_SIZE_16;
+  if ((nTxtScale >= 1) && (nTxtScale <= 3)) {
+    // Convert text scale into embedded font
+    nFontSel = RA8876_FONT_SIZE_16 + (nTxtScale-1);
+    nTxtScale = 1;
+  }
+  m_disp.selectInternalFont((enum FontSize) nFontSel);
+  m_disp.setTextScale(nTxtScale);
+  m_disp.setCursor(nTxtX,nTxtY);
+  m_disp.setTextColor(nColRaw);
+
 #else
   m_disp.setFont((const GFXfont *)pFont->pvFont);
   m_disp.setTextColor(nColRaw);
@@ -967,6 +1036,10 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
         //   in a way that is not compatible with the Adafruit-GFX font rendering.
         m_disp.Adafruit_GFX::write(ch);
       }
+
+    #elif defined(DRV_DISP_ADAGFX_RA8876)
+      m_disp.putChar(ch);
+
     #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)
       // The ILI9341_DUE_MB library utilizes the API setTextLetterSpacing()
       // to control the kerning / spacing between letters in a string.
@@ -1001,7 +1074,7 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
       chStr[1] = 0;
       m_disp.printFixed(m_nTxtX, m_nTxtY, chStr, STYLE_NORMAL);
       // Advance the text cursor
-	  m_nTxtX += m_disp.getFont().getTextSize(chStr, NULL);
+	    m_nTxtX += m_disp.getFont().getTextSize(chStr, NULL);
 
     #else
       // Call Adafruit-GFX for rendering
@@ -1052,6 +1125,8 @@ bool gslc_DrvDrawTxt(gslc_tsGui* pGui,int16_t nTxtX,int16_t nTxtY,gslc_tsFont* p
 #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)
   // TODO
 #elif defined(DRV_DISP_LCDGFX)
+  // TODO
+#elif defined(DRV_DISP_ADAGFX_RA8876)
   // TODO
 #else
   m_disp.setFont();
@@ -2521,6 +2596,14 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
     pGui->nDisp0H = m_disp.height();
     pGui->nDispW = m_disp.width();
     pGui->nDispH = m_disp.height();
+
+  #elif defined(DRV_DISP_ADAGFX_RA8876)
+    // No support for rotation in xlatb/RA8875 library
+    bSupportRotation = false;
+    pGui->nDisp0W = m_disp.getWidth();
+    pGui->nDisp0H = m_disp.getHeight();
+    pGui->nDispW = m_disp.getWidth();
+    pGui->nDispH = m_disp.getHeight();
 
   #elif defined(DRV_DISP_ADAGFX_MCUFRIEND)
     m_disp.setRotation(0);

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -782,7 +782,7 @@ bool gslc_DrvFontSetHelp(gslc_tsGui* pGui,gslc_tsFont* pFont)
     m_disp.selectInternalFont((enum FontSize) nFontSel);
   } else if (pFont->eFontRefMode == GSLC_FONTREF_MODE_1) {
     // Reserved for rendered fonts (not yet supported in RA8876 lib)
-  } else {-
+  } else {
     // All other encodings represent an external ROM font
     // - These values are packed into the integer value as follows:
     //    [1:0] GSLC_FONTREF_MODE_2  (==2)

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -851,7 +851,7 @@ bool gslc_DrvGetTxtSize(gslc_tsGui* pGui,gslc_tsFont* pFont,const char* pStr,gsl
     nTxtScale = 1;
   }
   m_disp.selectInternalFont((enum FontSize) nFontSel);
-  m_disp.setTextScale(1);
+  m_disp.setTextScale(nTxtScale);
 
   *pnTxtSzW = strlen(pStr) * nTxtScale * ((nFontSel+2)*4);
   *pnTxtSzH =                nTxtScale * ((nFontSel+2)*8);

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1215,6 +1215,9 @@ bool gslc_DrvDrawFillRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
     r.setRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1);
     m_disp.setColor(nColRaw);
 	  m_disp.fillRect(r);
+  #elif defined(DRV_DISP_ADAGFX_RA8876)
+    // xlatb/RA8876 uses a non-standard fillRect() API
+    m_disp.fillRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1,nColRaw);
   #else
     m_disp.fillRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
   #endif
@@ -1271,6 +1274,8 @@ bool gslc_DrvDrawFrameRect(gslc_tsGui* pGui,gslc_tsRect rRect,gslc_tsColor nCol)
     r.setRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1);
     m_disp.setColor(nColRaw);
 	  m_disp.drawRect(r);
+  #elif defined(DRV_DISP_ADAGFX_RA8876)
+    m_disp.fillRect(rRect.x,rRect.y,rRect.x+rRect.w-1,rRect.y+rRect.h-1,nColRaw);
   #else
     m_disp.drawRect(rRect.x,rRect.y,rRect.w,rRect.h,nColRaw);
   #endif

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -139,6 +139,13 @@ extern "C" {
   #define DRV_HAS_DRAW_CIRCLE_FILL       0
   #define DRV_HAS_DRAW_TRI_FRAME         0
   #define DRV_HAS_DRAW_TRI_FILL          0
+
+#elif defined(DRV_DISP_ADAGFX_RA8876)
+  #undef DRV_HAS_DRAW_RECT_ROUND_FRAME
+  #undef DRV_HAS_DRAW_RECT_ROUND_FILL
+
+  #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
+  #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
 #endif
 
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.13.0.13"
+#define GUISLICE_VER "0.13.0.14"
 
 #endif // _GUISLICE_VERSION_H_
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.13.0.12"
+#define GUISLICE_VER "0.13.0.13"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
Add support for the Raio RA8876 display driver per #177:

Add `DRV_DISP_ADAGFX_RA8876` config mode: 
- Support for internal ROM font
- Support for external ROM fonts

The selection of the Font source for RA8876 is done via `gslc_FontSetMode()`:

To use internal ROM font, the following is optionally used (it is the default)
- `gslc_FontSetMode(&m_gui, E_FONT_BTN, GSLC_FONTREF_MODE_DEFAULT);`

To use external ROM font chips, a special Font Mode must be configured since there are several font ROM chips and font families available:
- `#include "RA8876.h"`
- `gslc_FontSetMode(&m_gui, E_FONT_BTN, gslc_teFontRefMode(GSLC_FONTREF_MODE_2+(RA8876_FONT_ROM_GT30L32S4W<<4)+(RA8876_FONT_FAMILY_ARIAL<<2)));`

Font size can be applied as with other display drivers, for example: (the last parameter defines the size, 1,2,3, etc.)
- `gslc_FontSet(&m_gui,E_FONT_BTN,GSLC_FONTREF_PTR,FONT_NAME1,2);`
