### PR TITLE
FT5206 Touch Handler

### DIFF
--- a/configs/ard-adagfx-ra8876-ft5206.h
+++ b/configs/ard-adagfx-ra8876-ft5206.h
@@ -78,11 +78,12 @@ extern "C" {
   // -----------------------------------------------------------------------------
 
   // For shields, the following pinouts are typically hardcoded
-  #define ADAGFX_PIN_CS       11    // Display chip select
-  #define ADAGFX_PIN_RST      0     // Display Reset
+  // These values were defined to match an Arduino Zero config
+  #define ADAGFX_PIN_CS       42    // Display chip select
+  #define ADAGFX_PIN_RST      -1    // Display Reset
 
   // SD Card
-  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+  #define ADAGFX_PIN_SDCS     12     // SD card chip select (if GSLC_SD_EN=1)
 
 
 

--- a/configs/ard-adagfx-ra8876-ft5206.h
+++ b/configs/ard-adagfx-ra8876-ft5206.h
@@ -80,10 +80,10 @@ extern "C" {
   // For shields, the following pinouts are typically hardcoded
   // These values were defined to match an Arduino Zero config
   #define ADAGFX_PIN_CS       11    // Display chip select
-  #define ADAGFX_PIN_RST      12    // Display Reset
+  #define ADAGFX_PIN_RST      0     // Display Reset
 
   // SD Card
-  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+  #define ADAGFX_PIN_SDCS     12    // SD card chip select (if GSLC_SD_EN=1)
 
 
 

--- a/configs/ard-adagfx-ra8876-ft5206.h
+++ b/configs/ard-adagfx-ra8876-ft5206.h
@@ -79,11 +79,11 @@ extern "C" {
 
   // For shields, the following pinouts are typically hardcoded
   // These values were defined to match an Arduino Zero config
-  #define ADAGFX_PIN_CS       42    // Display chip select
-  #define ADAGFX_PIN_RST      -1    // Display Reset
+  #define ADAGFX_PIN_CS       11    // Display chip select
+  #define ADAGFX_PIN_RST      12    // Display Reset
 
   // SD Card
-  #define ADAGFX_PIN_SDCS     12     // SD card chip select (if GSLC_SD_EN=1)
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
 
 
 
@@ -106,7 +106,7 @@ extern "C" {
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
   // Touch bus & pinout
-  #define ADATOUCH_PIN_INT     38
+  #define ADATOUCH_PIN_INT     10
 
 
   // -----------------------------------------------------------------------------

--- a/configs/ard-adagfx-ra8876-ft5206.h
+++ b/configs/ard-adagfx-ra8876-ft5206.h
@@ -1,0 +1,208 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: RA8876 1024x600 SPI
+//   - Touch:   FT5206 (Capacitive)
+//   - Wiring:  Custom breakout
+//              - Pinout:
+//
+//   - Example display:
+//     -
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a breakout board, customization
+//   of the Pinout in SECTION 2 will be required to match your display.
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX           // Adafruit-GFX library
+  #define DRV_DISP_ADAGFX_RA8876    // xlatb/ra8876 library
+  #define DRV_TOUCH_ADA_FT5206      // sumotoy/FT5206 library
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For shields, the following pinouts are typically hardcoded
+  #define ADAGFX_PIN_CS       11    // Display chip select
+  #define ADAGFX_PIN_RST      0     // Display Reset
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+  // -----------------------------------------------------------------------------
+  // SECTION 4: Touch Handling
+  // - Documentation for configuring touch support can be found at:
+  //   https://github.com/ImpulseAdventure/GUIslice/wiki/Configure-Touch-Support
+  // -----------------------------------------------------------------------------
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4A: Update your pin connections here
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Touch bus & pinout
+  #define ADATOUCH_PIN_INT     38
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default: MAGENTA)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/configs/ard-adagfx-ra8876-notouch.h
+++ b/configs/ard-adagfx-ra8876-notouch.h
@@ -82,7 +82,7 @@ extern "C" {
   #define ADAGFX_PIN_RST      0     // Display Reset
 
   // SD Card
-  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+  #define ADAGFX_PIN_SDCS     12    // SD card chip select (if GSLC_SD_EN=1)
 
 
 

--- a/src/GUIslice_config.h
+++ b/src/GUIslice_config.h
@@ -98,6 +98,7 @@ extern "C" {
   //#include "../configs/ard-adagfx-pcd8544-notouch.h"
   //#include "../configs/ard-adagfx-ra8875-notouch.h"
   //#include "../configs/ard-adagfx-ra8876-notouch.h"
+  //#include "../configs/ard-adagfx-ra8876-ft5206.h"
   //#include "../configs/ard-adagfx-ssd1306-notouch.h"
   //#include "../configs/ard-adagfx-st7735-notouch.h"
   //#include "../configs/due-adagfx-ili9341-ft6206.h"

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -2085,13 +2085,13 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     uint8_t nCurTouches = m_touch.getTScoordinates(anCoords,anRegs);
 
     if (nCurTouches >= 1) {
+      // Only accept the first touch
 
       // Additional unused touch info
       //uint8_t nTemp1 = m_touch.getGesture(anRegs);
       //uint8_t nTemp2 = m_touch.getTSflag(anRegs);
 
-      // Only accept the first touch
-      // - As the FT5206 has flipped axes, we adjust them here
+      // As the FT5206 has flipped axes, we adjust them here
       m_nLastRawX = nDispOutMaxX-anCoords[0][0];
       m_nLastRawY = nDispOutMaxY-anCoords[0][1];
 
@@ -2099,18 +2099,21 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
       m_bLastTouched = true;
       bValid = true;
 
+    } else {
+	  // No touches detected, so treat as release event
+      if (!m_bLastTouched) {
+        // Wasn't touched before; do nothing
+      } else {
+        // Touch release
+        // Indicate old coordinate but with pressure=0
+        m_nLastRawPress = 0;
+        m_bLastTouched = false;
+        bValid = true;
+      }
     }
 
   } else {
-    if (!m_bLastTouched) {
-      // Wasn't touched before; do nothing
-    } else {
-      // Touch release
-      // Indicate old coordinate but with pressure=0
-      m_nLastRawPress = 0;
-      m_bLastTouched = false;
-      bValid = true;
-    }
+    // Interrupt didn't occur, so no change in events
   }
 
   // ----------------------------------------------------------------

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -175,6 +175,9 @@
   // https://github.com/adafruit/Adafruit_FT6206_Library
   #include <Wire.h>
   #include "Adafruit_FT6206.h"
+#elif defined(DRV_TOUCH_ADA_FT5206)
+  // https://github.com/sumotoy/FT5206
+  #include <FT5206.h>
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
   // https://github.com/adafruit/Adafruit_TouchScreen
   #include <stdint.h>
@@ -405,6 +408,12 @@ extern "C" {
   const char* m_acDrvTouch = "FT6206(I2C)";
   // Always use I2C
   Adafruit_FT6206 m_touch = Adafruit_FT6206();
+  #define DRV_TOUCH_INSTANCE
+// ------------------------------------------------------------------------
+#elif defined(DRV_TOUCH_ADA_FT5206)
+  const char* m_acDrvTouch = "FT5206(I2C)";
+  // Always use I2C
+  FT5206 m_touch = FT5206(ADATOUCH_PIN_INT);
   #define DRV_TOUCH_INSTANCE
 // ------------------------------------------------------------------------
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
@@ -1927,6 +1936,10 @@ bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
     } else {
       return true;
     }
+  #elif defined(DRV_TOUCH_ADA_FT5206)
+    m_touch.begin();
+    m_touch.setTouchLimit(1);
+    return true;
   #elif defined(DRV_TOUCH_ADA_SIMPLE)
     return true;
   #elif defined(DRV_TOUCH_XPT2046_STM)
@@ -2048,6 +2061,47 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     m_nLastRawPress = 255;  // Select arbitrary non-zero value
     m_bLastTouched = true;
     bValid = true;
+
+  } else {
+    if (!m_bLastTouched) {
+      // Wasn't touched before; do nothing
+    } else {
+      // Touch release
+      // Indicate old coordinate but with pressure=0
+      m_nLastRawPress = 0;
+      m_bLastTouched = false;
+      bValid = true;
+    }
+  }
+
+  // ----------------------------------------------------------------
+  #elif defined(DRV_TOUCH_ADA_FT5206)
+
+  if (m_touch.touched()) {
+
+    uint8_t anRegs[FT5206_REGISTERS];
+    uint16_t anCoords[5][2];
+    m_touch.getTSregisters(anRegs);
+    uint8_t nCurTouches = m_touch.getTScoordinates(anCoords,anRegs);
+
+    if (nCurTouches >= 1) {
+
+      // Additional unused touch info
+      //uint8_t nTemp1 = m_touch.getGesture(anRegs);
+      //uint8_t nTemp2 = m_touch.getTSflag(anRegs);
+
+      // Only accept the first touch
+      m_nLastRawX = anCoords[0][0];
+      m_nLastRawY = anCoords[0][1];
+      // If the FT5206 has flipped axes, we should adjust them here
+      //m_nLastRawX = nDispOutMaxX-anCoords[0][0];
+      //m_nLastRawY = nDispOutMaxY-anCoords[0][1];
+
+      m_nLastRawPress = 255;  // Select arbitrary non-zero value
+      m_bLastTouched = true;
+      bValid = true;
+
+    }
 
   } else {
     if (!m_bLastTouched) {

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -2091,11 +2091,9 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
       //uint8_t nTemp2 = m_touch.getTSflag(anRegs);
 
       // Only accept the first touch
-      m_nLastRawX = anCoords[0][0];
-      m_nLastRawY = anCoords[0][1];
-      // If the FT5206 has flipped axes, we should adjust them here
-      //m_nLastRawX = nDispOutMaxX-anCoords[0][0];
-      //m_nLastRawY = nDispOutMaxY-anCoords[0][1];
+      // - As the FT5206 has flipped axes, we adjust them here
+      m_nLastRawX = nDispOutMaxX-anCoords[0][0];
+      m_nLastRawY = nDispOutMaxY-anCoords[0][1];
 
       m_nLastRawPress = 255;  // Select arbitrary non-zero value
       m_bLastTouched = true;

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -59,6 +59,9 @@ extern "C" {
 #elif defined(DRV_TOUCH_ADA_FT6206)
   #define DRV_TOUCH_TYPE_EXTERNAL
   #define DRV_TOUCH_TYPE_CAP         // Capacitive
+#elif defined(DRV_TOUCH_ADA_FT5206)
+  #define DRV_TOUCH_TYPE_EXTERNAL
+  #define DRV_TOUCH_TYPE_CAP         // Capacitive
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
   #define DRV_TOUCH_TYPE_EXTERNAL
   #define DRV_TOUCH_TYPE_RES         // Resistive


### PR DESCRIPTION
- Add support for **FT5206** capacitive multi-touch handler by sumotoy
- Related controllers: FT5x06, FT5206, FT5306, FT5406. Used in **EastRising 7" ER-TFTM070** TFT.
- Config selection: `DRV_TOUCH_ADA_FT5206`