### PR TITLE
Add optimized BMP render from memory

### DIFF
--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1593,6 +1593,12 @@ void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,cons
   #if defined(DBG_DRIVER)
   GSLC_DEBUG_PRINT("DBG: DrvDrawBmp24FromMem() w=%d h=%d\n", w, h);
   #endif
+  #if defined(DRV_HAS_DRAW_BMP_MEM)
+  if (!bProgMem) {
+    m_disp.drawRGBBitmap(nDstX, nDstY, (uint16_t*) pImage,w, h); 
+    return;
+  }
+  #endif
   int row, col;
   for (row=0; row<h; row++) { // For each scanline...
     for (col=0; col<w; col++) { // For each pixel...

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -99,7 +99,6 @@ extern "C" {
 #define DRV_HAS_DRAW_POINT             1 ///< Support gslc_DrvDrawPoint()
 
 #define DRV_HAS_DRAW_POINTS            0 ///< Support gslc_DrvDrawPoints()
-#define DRV_HAS_DRAW_BMP_MEM           1 ///< Support gslc_DrvDrawBmp24FromMem()
 #define DRV_HAS_DRAW_LINE              1 ///< Support gslc_DrvDrawLine()
 #define DRV_HAS_DRAW_RECT_FRAME        1 ///< Support gslc_DrvDrawFrameRect()
 #define DRV_HAS_DRAW_RECT_FILL         1 ///< Support gslc_DrvDrawFillRect()
@@ -110,6 +109,7 @@ extern "C" {
 #define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
 #define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
 #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 
 #define DRV_OVERRIDE_TXT_ALIGN         0 ///< Driver provides text alignment
 
@@ -150,6 +150,11 @@ extern "C" {
 
   #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
   #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
+
+#elif defined(DRV_DISP_ADAGFX_ILI9341)
+  // BLIT support in library
+  #undef  DRV_HAS_DRAW_BMP_MEM
+  #define DRV_HAS_DRAW_BMP_MEM           1
 #endif
 
 

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -99,6 +99,7 @@ extern "C" {
 #define DRV_HAS_DRAW_POINT             1 ///< Support gslc_DrvDrawPoint()
 
 #define DRV_HAS_DRAW_POINTS            0 ///< Support gslc_DrvDrawPoints()
+#define DRV_HAS_DRAW_BMP_MEM           1 ///< Support gslc_DrvDrawBmp24FromMem()
 #define DRV_HAS_DRAW_LINE              1 ///< Support gslc_DrvDrawLine()
 #define DRV_HAS_DRAW_RECT_FRAME        1 ///< Support gslc_DrvDrawFrameRect()
 #define DRV_HAS_DRAW_RECT_FILL         1 ///< Support gslc_DrvDrawFillRect()

--- a/src/GUIslice_drv_m5stack.h
+++ b/src/GUIslice_drv_m5stack.h
@@ -80,6 +80,7 @@ extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
 #define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
 #define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
 #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 
 #define DRV_OVERRIDE_TXT_ALIGN         1 ///< Driver provides text alignment
 

--- a/src/GUIslice_drv_sdl.h
+++ b/src/GUIslice_drv_sdl.h
@@ -85,6 +85,7 @@ extern "C" {
   #define DRV_HAS_DRAW_TRI_FRAME         0 ///< Support gslc_DrvDrawFrameTriangle()
   #define DRV_HAS_DRAW_TRI_FILL          0 ///< Support gslc_DrvDrawFillTriangle()
   #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+  #define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 #endif
 
 #if defined(DRV_DISP_SDL2)
@@ -99,6 +100,7 @@ extern "C" {
   #define DRV_HAS_DRAW_TRI_FRAME         0 ///< Support gslc_DrvDrawFrameTriangle()
   #define DRV_HAS_DRAW_TRI_FILL          0 ///< Support gslc_DrvDrawFillTriangle()
   #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+  #define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 #endif
 
 #define DRV_OVERRIDE_TXT_ALIGN      0 ///< Driver provides text alignment

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -102,6 +102,7 @@ extern "C" {
 #define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
 #define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
 #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 
 #define DRV_OVERRIDE_TXT_ALIGN         1 ///< Driver provides text alignment
 

--- a/src/GUIslice_drv_utft.h
+++ b/src/GUIslice_drv_utft.h
@@ -85,6 +85,7 @@ extern "C" {
 #define DRV_HAS_DRAW_TRI_FRAME         0 ///< Support gslc_DrvDrawFrameTriangle()
 #define DRV_HAS_DRAW_TRI_FILL          0 ///< Support gslc_DrvDrawFillTriangle()
 #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 
 #define DRV_OVERRIDE_TXT_ALIGN         0 ///< Driver provides text alignment
 


### PR DESCRIPTION
- Enable fast “BMP from memory” (BLIT) calls in drivers
- Initially only enabled for Adafruit_ILI9341 but plan to extend to most other native Adafruit-GFX derived libraries next.
- Driver call: drawRGBBitmap()