### PR TITLE
Fix color conversion for #219

### DIFF
--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1359,7 +1359,7 @@ void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 // Graphics Primitives Functions
 // -----------------------------------------------------------------------
 
-inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, int16_t nColRaw)
+inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, uint16_t nColRaw)
 {
   #if defined(DRV_DISP_LCDGFX)
     NanoPoint p;
@@ -1371,7 +1371,7 @@ inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, int16_t nColRaw)
   #endif
 }
 
-inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int16_t nColRaw)
+inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,uint16_t nColRaw)
 {
   #if defined(DRV_DISP_LCDGFX)
     m_disp.setColor(nColRaw);
@@ -1629,7 +1629,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
 void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,const unsigned char* pBitmap,bool bProgMem)
 {
   // AdaFruit GFX doesn't have a routine for this so we output pixel by pixel
-  const int16_t* pImage = (const int16_t*)pBitmap;
+  const uint16_t* pImage = (const uint16_t*)pBitmap;
   int16_t h, w;
   if (bProgMem) {
     h = pgm_read_word(pImage++);

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -367,12 +367,12 @@ void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 // Graphics Primitives Functions
 // -----------------------------------------------------------------------
 
-inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, int16_t nColRaw)
+inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, uint16_t nColRaw)
 {
   m_disp.drawPixel(nX,nY,nColRaw);
 }
 
-inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int16_t nColRaw)
+inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,uint16_t nColRaw)
 {
   m_disp.drawLine(nX0,nY0,nX1,nY1,nColRaw);
 }
@@ -605,7 +605,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
 
 void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,const unsigned char* pBitmap,bool bProgMem)
 {
-  const int16_t* pImage = (const int16_t*)pBitmap;
+  const uint16_t* pImage = (const uint16_t*)pBitmap;
   int16_t h = *(pImage++);
   int16_t w = *(pImage++);
   int row, col;

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -533,12 +533,12 @@ void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 // Graphics Primitives Functions
 // -----------------------------------------------------------------------
 
-inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, int16_t nColRaw)
+inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, uint16_t nColRaw)
 {
   m_disp.drawPixel(nX,nY,nColRaw);
 }
 
-inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int16_t nColRaw)
+inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,uint16_t nColRaw)
 {
   m_disp.drawLine(nX0,nY0,nX1,nY1,nColRaw);
 }
@@ -771,7 +771,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
 
 void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,const unsigned char* pBitmap,bool bProgMem)
 {
-  const int16_t* pImage = (const int16_t*)pBitmap;
+  const uint16_t* pImage = (const uint16_t*)pBitmap;
   int16_t h = *(pImage++);
   int16_t w = *(pImage++);
   int row, col;

--- a/src/GUIslice_drv_utft.cpp
+++ b/src/GUIslice_drv_utft.cpp
@@ -432,13 +432,13 @@ void gslc_DrvPageFlipNow(gslc_tsGui* pGui)
 // Graphics Primitives Functions
 // -----------------------------------------------------------------------
 
-inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, int16_t nColRaw)
+inline void gslc_DrvDrawPoint_base(int16_t nX, int16_t nY, uint16_t nColRaw)
 {
   m_disp.setColor(nColRaw);
   m_disp.drawPixel(nX, nY);
 }
 
-inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,int16_t nColRaw)
+inline void gslc_DrvDrawLine_base(int16_t nX0,int16_t nY0,int16_t nX1,int16_t nY1,uint16_t nColRaw)
 {
   m_disp.setColor(nColRaw);
   m_disp.drawLine(nX0,nY0,nX1,nY1);
@@ -648,7 +648,7 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
 void gslc_DrvDrawBmp24FromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,const unsigned char* pBitmap,bool bProgMem)
 {
   // AdaFruit GFX doesn't have a routine for this so we output pixel by pixel
-  const int16_t* pImage = (const int16_t*)pBitmap;
+  const uint16_t* pImage = (const uint16_t*)pBitmap;
   int16_t h, w;
   if (bProgMem) {
     h = pgm_read_word(pImage++);

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.14.0.6"
+#define GUISLICE_VER "0.14.0.10"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
This update addresses color conversion issues with certain drawing APIs / drivers that may utilize pixel-by-pixel rendering (reported in #219 ):
- `DrvDrawPoint()`
- `DrvDrawLine()`
- `DrvDrawBmp24FromMem()`