### PR TITLE
support for android style toggle buttons

### DIFF
--- a/examples/arduino/ex46_ard_togglebtn/ex46_ard_togglebtn.ino
+++ b/examples/arduino/ex46_ard_togglebtn/ex46_ard_togglebtn.ino
@@ -1,0 +1,230 @@
+// FILE: [ex46_ard_togglebtn.ino]
+//
+// For the latest guides, updates and support view:
+// https://github.com/ImpulseAdventure/GUIslice
+//
+// - Example 46 (Arduino): 
+//   - Demonstrates toggle buttons, Android (Rectangle) and ios (circular) styles 
+//   - Shows callback notifications for toogle buttons
+//   - Provide example of additional Adafruit-GFX fonts
+//
+//   - NOTE: This is the simple version of the example without
+//     optimizing for memory consumption. A "minimal"
+//     version is located in the "arduino_min" folder which includes
+//     FLASH memory optimization for reduced memory devices.
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+//
+
+// ------------------------------------------------
+// Headers to include
+// ------------------------------------------------
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XTogglebtn.h"
+
+// ------------------------------------------------
+// Headers and Defines for fonts
+// Note that font files are located within the Adafruit-GFX library folder:
+// ------------------------------------------------
+#include <Adafruit_GFX.h>
+// Note that these files are located within the Adafruit-GFX library folder:
+#include "Fonts/FreeSans9pt7b.h"
+
+
+// ------------------------------------------------
+// Enumerations for pages, elements, fonts, images
+// ------------------------------------------------
+enum {E_PG_MAIN};
+enum {E_BTN_PLAY,E_BTN_SHOW,E_ELEM_BOX1,E_ELEM_BOX3,E_LBL_APP
+      ,E_LBL_NOTIFICATIONS,E_LBL_PLAY,E_LBL_SHOW};
+// Must use separate enum for fonts with MAX_FONT at end to use gslc_FontSet.
+enum {E_FONT_SANS9,MAX_FONT};
+
+// ------------------------------------------------
+// Instantiate the GUI
+// ------------------------------------------------
+
+// ------------------------------------------------
+// Define the maximum number of elements and pages
+// ------------------------------------------------
+#define MAX_PAGE                1
+
+#define MAX_ELEM_PG_MAIN 8                                          // # Elems total on page
+#define MAX_ELEM_PG_MAIN_RAM MAX_ELEM_PG_MAIN // # Elems in RAM
+
+// ------------------------------------------------
+// Create element storage
+// ------------------------------------------------
+gslc_tsGui                      m_gui;
+gslc_tsDriver                   m_drv;
+gslc_tsFont                     m_asFont[MAX_FONT];
+gslc_tsPage                     m_asPage[MAX_PAGE];
+
+gslc_tsElem                     m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef                  m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsXTogglebtn               m_sXTogglebtn1;
+gslc_tsXTogglebtn               m_sXTogglebtn2;
+
+#define MAX_STR                 100
+
+// ------------------------------------------------
+// Program Globals
+// ------------------------------------------------
+
+// Save some element references for direct access
+gslc_tsElemRef*  m_pElemPlayApp    = NULL;
+gslc_tsElemRef*  m_pElemShowApp    = NULL;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { if (ch == (char)'\n') Serial.println(""); else Serial.write(ch); return 0; }
+
+// ------------------------------------------------
+// Callback Methods
+// ------------------------------------------------
+// Common Button callback
+bool CbBtnCommon(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem    = pElemRef->pElem;
+  gslc_tsGui*     pGui     = (gslc_tsGui*)(pvGui);
+
+  if ( eTouch == GSLC_TOUCH_UP_IN ) {
+    // From the element's ID we can determine which button was pressed.
+    switch (pElem->nId) {
+      case E_BTN_SHOW:
+        if (gslc_ElemXTogglebtnGetState(pGui, m_pElemShowApp))
+          Serial.println("Show Notifications");
+        else 
+          Serial.println("Don't Show Notifications");
+        break;
+      case E_BTN_PLAY:
+        if (gslc_ElemXTogglebtnGetState(pGui, m_pElemPlayApp))
+          Serial.println("Play Notification sounds");
+        else
+          Serial.println("Don't Play Notification sounds");
+        break;
+
+      default:
+        break;
+    } // switch
+  }
+  return true;
+}
+
+// ------------------------------------------------
+// Create page elements
+// ------------------------------------------------
+bool InitGUI()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPage1Elem,MAX_ELEM_PG_MAIN_RAM,m_asPage1ElemRef,MAX_ELEM_PG_MAIN);
+
+  // NOTE: The current page defaults to the first page added. Here we explicitly
+  //       ensure that the main page is the correct page no matter the add order.
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+  
+  // Set Background to a flat color
+  gslc_SetBkgndColor(&m_gui,(gslc_tsColor){55,0,190});
+
+  // -----------------------------------
+  // PAGE: E_PG_MAIN
+  
+   
+  // Create E_ELEM_BOX1 box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX1,E_PG_MAIN,(gslc_tsRect){10,60,300,150});
+  gslc_ElemSetRoundEn(&m_gui, pElemRef, true);
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_WHITE);
+   
+  // Create E_ELEM_BOX3 box
+  pElemRef = gslc_ElemCreateBox(&m_gui,E_ELEM_BOX3,E_PG_MAIN,(gslc_tsRect){10,47,150,30});
+  gslc_ElemSetRoundEn(&m_gui, pElemRef, true);
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_COL_WHITE);
+  
+  // Create E_LBL_NOTIFICATIONS text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_LBL_NOTIFICATIONS,E_PG_MAIN,(gslc_tsRect){17,52,130,30},
+    (char*)"Notifications",0,E_FONT_SANS9);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_ORANGE);
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_COL_WHITE);
+  
+  // Create E_LBL_SHOW text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_LBL_SHOW,E_PG_MAIN,(gslc_tsRect){20,100,176,23},
+    (char*)"Show app notications:",0,E_FONT_SANS9);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_BLACK);
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_COL_WHITE);
+   
+  // create toggle button E_BTN_SHOW
+  pElemRef = gslc_ElemXTogglebtnCreate(&m_gui,E_BTN_SHOW,E_PG_MAIN,&m_sXTogglebtn1,
+    (gslc_tsRect){230,100,60,30},
+    GSLC_COL_GRAY_LT2,GSLC_COL_GREEN_DK3,GSLC_COL_RED_DK1,true, // circular
+    false,&CbBtnCommon);
+  m_pElemShowApp = pElemRef;
+  
+  // Create E_LBL_PLAY text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_LBL_PLAY,E_PG_MAIN,(gslc_tsRect){20,150,194,23},
+    (char*)"Play notification sounds:",0,E_FONT_SANS9);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_BLACK);
+  gslc_ElemSetCol(&m_gui,pElemRef,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_COL_WHITE);
+   
+  // create toggle button E_BTN_PLAY
+  pElemRef = gslc_ElemXTogglebtnCreate(&m_gui,E_BTN_PLAY,E_PG_MAIN,&m_sXTogglebtn2,
+    (gslc_tsRect){230,150,60,30},
+    GSLC_COL_GRAY_LT2,GSLC_COL_GREEN_DK3,GSLC_COL_RED_DK1,false, // rectangular
+    false,&CbBtnCommon);
+  m_pElemPlayApp = pElemRef;
+  
+  // Create E_LBL_APP text label
+  pElemRef = gslc_ElemCreateTxt(&m_gui,E_LBL_APP,E_PG_MAIN,(gslc_tsRect){0,0,320,32},
+    (char*)"My App",0,E_FONT_SANS9);
+  gslc_ElemSetTxtAlign(&m_gui,pElemRef,GSLC_ALIGN_MID_MID);
+  gslc_ElemSetTxtCol(&m_gui,pElemRef,GSLC_COL_WHITE);
+
+  return true;
+}
+
+void setup()
+{
+  // ------------------------------------------------
+  // Initialize
+  // ------------------------------------------------
+  Serial.begin(9600);
+  // Wait for USB Serial 
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  gslc_InitDebug(&DebugOut);
+
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // ------------------------------------------------
+  // Load Fonts
+  // ------------------------------------------------
+    if (!gslc_FontSet(&m_gui,E_FONT_SANS9,GSLC_FONTREF_PTR,&FreeSans9pt7b,1)) { return; }
+
+  // ------------------------------------------------
+  // Create graphic elements
+  // ------------------------------------------------
+  InitGUI();
+
+}
+
+// -----------------------------------
+// Main event loop
+// -----------------------------------
+void loop()
+{
+
+  // ------------------------------------------------
+  // Update GUI Elements
+  // ------------------------------------------------
+  
+  // ------------------------------------------------
+  // Periodically call GUIslice update function
+  // ------------------------------------------------
+  gslc_Update(&m_gui);
+    
+}

--- a/examples/arduino_min/ex46_ardmin_togglebtn/ex46_ardmin_togglebtn.ino
+++ b/examples/arduino_min/ex46_ardmin_togglebtn/ex46_ardmin_togglebtn.ino
@@ -1,0 +1,223 @@
+// FILE: [ex46_ard_togglebtn.ino]
+//
+// For the latest guides, updates and support view:
+// https://github.com/ImpulseAdventure/GUIslice
+//
+// - Example 46 (Arduino): [minimum RAM version]
+//   - Demonstrates toggle buttons, Android (Rectangle) and ios (circular) styles 
+//   - Shows callback notifications for toogle buttons
+//   - Provide example of additional Adafruit-GFX fonts
+//
+// ARDUINO NOTES:
+// - GUIslice_config.h must be edited to match the pinout connections
+//   between the Arduino CPU and the display controller (see ADAGFX_PIN_*).
+//
+
+// ------------------------------------------------
+// Headers to include
+// ------------------------------------------------
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+// Include any extended elements
+#include "elem/XTogglebtn.h"
+
+// ------------------------------------------------
+// Headers and Defines for fonts
+// Note that font files are located within the Adafruit-GFX library folder:
+// ------------------------------------------------
+#include <Adafruit_GFX.h>
+// Note that these files are located within the Adafruit-GFX library folder:
+#include "Fonts/FreeSans9pt7b.h"
+
+
+// ------------------------------------------------
+// Enumerations for pages, elements, fonts, images
+// ------------------------------------------------
+enum {E_PG_MAIN};
+enum {E_BTN_PLAY,E_BTN_SHOW,E_ELEM_BOX1,E_ELEM_BOX3,E_LBL_APP
+      ,E_LBL_NOTIFICATIONS,E_LBL_PLAY,E_LBL_SHOW};
+// Must use separate enum for fonts with MAX_FONT at end to use gslc_FontSet.
+enum {E_FONT_SANS9,MAX_FONT};
+
+// ------------------------------------------------
+// Instantiate the GUI
+// ------------------------------------------------
+
+// ------------------------------------------------
+// Define the maximum number of elements and pages
+// ------------------------------------------------
+#define MAX_PAGE                1
+
+// Define the maximum number of elements per page
+// - To enable the same code to run on devices that support storing
+//   data into Flash (PROGMEM) and those that don't, we can make the
+//   number of elements in Flash dependent upon GSLC_USE_PROGMEM
+// - This should allow both Arduino and ARM Cortex to use the same code
+#define MAX_ELEM_PG_MAIN 8  // # Elems total on page
+#if (GSLC_USE_PROGMEM)
+  #define MAX_ELEM_PG_MAIN_PROG   8                                         // # Elems in Flash
+#else
+  #define MAX_ELEM_PG_MAIN_PROG   0                                         // # Elems in Flash
+#endif
+#define MAX_ELEM_PG_MAIN_RAM      MAX_ELEM_PG_MAIN - MAX_ELEM_PG_MAIN_PROG  // # Elems in RAM
+
+// ------------------------------------------------
+// Create element storage
+// ------------------------------------------------
+gslc_tsGui                      m_gui;
+gslc_tsDriver                   m_drv;
+gslc_tsFont                     m_asFont[MAX_FONT];
+gslc_tsPage                     m_asPage[MAX_PAGE];
+
+gslc_tsElem                     m_asPage1Elem[MAX_ELEM_PG_MAIN_RAM];
+gslc_tsElemRef                  m_asPage1ElemRef[MAX_ELEM_PG_MAIN];
+gslc_tsXTogglebtn               m_sXTogglebtn1;
+gslc_tsXTogglebtn               m_sXTogglebtn2;
+
+#define MAX_STR                 100
+
+// ------------------------------------------------
+// Program Globals
+// ------------------------------------------------
+
+// Save some element references for direct access
+gslc_tsElemRef*  m_pElemPlayApp    = NULL;
+gslc_tsElemRef*  m_pElemShowApp    = NULL;
+
+// Define debug message function
+static int16_t DebugOut(char ch) { if (ch == (char)'\n') Serial.println(""); else Serial.write(ch); return 0; }
+
+// ------------------------------------------------
+// Callback Methods
+// ------------------------------------------------
+// Common Button callback
+bool CbBtnCommon(void* pvGui,void *pvElemRef,gslc_teTouch eTouch,int16_t nX,int16_t nY)
+{
+  gslc_tsElemRef* pElemRef = (gslc_tsElemRef*)(pvElemRef);
+  gslc_tsElem*    pElem    = pElemRef->pElem;
+  gslc_tsGui*     pGui     = (gslc_tsGui*)(pvGui);
+
+  if ( eTouch == GSLC_TOUCH_UP_IN ) {
+    // From the element's ID we can determine which button was pressed.
+    switch (pElem->nId) {
+      case E_BTN_SHOW:
+        if (gslc_ElemXTogglebtnGetState(pGui, m_pElemShowApp))
+          Serial.println("Show Notifications");
+        else 
+          Serial.println("Don't Show Notifications");
+        break;
+      case E_BTN_PLAY:
+        if (gslc_ElemXTogglebtnGetState(pGui, m_pElemPlayApp))
+          Serial.println("Play Notification sounds");
+        else
+          Serial.println("Don't Play Notification sounds");
+        break;
+
+      default:
+        break;
+    } // switch
+  }
+  return true;
+}
+
+// ------------------------------------------------
+// Create page elements
+// ------------------------------------------------
+bool InitGUI()
+{
+  gslc_tsElemRef* pElemRef = NULL;
+
+  gslc_PageAdd(&m_gui,E_PG_MAIN,m_asPage1Elem,MAX_ELEM_PG_MAIN_RAM,m_asPage1ElemRef,MAX_ELEM_PG_MAIN);
+
+  // NOTE: The current page defaults to the first page added. Here we explicitly
+  //       ensure that the main page is the correct page no matter the add order.
+  gslc_SetPageCur(&m_gui,E_PG_MAIN);
+  
+  // Set Background to a flat color
+  gslc_SetBkgndColor(&m_gui,(gslc_tsColor){55,0,190});
+
+  // -----------------------------------
+  // PAGE: E_PG_MAIN
+  
+   
+  // Create E_ELEM_BOX1 box
+  gslc_ElemCreateBox_P(&m_gui,E_ELEM_BOX1,E_PG_MAIN,10,60,300,150,GSLC_COL_BLACK,GSLC_COL_WHITE,
+    true,true,NULL,NULL);
+   
+  // Create E_ELEM_BOX3 box
+  gslc_ElemCreateBox_P(&m_gui,E_ELEM_BOX3,E_PG_MAIN,10,47,150,30,GSLC_COL_WHITE,GSLC_COL_WHITE,
+    true,true,NULL,NULL);
+  
+  // Create E_LBL_NOTIFICATIONS text label
+  gslc_ElemCreateTxt_P(&m_gui,E_LBL_NOTIFICATIONS,E_PG_MAIN,17,52,130,30,"Notifications:",&m_asFont[E_FONT_SANS9],
+     GSLC_COL_ORANGE,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_ALIGN_MID_LEFT,false,true);
+  
+  // Create E_LBL_SHOW text label
+  gslc_ElemCreateTxt_P(&m_gui,E_LBL_SHOW,E_PG_MAIN,20,100,176,23,"Show app notications:",&m_asFont[E_FONT_SANS9],
+    GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_ALIGN_MID_LEFT,false,true);
+   
+  // create toggle button E_BTN_SHOW
+  gslc_ElemXTogglebtnCreate_P(&m_gui,E_BTN_SHOW,E_PG_MAIN,230,100,60,30,
+    GSLC_COL_GRAY_LT2,GSLC_COL_GREEN_DK3,GSLC_COL_RED_DK1,true, // circular
+    false,&CbBtnCommon);
+  m_pElemShowApp = gslc_PageFindElemById(&m_gui,E_PG_MAIN,E_BTN_SHOW); // Save for quick access
+  
+  // Create E_LBL_PLAY text label
+  gslc_ElemCreateTxt_P(&m_gui,E_LBL_PLAY,E_PG_MAIN,20,150,194,23,"Play notification sounds:",&m_asFont[E_FONT_SANS9],
+    GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_WHITE,GSLC_ALIGN_MID_LEFT,false,true);
+   
+  // create toggle button E_BTN_PLAY
+  gslc_ElemXTogglebtnCreate_P(&m_gui,E_BTN_PLAY,E_PG_MAIN,230,150,60,30,
+    GSLC_COL_GRAY_LT2,GSLC_COL_GREEN_DK3,GSLC_COL_RED_DK1,false, // rectangular
+    false,&CbBtnCommon);
+  m_pElemPlayApp = gslc_PageFindElemById(&m_gui,E_PG_MAIN,E_BTN_PLAY); // Save for quick access
+  
+  // Create E_LBL_APP text label
+  gslc_ElemCreateTxt_P(&m_gui,E_LBL_APP,E_PG_MAIN,0,0,320,32,"My App",&m_asFont[E_FONT_SANS9],
+    GSLC_COL_WHITE,GSLC_COL_BLACK,GSLC_COL_BLACK,GSLC_ALIGN_MID_MID,false,true);
+
+  return true;
+}
+
+void setup()
+{
+  // ------------------------------------------------
+  // Initialize
+  // ------------------------------------------------
+  Serial.begin(9600);
+  // Wait for USB Serial 
+  //delay(1000);  // NOTE: Some devices require a delay after Serial.begin() before serial port can be used
+
+  gslc_InitDebug(&DebugOut);
+
+  if (!gslc_Init(&m_gui,&m_drv,m_asPage,MAX_PAGE,m_asFont,MAX_FONT)) { return; }
+
+  // ------------------------------------------------
+  // Load Fonts
+  // ------------------------------------------------
+    if (!gslc_FontSet(&m_gui,E_FONT_SANS9,GSLC_FONTREF_PTR,&FreeSans9pt7b,1)) { return; }
+
+  // ------------------------------------------------
+  // Create graphic elements
+  // ------------------------------------------------
+  InitGUI();
+
+}
+
+// -----------------------------------
+// Main event loop
+// -----------------------------------
+void loop()
+{
+
+  // ------------------------------------------------
+  // Update GUI Elements
+  // ------------------------------------------------
+  
+  // ------------------------------------------------
+  // Periodically call GUIslice update function
+  // ------------------------------------------------
+  gslc_Update(&m_gui);
+    
+}

--- a/src/elem/XTogglebtn.c
+++ b/src/elem/XTogglebtn.c
@@ -1,0 +1,470 @@
+// =======================================================================
+// GUIslice library extension: Toggle button control
+// - Paul Conti
+// - Toggle button with Android and iOS like styles
+// - Based on Calvin Hass' Checkbox control
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2020 Calvin Hass and Paul Conti
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XTogglebtn.c
+
+
+
+// GUIslice library
+#include "GUIslice.h"
+#include "GUIslice_drv.h"
+
+//#include "elem/XTogglebtn.h"
+#include "XTogglebtn.h"
+
+#include <stdio.h>
+
+#if (GSLC_USE_PROGMEM)
+    #include <avr/pgmspace.h>
+#endif
+
+// ----------------------------------------------------------------------------
+// Error Messages
+// ----------------------------------------------------------------------------
+
+extern const char GSLC_PMEM ERRSTR_NULL[];
+extern const char GSLC_PMEM ERRSTR_PXD_NULL[];
+
+
+// ----------------------------------------------------------------------------
+// Extended element definitions
+// ----------------------------------------------------------------------------
+//
+// - This file extends the core GUIslice functionality with
+//   additional widget types
+//
+// ----------------------------------------------------------------------------
+
+// ============================================================================
+// Extended Element: Togglebtn
+// - Togglebtn 
+//   Acts much like a checkbox but with styles that are similar to iOS and 
+//   Android slider buttons.
+// ============================================================================
+
+// Create a togglebtn element and add it to the GUI element list
+gslc_tsElemRef* gslc_ElemXTogglebtnCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXTogglebtn* pXData,gslc_tsRect rElem,
+  gslc_tsColor colThumb,gslc_tsColor colOnState,gslc_tsColor colOffState,
+  bool bCircular,bool bChecked,GSLC_CB_TOUCH cbTouch)
+{
+  if ((pGui == NULL) || (pXData == NULL)) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXTogglebtnCreate";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+  gslc_tsElem     sElem;
+  gslc_tsElemRef* pElemRef = NULL;
+  sElem = gslc_ElemCreate(pGui,nElemId,nPage,GSLC_TYPEX_TOGGLEBTN,rElem,NULL,0,GSLC_FONT_NONE);
+  sElem.nFeatures        &= ~GSLC_ELEM_FEA_FRAME_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_CLICK_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_GLOW_EN;
+
+  // Define other extended data
+  sElem.pXData            = (void*)(pXData);
+  pXData->bOn             = bChecked;    // save on/off status
+  pXData->pfunctUser      = cbTouch;     // save user's callback in our extra data
+  pXData->nMyPageId       = nPage;       // save our page id for group by access later, if needed.
+  pXData->colThumb        = colThumb;    // save thumb color
+  pXData->colOnState      = colOnState;  // save on color
+  pXData->colOffState     = colOffState; // save off color
+  pXData->bCircular       = bCircular;   // save button style
+  
+  // Specify the custom drawing callback
+  sElem.pfuncXDraw        = &gslc_ElemXTogglebtnDraw;
+  
+  // Specify the custom touch handler
+  sElem.pfuncXTouch       = &gslc_ElemXTogglebtnTouch;
+  sElem.colElemFill       = GSLC_COL_BLACK;
+  sElem.colElemFillGlow   = GSLC_COL_BLACK;
+  sElem.colElemFrame      = GSLC_COL_GRAY;
+  sElem.colElemFrameGlow  = GSLC_COL_WHITE;
+  
+  if (nPage != GSLC_PAGE_NONE) {
+    pElemRef = gslc_ElemAdd(pGui,nPage,&sElem,GSLC_ELEMREF_DEFAULT);
+    return pElemRef;
+#if (GSLC_FEATURE_COMPOUND)
+  } else {
+    // Save as temporary element
+    pGui->sElemTmp = sElem;
+    pGui->sElemRefTmp.pElem = &(pGui->sElemTmp);
+    pGui->sElemRefTmp.eElemFlags = GSLC_ELEMREF_DEFAULT | GSLC_ELEMREF_REDRAW_FULL;
+    return &(pGui->sElemRefTmp);
+#endif
+  }
+  return NULL;
+}
+
+bool gslc_ElemXTogglebtnGetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
+{
+  gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
+  if (!pTogglebtn) return false;
+
+  return pTogglebtn->bOn;
+}
+
+// Helper routine for gslc_ElemXTogglebtnSetState()
+// - Updates the togglebtn control's state but does
+//   not touch any other controls in the group
+void gslc_ElemXTogglebtnSetStateHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bOn)
+{
+  gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
+  if (!pTogglebtn) return;
+
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+
+  // Update our data element
+  bool  bStateOld = pTogglebtn->bOn;
+  pTogglebtn->bOn = bOn;
+
+  // Element needs redraw
+  if (bOn != bStateOld) {
+    // Only need an incremental redraw
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+  }
+
+}
+
+// Update the togglebtn control's state. If it's part of a group
+// then also update the state of all other buttons in the group.
+void gslc_ElemXTogglebtnSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bOn)
+{
+  gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
+  if (!pTogglebtn) return;
+
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+
+  int16_t             nGroup    = pElem->nGroup;
+  int16_t             nElemId   = pElem->nId;
+
+  if (bOn && pElem->nGroup != GSLC_GROUP_ID_NONE) {
+
+    // If we are selecting a button that is already
+    // selected, then skip further update events.
+    // NOTE: This check is not very efficient, but it avoids
+    // the creation of extra events.
+    gslc_tsElemRef* pTmpRef = gslc_ElemXTogglebtnFindSelected(pGui, nGroup);
+    if (pTmpRef == pElemRef) {
+      // Same element, so skip
+      return;
+    }
+
+    // Proceed to deselect any other selected items in the group.
+    // Note that SetState calls itself to deselect other items so it
+    // is important to qualify this logic with bOn=true
+    int16_t           nCurInd;
+    int16_t           nCurId;
+    gslc_tsElem*      pCurElem = NULL;
+    gslc_tsElemRef*   pCurElemRef = NULL;
+    int16_t           nCurType;
+    int16_t           nCurGroup;
+
+    /* 
+     * The elements must be grouped on the same layer but do not need to be on the current
+     * page.  This allows us to place grouped elements on the base page.
+     * p conti.
+     */
+    // Find our page layer
+    gslc_tsPage* pPage = gslc_PageFindById(pGui, pTogglebtn->nMyPageId);
+    if (pPage == NULL) {
+      GSLC_DEBUG2_PRINT("ERROR: gslc_ElemXTogglebtnSetState() can't find page (ID=%d)\n", 
+         pTogglebtn->nMyPageId);
+      return;
+    }
+
+    gslc_tsCollect* pCollect = &pPage->sCollect;
+    for (nCurInd=0;nCurInd<pCollect->nElemRefCnt;nCurInd++) {
+      // Fetch extended data
+      pCurElemRef   = &pCollect->asElemRef[nCurInd];
+      pCurElem      = gslc_GetElemFromRef(pGui,pCurElemRef);
+
+      // NOTE: Sorry but I have no idea what this FIXME is talking about - p conti
+      // FIXME: Handle pCurElemRef->eElemFlags 
+      nCurId        = pCurElem->nId;
+      nCurType      = pCurElem->nType;
+
+      nCurGroup     = pCurElem->nGroup;
+
+      // If this is in a different group, ignore it
+      if (nCurGroup != nGroup) {
+        continue;
+      }
+
+      // Is this our element? If so, ignore the deselect operation
+      if (nCurId == nElemId) {
+        continue;
+      }
+
+      // Deselect all other elements
+      gslc_ElemSetGlow(pGui,pCurElemRef,false);  // trurn off glow state
+      gslc_ElemXTogglebtnSetStateHelp(pGui,pCurElemRef,false);
+
+    } // nInd
+
+  } // bOn
+
+  // Set the state of the current element
+  gslc_ElemXTogglebtnSetStateHelp(pGui,pElemRef,bOn);
+}
+
+// Toggle the togglebtn control's state
+void gslc_ElemXTogglebtnToggleState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
+{
+  if (pElemRef == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXTogglebtnToggleState";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return;
+  }
+  // Toggle the data element value
+  bool bStateNew = (gslc_ElemXTogglebtnGetState(pGui,pElemRef))? false : true;
+  gslc_ElemXTogglebtnSetState(pGui,pElemRef,bStateNew);
+}
+
+void gslc_ElemXTogglebtnDrawCircularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsXTogglebtn* pTogglebtn) 
+{
+  // frame enabled?
+  bool bFrameEn  = pElem->nFeatures & GSLC_ELEM_FEA_FRAME_EN;
+
+  // Work out the sizes of the inner rectangles 
+  gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
+  gslc_tsRect rText = {
+    rInner.x,
+    rInner.y,
+    rInner.w - rInner.h,
+    rInner.h
+  };
+
+  // work out our circle positions
+  uint16_t nRadius  = rInner.h / 2;
+  int16_t  nLeftX   = rInner.x + nRadius;
+  int16_t  nLeftY   = rInner.y + nRadius;
+  int16_t  nRightX  = rInner.x + pElem->rElem.w - nRadius -1;
+  int16_t  nRightY  = rInner.y + nRadius;
+    
+  if (pTogglebtn->bOn) {
+    // draw our main body
+    gslc_DrawFillRoundRect(pGui,rInner,rInner.h,pTogglebtn->colOnState);
+    // place thumb on left-hand side
+    gslc_DrawFillCircle(pGui,nLeftX,nLeftY,nRadius-1,pTogglebtn->colThumb);
+    if (bFrameEn) {
+      gslc_DrawFrameRoundRect(pGui,pElem->rElem,pElem->rElem.h,pElem->colElemFrame);
+      gslc_DrawFrameCircle(pGui,nLeftX,nLeftY,nRadius,pElem->colElemFrame);
+    }
+  } else {
+    // draw our main body
+    gslc_DrawFillRoundRect(pGui,rInner,rInner.h,pTogglebtn->colOffState);
+    // place thumb on right-hand side
+    gslc_DrawFillCircle(pGui,nRightX,nRightY,nRadius-1,pTogglebtn->colThumb);
+    if (bFrameEn) {
+      gslc_DrawFrameRoundRect(pGui,pElem->rElem,pElem->rElem.h,pElem->colElemFrame);
+      gslc_DrawFrameCircle(pGui,nRightX,nRightY,nRadius,pElem->colElemFrame);
+    }
+  }
+}
+
+void gslc_ElemXTogglebtnDrawRectangularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsXTogglebtn* pTogglebtn) 
+{
+  // frame enabled?
+  bool bFrameEn  = pElem->nFeatures & GSLC_ELEM_FEA_FRAME_EN;
+
+  // Work out the sizes of the inner rectangles 
+  gslc_tsRect rSquare = {
+    pElem->rElem.x,
+    pElem->rElem.y,
+    pElem->rElem.h, // force a square
+    pElem->rElem.h
+  };
+  gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
+  gslc_tsRect rText = {
+    rInner.x,
+    rInner.y,
+    rInner.w - rInner.h,
+    rInner.h
+  };
+
+  if (pTogglebtn->bOn) {
+    gslc_DrawFillRect(pGui,rInner,pTogglebtn->colOnState);
+    // place thumb on left-hand side
+    gslc_DrawFillRect(pGui,rSquare,pTogglebtn->colThumb);
+    if (bFrameEn) {
+      gslc_DrawFrameRect(pGui,pElem->rElem,pElem->colElemFrame);
+      gslc_DrawFrameRect(pGui,rSquare,pElem->colElemFrame);
+    }
+  } else {
+    gslc_DrawFillRect(pGui,rInner,pTogglebtn->colOffState);
+    // place thumb on right-hand side
+    rSquare.x = rInner.x + rInner.w - rInner.h - 1;
+    gslc_DrawFillRect(pGui,rSquare,pTogglebtn->colThumb);
+    if (bFrameEn) {
+      gslc_DrawFrameRect(pGui,pElem->rElem,pElem->colElemFrame);
+      gslc_DrawFrameRect(pGui,rSquare,pElem->colElemFrame);
+    }
+  }
+}
+
+// Redraw the togglebtn
+// - Note that this redraw is for the entire element rect region
+// - The Draw function parameters use void pointers to allow for
+//   simpler callback function definition & scalability.
+
+bool gslc_ElemXTogglebtnDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
+{
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui  = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef = (gslc_tsElemRef*)(pvElemRef);
+
+  gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
+  if (!pTogglebtn) {
+    GSLC_DEBUG_PRINT("ERROR: gslc_ElemXTogglebtnDraw(%s) pXData is NULL\n","");
+    return false;
+  }
+
+  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+ 
+  if (pTogglebtn->bCircular) {
+    gslc_ElemXTogglebtnDrawCircularHelp(pGui, pElem, pTogglebtn);
+  } else {
+    gslc_ElemXTogglebtnDrawRectangularHelp(pGui, pElem, pTogglebtn);
+  }
+  
+  // Clear the redraw flag
+  gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_NONE);
+
+  // Mark page as needing flip
+  gslc_PageFlipSet(pGui,true);
+
+  return true;
+}
+
+// This callback function is called by gslc_ElemSendEventTouch()
+// after any touch event
+// - NOTE: Adding this touch callback is optional. Without it, we
+//   can still have a functional togglebtn, but doing the touch
+//   tracking allows us to change the glow state of the element
+//   dynamically, as well as updating the togglebtn state if the
+//   user releases over it (ie. a click event).
+//
+bool gslc_ElemXTogglebtnTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16_t nRelX,int16_t nRelY)
+{
+#if defined(DRV_TOUCH_NONE)
+  return false;
+#else
+
+  // Typecast the parameters to match the GUI and element types
+  gslc_tsGui*       pGui  = (gslc_tsGui*)(pvGui);
+  gslc_tsElemRef*   pElemRef = (gslc_tsElemRef*)(pvElemRef);
+
+  gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
+  if (!pTogglebtn) return false;
+
+  //gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+  bool  bStateOld = pTogglebtn->bOn;
+  bool  bGlowingOld = gslc_ElemGetGlow(pGui,pElemRef);
+
+  switch(eTouch) {
+
+    case GSLC_TOUCH_UP_IN:
+      // Now that we released on element, update the state
+      // Togglebtn button action: toggle
+      gslc_ElemXTogglebtnToggleState(pGui,pElemRef);
+      break;
+    default:
+      return false;
+      break;
+  }
+
+  // If the togglebtn changed state, redraw and notify user
+  if (pTogglebtn->bOn != bStateOld) {
+    // Now send the callback notification
+    (*pTogglebtn->pfunctUser)((void*)(pGui), (void*)(pElemRef), eTouch, nRelX, nRelY);
+    // Incremental redraw
+    gslc_ElemSetRedraw(pGui,pElemRef,GSLC_REDRAW_INC);
+  }
+
+  return true;
+  #endif // !DRV_TOUCH_NONE
+}
+
+// Determine which togglebtn in the group is selected "on"
+gslc_tsElemRef* gslc_ElemXTogglebtnFindSelected(gslc_tsGui* pGui,int16_t nGroupId)
+{
+  int16_t             nCurInd;
+  gslc_tsElemRef*     pCurElemRef = NULL;
+  gslc_tsElem*        pCurElem = NULL;
+  int16_t             nCurType;
+  int16_t             nCurGroup;
+  bool                bCurSelected;
+  gslc_tsElemRef*     pFoundElemRef = NULL;
+
+  // Operate on current page
+  // TODO: Support other page layers
+  gslc_tsPage* pPage = pGui->apPageStack[GSLC_STACK_CUR];
+  if (pPage == NULL) {
+    return NULL; // No page added yet
+  }
+  
+  if (pGui == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "ElemXTogglebtnFindChecked";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL,FUNCSTR);
+    return NULL;
+  }
+
+  gslc_tsCollect* pCollect = &pPage->sCollect;
+  for (nCurInd=0;nCurInd<pCollect->nElemCnt;nCurInd++) {
+    // Fetch extended data
+    pCurElemRef   = &(pCollect->asElemRef[nCurInd]);
+    pCurElem      = gslc_GetElemFromRef(pGui,pCurElemRef);
+    nCurType      = pCurElem->nType;
+    // Only want to proceed if it is a togglebtn
+    if (nCurType != GSLC_TYPEX_TOGGLEBTN) {
+      continue;
+    }
+
+    nCurGroup     = pCurElem->nGroup;
+    bCurSelected   = gslc_ElemXTogglebtnGetState(pGui,pCurElemRef);
+
+    // If this is in a different group, ignore it
+    if (nCurGroup != nGroupId) {
+      continue;
+    }
+
+    // Did we find an element in the group that was checked?
+    if (bCurSelected) {
+      pFoundElemRef = pCurElemRef;
+      break;
+    }
+  } // nCurInd
+  return pFoundElemRef;
+}
+
+// ============================================================================

--- a/src/elem/XTogglebtn.h
+++ b/src/elem/XTogglebtn.h
@@ -1,0 +1,282 @@
+#ifndef _GUISLICE_EX_XTOGGLEBTN_H_
+#define _GUISLICE_EX_XTOGGLEBTN_H_
+
+#include "GUIslice.h"
+
+
+// =======================================================================
+// GUIslice library extension: Toggle button control
+// - Paul Conti
+// - Toggle button with Android and iOS like styles
+// - Based on Calvin Hass' Checkbox control
+// - https://www.impulseadventure.com/elec/guislice-gui.html
+// - https://github.com/ImpulseAdventure/GUIslice
+// =======================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2020 Calvin Hass and Paul Conti
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =======================================================================
+/// \file XTogglebtn.h
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// ============================================================================
+// Extended Element: Togglebtn
+// - Togglebtn 
+//   Acts much like a checkbox but with styles that are similar to iOS and 
+//   Android slider buttons.
+// ============================================================================
+
+// Define unique identifier for extended element type
+// - Select any number above GSLC_TYPE_BASE_EXTEND
+#define  GSLC_TYPEX_TOGGLEBTN GSLC_TYPE_BASE_EXTEND + 40
+
+// Extended element data structures
+// - These data structures are maintained in the gslc_tsElem
+//   structure via the pXData pointer
+
+/// Extended data for Togglebtn element
+typedef struct {
+  bool                        bOn;          ///< Indicates if button is ON or OFF
+  int16_t                     nMyPageId;    ///< We need to track our page in case of grouping elements 
+                                            ///< on a non current layer, like base layer
+  gslc_tsColor                colThumb;     ///< Color of thumb
+  gslc_tsColor                colOnState;   ///< Color of button in ON state
+  gslc_tsColor                colOffState;  ///< Color of button in OFF state
+  bool                        bCircular;    ///< Style of the toggle button circular or rectangular
+  GSLC_CB_TOUCH               pfunctUser;   ///< User's Callback event to say element has changed
+} gslc_tsXTogglebtn;
+
+
+///
+/// Create a Togglebtn button Element
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  pXData:      Ptr to extended element data structure
+/// \param[in]  rElem:       Rectangle coordinates defining togglebtn size
+/// \param[in]  colThumb:    Color of thumb
+/// \param[in]  colOnState:  Color to indicate on position
+/// \param[in]  colOffState: Color to indicate off position
+/// \param[in]  bCircular:   Style of the toggle button circular or rectangular
+/// \param[in]  bChecked:    Default state
+/// \param[in]  cbTouch:     Callback for touch events
+///
+/// \return Pointer to Element reference or NULL if failure
+///
+gslc_tsElemRef* gslc_ElemXTogglebtnCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t nPage,
+  gslc_tsXTogglebtn* pXData,gslc_tsRect rElem,
+  gslc_tsColor colThumb,gslc_tsColor colOnState,gslc_tsColor colOffState,
+  bool bCircular,bool bChecked,GSLC_CB_TOUCH cbTouch);
+
+
+///
+/// Get a Togglebtn element's current state
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+///
+/// \return Current state
+///
+bool gslc_ElemXTogglebtnGetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
+
+///
+/// Set a Togglebtn element's current state
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+/// \param[in]  bOn:    New state
+///
+/// \return none
+///
+void gslc_ElemXTogglebtnSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool bOn);
+
+///
+/// Toggle a Togglebtn element's current state
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  pElemRef:    Pointer to Element reference
+///
+/// \return none
+///
+void gslc_ElemXTogglebtnToggleState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef);
+
+///
+/// Draw a Togglebtn element on the screen
+/// - Called from gslc_ElemDraw()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element reference (typecast to gslc_tsElemRef*)
+/// \param[in]  eRedraw:     Redraw mode
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXTogglebtnDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw);
+
+///
+/// Handle touch events to Togglebtn element
+/// - Called from gslc_ElemSendEventTouch()
+///
+/// \param[in]  pvGui:       Void ptr to GUI (typecast to gslc_tsGui*)
+/// \param[in]  pvElemRef:   Void ptr to Element reference (typecast to gslc_tsElemRef*)
+/// \param[in]  eTouch:      Touch event type
+/// \param[in]  nRelX:       Touch X coord relative to element
+/// \param[in]  nRelY:       Touch Y coord relative to element
+///
+/// \return true if success, false otherwise
+///
+bool gslc_ElemXTogglebtnTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16_t nRelX,int16_t nRelY);
+
+///
+/// Find the togglebtn within a group that has been selected
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nGroupId:    Group ID to search
+///
+/// \return Element Ptr or NULL if none selected
+///
+gslc_tsElemRef* gslc_ElemXTogglebtnFindSelected(gslc_tsGui* pGui,int16_t nGroupId);
+
+// ============================================================================
+// ------------------------------------------------------------------------
+// Read-only element macros
+// ------------------------------------------------------------------------
+
+// Macro initializers for Read-Only Elements in Flash/PROGMEM
+//
+
+
+/// \def gslc_ElemXTogglebtnCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,nGroup,bRadio_,nStyle_,colCheck_,bChecked_)
+///
+/// Create a Togglebtn button Element
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  nElemId:     Element ID to assign (0..16383 or GSLC_ID_AUTO to autogen)
+/// \param[in]  nPage:       Page ID to attach element to
+/// \param[in]  nX:          X coordinate of element
+/// \param[in]  nY:          Y coordinate of element
+/// \param[in]  nW:          Width of element
+/// \param[in]  nH:          Height of element
+/// \param[in]  colThumb:    Color of thumb
+/// \param[in]  colOnState:  Color to indicate on position
+/// \param[in]  colOffState: Color to indicate off position
+/// \param[in]  bCircular:   Style of the toggle button circular or rectangular
+/// \param[in]  bChecked:    Default state
+/// \param[in]  cbTouch:     Callback for touch events
+///
+/// \return none
+///
+
+#if (GSLC_USE_PROGMEM)
+
+#define gslc_ElemXTogglebtnCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,colThumb_,colOnState_,colOffState_,bCircular_,bChecked_,cbTouch) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_CLICK_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXTogglebtn sTogglebtn##nElemId;                   \
+  sTogglebtn##nElemId.bOn = bChecked_;                            \
+  sTogglebtn##nElemId.nMyPageId = nPage;                          \
+  sTogglebtn##nElemId.colThumb = colThumb_;                       \
+  sTogglebtn##nElemId.colOnState = colOnState_;                   \
+  sTogglebtn##nElemId.colOffState = colOffState_;                 \
+  sTogglebtn##nElemId.bCircular = bCircular_;                     \
+  sTogglebtn##nElemId.pfunctUser = cbTouch;                       \
+  static const gslc_tsElem sElem##nElemId PROGMEM = {             \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_TOGGLEBTN,                                       \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      0,                                                          \
+      GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sTogglebtn##nElemId),                              \
+      NULL,                                                       \
+      &gslc_ElemXTogglebtnDraw,                                   \
+      &gslc_ElemXTogglebtnTouch,                                  \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_PROG | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+
+#else
+
+#define gslc_ElemXTogglebtnCreate_P(pGui,nElemId,nPage,nX,nY,nW,nH,colThumb_,colOnState_,colOffState_,bCircular_,bChecked_,cbTouch) \
+  static const uint8_t nFeatures##nElemId = GSLC_ELEM_FEA_VALID | \
+    GSLC_ELEM_FEA_GLOW_EN | GSLC_ELEM_FEA_CLICK_EN | GSLC_ELEM_FEA_FILL_EN; \
+  static gslc_tsXTogglebtn sTogglebtn##nElemId;                   \
+  sTogglebtn##nElemId.bOn = bChecked_;                            \
+  sTogglebtn##nElemId.nMyPageId = nPage;                          \
+  sTogglebtn##nElemId.colThumb = colThumb_;                       \
+  sTogglebtn##nElemId.colOnState = colOnState_;                   \
+  sTogglebtn##nElemId.colOffState = colOffState_;                 \
+  sTogglebtn##nElemId.bCircular = bCircular_;                     \
+  sTogglebtn##nElemId.pfunctUser = cbTouch;                       \
+  static const gslc_tsElem sElem##nElemId = {                     \
+      nElemId,                                                    \
+      nFeatures##nElemId,                                         \
+      GSLC_TYPEX_TOGGLEBTN,                                       \
+      (gslc_tsRect){nX,nY,nW,nH},                                 \
+      0,                                                          \
+      GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
+      NULL,                                                       \
+      NULL,                                                       \
+      0,                                                          \
+      (gslc_teTxtFlags)(GSLC_TXT_DEFAULT),                        \
+      GSLC_COL_WHITE,                                             \
+      GSLC_COL_WHITE,                                             \
+      GSLC_ALIGN_MID_MID,                                         \
+      0,                                                          \
+      0,                                                          \
+      NULL,                                                       \
+      (void*)(&sTogglebtn##nElemId),                              \
+      NULL,                                                       \
+      &gslc_ElemXTogglebtnDraw,                                   \
+      &gslc_ElemXTogglebtnTouch,                                  \
+      NULL,                                                       \
+  };                                                              \
+  gslc_ElemAdd(pGui,nPage,(gslc_tsElem*)&sElem##nElemId,          \
+    (gslc_teElemRefFlags)(GSLC_ELEMREF_SRC_PROG | GSLC_ELEMREF_VISIBLE | GSLC_ELEMREF_REDRAW_FULL));
+
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_EX_XTOGGLEBTN_H_


### PR DESCRIPTION
Added support for Android and Apple IOS Style Toggle Buttons.
elem/XTogglebtn.<h,c>
and two example files, one for RAM and one for Flash
examples/arduino/ex45_ard_togglebtn
examples/arduino_min/ex45_ardmin_togglebtn

If and when you merge I'll add support to the Builder.