### PR TITLE
Slider number range extension

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -592,7 +592,7 @@ void gslc_Update(gslc_tsGui* pGui)
   //   finger events may have occurred. If we only handle a single
   //   motion event per display update, then we may experience very
   //   lagging responsiveness from the controls.
-  // - Instead, we drain the even queue before proceeding on to the
+  // - Instead, we drain the event queue before proceeding on to the
   //   display update, giving rise to a much more responsive GUI.
   //   The maximum number of touch events that can be handled per
   //   main loop is defined by the GSLC_TOUCH_MAX_EVT config param.

--- a/src/elem/XSlider.c
+++ b/src/elem/XSlider.c
@@ -176,7 +176,7 @@ void gslc_ElemXSliderSetPos(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,int16_t nP
   int16_t           nPosOld;
   // Clip position
   if (nPos < pSlider->nPosMin) { nPos = pSlider->nPosMin; }
-  if (nPos > pSlider->nPosMax) { nPos = pSlider->nPosMax; }
+  else if (nPos > pSlider->nPosMax) { nPos = pSlider->nPosMax; }
   // Update
   nPosOld = pSlider->nPos;
   pSlider->nPos = nPos;
@@ -248,7 +248,7 @@ bool gslc_ElemXSliderDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
 
   // Range check on nPos
   if (nPos < nPosMin) { nPos = nPosMin; }
-  if (nPos > nPosMax) { nPos = nPosMax; }
+  else if (nPos > nPosMax) { nPos = nPosMax; }
 
   int16_t nX0,nY0,nX1,nY1,nXMid,nYMid;
   nX0 = pElem->rElem.x;

--- a/src/elem/XSlider.c
+++ b/src/elem/XSlider.c
@@ -272,8 +272,8 @@ bool gslc_ElemXSliderDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
   } else {
     nCtrlRng = (nY1-nMargin)-(nY0+nMargin);
   }
-  int16_t nCtrlPos  = (nPosOffset*nCtrlRng/nPosRng)+nMargin;
 
+  int16_t nCtrlPos  = (int16_t)((int32_t)nPosOffset * (int32_t)nCtrlRng / (int32_t)nPosRng) + nMargin;
 
   // Draw the background
   // - TODO: To reduce flicker on unbuffered displays, one could consider
@@ -289,7 +289,7 @@ bool gslc_ElemXSliderDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
     uint16_t  nTickInd;
     int16_t   nTickOffset;
     for (nTickInd=0;nTickInd<=nTickDiv;++nTickInd) {
-      nTickOffset = nTickInd * nCtrlRng / nTickDiv;
+      nTickOffset = (int16_t)((int32_t)nTickInd * (int32_t)nCtrlRng / (int32_t)nTickDiv);
       if (!bVert) {
         gslc_DrawLine(pGui,nX0+nMargin+ nTickOffset,nYMid,
                 nX0+nMargin + nTickOffset,nYMid+nTickLen,colTick);
@@ -457,9 +457,9 @@ bool gslc_ElemXSliderTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,int16
       // Calc new position
       nPosRng = pSlider->nPosMax - pSlider->nPosMin;
       if (!pSlider->bVert) {
-        nPos = (nRelX * nPosRng / pElem->rElem.w) + pSlider->nPosMin;
+        nPos = (int16_t)((int32_t)nRelX * (int32_t)nPosRng / (int32_t)pElem->rElem.w) + pSlider->nPosMin;
       } else {
-        nPos = (nRelY * nPosRng / pElem->rElem.h) + pSlider->nPosMin;
+        nPos = (int16_t)((int32_t)nRelY * (int32_t)nPosRng / (int32_t)pElem->rElem.h) + pSlider->nPosMin;
       }
     }
     // Update the slider

--- a/src/elem/XSlider.c
+++ b/src/elem/XSlider.c
@@ -288,7 +288,7 @@ bool gslc_ElemXSliderDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
   if (nTickDiv>=1) {
     uint16_t  nTickInd;
     int16_t   nTickOffset;
-    for (nTickInd=0;nTickInd<=nTickDiv;nTickInd++) {
+    for (nTickInd=0;nTickInd<=nTickDiv;++nTickInd) {
       nTickOffset = nTickInd * nCtrlRng / nTickDiv;
       if (!bVert) {
         gslc_DrawLine(pGui,nX0+nMargin+ nTickOffset,nYMid,

--- a/src/elem/XSlider.c
+++ b/src/elem/XSlider.c
@@ -264,6 +264,7 @@ bool gslc_ElemXSliderDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
   int16_t nPosOffset = nPos-nPosMin;
 
   // Provide some margin so thumb doesn't exceed control bounds
+  // TODO: Handle nCtrlRng <= 0
   int16_t nMargin   = nThumbSz;
   int16_t nCtrlRng;
   if (!bVert) {


### PR DESCRIPTION
I wanted to use a slider with values from 0 to 255 and a width of 256. This however lead to the following strange behaviour:
    - The slider marker could wrapped around at approx. the center of the slider and appeared to the left of the slider [outwards].
    - I could also move the slider marker to the right of the slider [outwards], while the slider value returned wrapped around to 0 [stayed positive].
These changes only affect the visuals.