### PR TITLE
Cleanup warnings

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -4452,7 +4452,6 @@ gslc_tsElemRef* gslc_CollectElemAdd(gslc_tsGui* pGui,gslc_tsCollect* pCollect,co
 
   uint16_t nElemInd;
   uint16_t nElemRefInd;
-  const gslc_tsElem* pElemRam = NULL; // Local element in RAM
 
   if ((eFlags & GSLC_ELEMREF_SRC) == GSLC_ELEMREF_SRC_RAM) {
 
@@ -4489,7 +4488,10 @@ gslc_tsElemRef* gslc_CollectElemAdd(gslc_tsGui* pGui,gslc_tsCollect* pCollect,co
     // - Pointer (pElem) links to an element stored in FLASH (must be declared statically)
 
     // Fetch a RAM copy of the FLASH element
-    pElemRam = pElem;
+    #if (GSLC_USE_PROGMEM) || defined(DBG_LOG) // Avoid unused variable warning
+    const gslc_tsElem* pElemRam = pElem; // Local element in RAM
+    #endif
+
     #if (GSLC_USE_PROGMEM)
     memcpy_P(&pGui->sElemTmpProg,pElem,sizeof(gslc_tsElem));
     pElemRam = &pGui->sElemTmpProg;

--- a/src/elem/XListbox.c
+++ b/src/elem/XListbox.c
@@ -377,7 +377,6 @@ bool gslc_ElemXListboxDeleteItemAt(gslc_tsGui* pGui, gslc_tsElemRef* pElemRef, u
   int8_t      nStrItemLen;
   char*       pBuf = NULL;
   uint16_t    nBufItemsPos = pListbox->nBufItemsPos;
-  uint16_t    nBufItemsMax = pListbox->nBufItemsMax;
 
 //  GSLC_DEBUG2_PRINT("Xlistbox:DeleteAt: %d\n", nDeletePos);
 //  debug_ElemXListboxDump(pGui, pElemRef);

--- a/src/elem/XRingGauge.c
+++ b/src/elem/XRingGauge.c
@@ -190,9 +190,9 @@ bool gslc_ElemXRingGaugeDraw(void* pvGui, void* pvElemRef, gslc_teRedrawType eRe
   // or a smaller, updated region (incremental redraw)
   bool bInc = (eRedraw == GSLC_REDRAW_INC) ? true : false;
 
-  int16_t nDrawStart;
-  int16_t nDrawVal;
-  int16_t nDrawEnd;
+  int16_t nDrawStart = 0;
+  int16_t nDrawVal = 0;
+  int16_t nDrawEnd = 0;
 
   bool bDrawActive = false;
   bool bDrawInactive = false;

--- a/src/elem/XSpinner.h
+++ b/src/elem/XSpinner.h
@@ -58,7 +58,7 @@ extern "C" {
 #define XSPINNER_COMP_CNT 3
 
 // Define the max string length to allocate for dynamic text elements
-#define XSPINNER_STR_LEN  6
+#define XSPINNER_STR_LEN  8
 
 // Define the status for GSLC_CB_INPUT callback
 #define XSPINNER_CB_STATE_UPDATE 3

--- a/src/elem/XTogglebtn.c
+++ b/src/elem/XTogglebtn.c
@@ -184,7 +184,6 @@ void gslc_ElemXTogglebtnSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool 
     int16_t           nCurId;
     gslc_tsElem*      pCurElem = NULL;
     gslc_tsElemRef*   pCurElemRef = NULL;
-    int16_t           nCurType;
     int16_t           nCurGroup;
 
     /* 
@@ -209,7 +208,6 @@ void gslc_ElemXTogglebtnSetState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,bool 
       // NOTE: Sorry but I have no idea what this FIXME is talking about - p conti
       // FIXME: Handle pCurElemRef->eElemFlags 
       nCurId        = pCurElem->nId;
-      nCurType      = pCurElem->nType;
 
       nCurGroup     = pCurElem->nGroup;
 
@@ -375,7 +373,6 @@ bool gslc_ElemXTogglebtnTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,in
 
   //gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
   bool  bStateOld = pTogglebtn->bOn;
-  bool  bGlowingOld = gslc_ElemGetGlow(pGui,pElemRef);
 
   switch(eTouch) {
 

--- a/src/elem/XTogglebtn.c
+++ b/src/elem/XTogglebtn.c
@@ -141,8 +141,6 @@ void gslc_ElemXTogglebtnSetStateHelp(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef,b
   gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
   if (!pTogglebtn) return;
 
-  gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
-
   // Update our data element
   bool  bStateOld = pTogglebtn->bOn;
   pTogglebtn->bOn = bOn;
@@ -257,12 +255,6 @@ void gslc_ElemXTogglebtnDrawCircularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gsl
 
   // Work out the sizes of the inner rectangles 
   gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
-  gslc_tsRect rText = {
-    rInner.x,
-    rInner.y,
-    rInner.w - rInner.h,
-    rInner.h
-  };
 
   // work out our circle positions
   uint16_t nRadius  = rInner.h / 2;
@@ -305,12 +297,6 @@ void gslc_ElemXTogglebtnDrawRectangularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,
     pElem->rElem.h
   };
   gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
-  gslc_tsRect rText = {
-    rInner.x,
-    rInner.y,
-    rInner.w - rInner.h,
-    rInner.h
-  };
 
   if (pTogglebtn->bOn) {
     gslc_DrawFillRect(pGui,rInner,pTogglebtn->colOnState);


### PR DESCRIPTION
Fix a number of warnings that may appear when enhanced compiler messaging enabled (eg. gcc)
