### PR TITLE
Added touch flip flags to TFT_eSPI driver.

### DIFF
--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -2132,8 +2132,8 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
   #if !defined(DRV_TOUCH_NONE)
     // Correct touch mapping according to current rotation mode
     pGui->nSwapXY = TOUCH_ROTATION_SWAPXY(pGui->nRotation);
-    pGui->nFlipX = TOUCH_ROTATION_FLIPX(pGui->nRotation);
-    pGui->nFlipY = TOUCH_ROTATION_FLIPY(pGui->nRotation);
+    pGui->nFlipX = TOUCH_ROTATION_FLIPX(pGui->nRotation) | ADATOUCH_FLIP_X;
+    pGui->nFlipY = TOUCH_ROTATION_FLIPY(pGui->nRotation) | ADATOUCH_FLIP_Y;
   #endif // !DRV_TOUCH_NONE
 
   // Mark the current page ask requiring redraw


### PR DESCRIPTION
I don't know if this is the right way to do this, but it is the way that works for me. I am creating this pull request knowing full well that you might come up with a better way. I need the touch to be rotated independent of the screen graphics and don't see a way to do one without the other. So adding these flags lets me rotate just the touch input.