### PR TITLE
#254 : ILI9225 does not handdle rounded rectangles

### DIFF
--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -10,7 +10,7 @@
 //
 // The MIT License
 //
-// Copyright 2016-2019 Calvin Hass
+// Copyright 2016-2020 Calvin Hass
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -59,11 +59,17 @@ extern "C" {
 #elif defined(DRV_TOUCH_ADA_FT6206)
   #define DRV_TOUCH_TYPE_EXTERNAL
   #define DRV_TOUCH_TYPE_CAP         // Capacitive
+#elif defined(DRV_TOUCH_ADA_FT5206)
+  #define DRV_TOUCH_TYPE_EXTERNAL
+  #define DRV_TOUCH_TYPE_CAP         // Capacitive
 #elif defined(DRV_TOUCH_ADA_SIMPLE)
   #define DRV_TOUCH_TYPE_EXTERNAL
   #define DRV_TOUCH_TYPE_RES         // Resistive
   #define DRV_TOUCH_TYPE_ANALOG      // Analog
 #elif defined(DRV_TOUCH_ADA_RA8875)
+  #define DRV_TOUCH_TYPE_EXTERNAL
+  #define DRV_TOUCH_TYPE_RES         // Resistive
+#elif defined(DRV_TOUCH_ADA_RA8875_SUMO)
   #define DRV_TOUCH_TYPE_EXTERNAL
   #define DRV_TOUCH_TYPE_RES         // Resistive
 #elif defined(DRV_TOUCH_XPT2046_STM)
@@ -106,6 +112,7 @@ extern "C" {
 #define DRV_HAS_DRAW_TRI_FRAME         1 ///< Support gslc_DrvDrawFrameTriangle()
 #define DRV_HAS_DRAW_TRI_FILL          1 ///< Support gslc_DrvDrawFillTriangle()
 #define DRV_HAS_DRAW_TEXT              1 ///< Support gslc_DrvDrawTxt()
+#define DRV_HAS_DRAW_BMP_MEM           0 ///< Support gslc_DrvDrawBmp24FromMem()
 
 #define DRV_OVERRIDE_TXT_ALIGN         0 ///< Driver provides text alignment
 
@@ -140,19 +147,30 @@ extern "C" {
   #define DRV_HAS_DRAW_TRI_FRAME         0
   #define DRV_HAS_DRAW_TRI_FILL          0
 
-#elif defined(DRV_DISP_ADAGFX_ILI9225_NK)
-  #undef DRV_HAS_DRAW_RECT_ROUND_FRAME
-  #undef DRV_HAS_DRAW_RECT_ROUND_FILL
-
-  #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
-  #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
-
 #elif defined(DRV_DISP_ADAGFX_RA8876)
   #undef DRV_HAS_DRAW_RECT_ROUND_FRAME
   #undef DRV_HAS_DRAW_RECT_ROUND_FILL
 
   #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
   #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
+
+#elif defined(DRV_DISP_ADAGFX_RA8876_GV)
+  #undef DRV_HAS_DRAW_RECT_ROUND_FRAME
+  #undef DRV_HAS_DRAW_RECT_ROUND_FILL
+
+  #define DRV_HAS_DRAW_RECT_ROUND_FRAME  0
+  #define DRV_HAS_DRAW_RECT_ROUND_FILL   0
+
+
+#elif defined(DRV_DISP_ADAGFX_ILI9225)
+  //Round rectangles not defined in ILI9225 (but it is in ILI9225_DUE)
+  #undef DRV_HAS_DRAW_RECT_ROUND_FRAME
+  #undef DRV_HAS_DRAW_RECT_ROUND_FILL
+
+#elif defined(DRV_DISP_ADAGFX_ILI9341)
+  // BLIT support in library
+  #undef  DRV_HAS_DRAW_BMP_MEM
+  #define DRV_HAS_DRAW_BMP_MEM           1
 #endif
 
 


### PR DESCRIPTION
ILI9225-due should be used insted of ILI9225 for rounded rectangles.