### PR TITLE
Toggle button rounded corners not rendering correctly issue 266

### DIFF
--- a/src/elem/XTogglebtn.c
+++ b/src/elem/XTogglebtn.c
@@ -252,9 +252,6 @@ void gslc_ElemXTogglebtnToggleState(gslc_tsGui* pGui,gslc_tsElemRef* pElemRef)
 
 void gslc_ElemXTogglebtnDrawCircularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gslc_tsXTogglebtn* pTogglebtn) 
 {
-  // frame enabled?
-  bool bFrameEn  = pElem->nFeatures & GSLC_ELEM_FEA_FRAME_EN;
-
   // Work out the sizes of the inner rectangles 
   gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
 
@@ -267,22 +264,14 @@ void gslc_ElemXTogglebtnDrawCircularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gsl
     
   if (pTogglebtn->bOn) {
     // draw our main body
-    gslc_DrawFillRoundRect(pGui,rInner,rInner.h,pTogglebtn->colOnState);
+    gslc_DrawFillRoundRect(pGui,rInner,nRadius,pTogglebtn->colOnState);
     // place thumb on left-hand side
     gslc_DrawFillCircle(pGui,nLeftX,nLeftY,nRadius-1,pTogglebtn->colThumb);
-    if (bFrameEn) {
-      gslc_DrawFrameRoundRect(pGui,pElem->rElem,pElem->rElem.h,pElem->colElemFrame);
-      gslc_DrawFrameCircle(pGui,nLeftX,nLeftY,nRadius,pElem->colElemFrame);
-    }
   } else {
     // draw our main body
-    gslc_DrawFillRoundRect(pGui,rInner,rInner.h,pTogglebtn->colOffState);
+    gslc_DrawFillRoundRect(pGui,rInner,nRadius,pTogglebtn->colOffState);
     // place thumb on right-hand side
-    gslc_DrawFillCircle(pGui,nRightX,nRightY,nRadius-1,pTogglebtn->colThumb);
-    if (bFrameEn) {
-      gslc_DrawFrameRoundRect(pGui,pElem->rElem,pElem->rElem.h,pElem->colElemFrame);
-      gslc_DrawFrameCircle(pGui,nRightX,nRightY,nRadius,pElem->colElemFrame);
-    }
+    gslc_DrawFillCircle(pGui,nRightX-1,nRightY,nRadius-1,pTogglebtn->colThumb);
   }
 }
 
@@ -338,6 +327,7 @@ bool gslc_ElemXTogglebtnDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedr
   }
 
   gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
+//  gslc_DrawFillRect(pGui,pElem->rElem,pElem->colElemFill);
  
   if (pTogglebtn->bCircular) {
     gslc_ElemXTogglebtnDrawCircularHelp(pGui, pElem, pTogglebtn);
@@ -375,9 +365,8 @@ bool gslc_ElemXTogglebtnTouch(void* pvGui,void* pvElemRef,gslc_teTouch eTouch,in
   gslc_tsXTogglebtn* pTogglebtn = (gslc_tsXTogglebtn*)gslc_GetXDataFromRef(pGui, pElemRef, GSLC_TYPEX_TOGGLEBTN, __LINE__);
   if (!pTogglebtn) return false;
 
-  //gslc_tsElem* pElem = gslc_GetElemFromRef(pGui,pElemRef);
   bool  bStateOld = pTogglebtn->bOn;
-
+  
   switch(eTouch) {
 
     case GSLC_TOUCH_UP_IN:


### PR DESCRIPTION
Turns out to be problem with TFT_eSPI and the ILI9341 driver.  Does not happen with Arduino Mega and ILI9341 or TFT_eSPI and HX8357.  The problem stems from an error in the code where raduis was not being used but somehow worked correctly on most drivers.
Paul--