### PR TITLE
fix to XTogglebtn not showing frame issue 275

### DIFF
--- a/src/elem/XTogglebtn.c
+++ b/src/elem/XTogglebtn.c
@@ -255,6 +255,9 @@ void gslc_ElemXTogglebtnDrawCircularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gsl
   // Work out the sizes of the inner rectangles 
   gslc_tsRect rInner = gslc_ExpandRect(pElem->rElem,-1,-1);
 
+  // frame enabled?
+  bool bFrameEn  = pElem->nFeatures & GSLC_ELEM_FEA_FRAME_EN;
+
   // work out our circle positions
   uint16_t nRadius  = rInner.h / 2;
   int16_t  nLeftX   = rInner.x + nRadius;
@@ -267,11 +270,23 @@ void gslc_ElemXTogglebtnDrawCircularHelp(gslc_tsGui* pGui,gslc_tsElem* pElem,gsl
     gslc_DrawFillRoundRect(pGui,rInner,nRadius,pTogglebtn->colOnState);
     // place thumb on right-hand side
     gslc_DrawFillCircle(pGui,nRightX-1,nRightY,nRadius-1,pTogglebtn->colThumb);
+    if (bFrameEn) {
+// ON HX8357 and ILI9341 with TFT_eSPI if we do rounded rect frame we get 
+// something that looks like two reversed parenthesis )button( around button 
+      gslc_DrawFrameCircle(pGui,nRightX,nRightY,nRadius-1,pElem->colElemFrame);
+//      gslc_DrawFrameRoundRect(pGui,pElem->rElem,pElem->rElem.h,pElem->colElemFrame);
+      gslc_DrawFrameRoundRect(pGui,rInner,nRadius,pElem->colElemFrame);
+    }
   } else {
     // draw our main body
     gslc_DrawFillRoundRect(pGui,rInner,nRadius,pTogglebtn->colOffState);
     // place thumb on left-hand side
     gslc_DrawFillCircle(pGui,nLeftX,nLeftY,nRadius-1,pTogglebtn->colThumb);
+    if (bFrameEn) {
+      gslc_DrawFrameCircle(pGui,nLeftX,nLeftY,nRadius-1,pElem->colElemFrame);
+//      gslc_DrawFrameRoundRect(pGui,,pElem->rElem.h,pElem->colElemFrame);
+      gslc_DrawFrameRoundRect(pGui,rInner,nRadius,pElem->colElemFrame);
+    }
   }
 }
 


### PR DESCRIPTION
Frame support had been removed due to issue `266` but further examination showed the problem to be sizing of the button's frame.  This pull will restore the frame support.  This fixes issue `#275`.   