### PR TITLE
Fix GFX font TxtOffsetX per #277

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -2979,7 +2979,7 @@ void gslc_DrawTxtBase(gslc_tsGui* pGui, char* pStrBuf,gslc_tsRect rTxt,gslc_tsFo
     // Now correct for offset from text bounds
     // - This is used by the driver (such as Adafruit-GFX) to provide an
     //   adjustment for baseline height, etc.
-    nTxtX += nTxtOffsetX;
+    nTxtX -= nTxtOffsetX;
     nTxtY -= nTxtOffsetY;
 
     // Call the driver text rendering routine

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.15.0.10"
+#define GUISLICE_VER "0.15.0.11"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
@Pconti31 identified a bug in the text alignment for GFX fonts in #277 
- This PR addresses his proposed fix
