### PR TITLE
Add fast optimized clipping redraw for TFT_eSPI

### DIFF
--- a/configs/esp-shld-adafruit_24_feather_touch-espi.h
+++ b/configs/esp-shld-adafruit_24_feather_touch-espi.h
@@ -74,6 +74,9 @@ extern "C" {
   #define DRV_DISP_TFT_ESPI         // bodmer/TFT_eSPI
   #define DRV_TOUCH_ADA_STMPE610    // Adafruit STMPE610 touch driver
 
+  // Recent versions of TFT_eSPI support additional functionality:
+  // - setViewport() in v2.3.0: enhanced redraw performance
+  //#define DRV_DISP_TFT_ESPI_HAS_SETVIEWPORT // Uncomment if TFT_eSPI v2.3.0 onwards
 
   // -----------------------------------------------------------------------------
   // SECTION 2: Pinout

--- a/configs/esp-shld-adafruit_24_feather_touch-espi.h
+++ b/configs/esp-shld-adafruit_24_feather_touch-espi.h
@@ -74,9 +74,6 @@ extern "C" {
   #define DRV_DISP_TFT_ESPI         // bodmer/TFT_eSPI
   #define DRV_TOUCH_ADA_STMPE610    // Adafruit STMPE610 touch driver
 
-  // Recent versions of TFT_eSPI support additional functionality:
-  // - setViewport() in v2.3.0: enhanced redraw performance
-  //#define DRV_DISP_TFT_ESPI_HAS_SETVIEWPORT // Uncomment if TFT_eSPI v2.3.0 onwards
 
   // -----------------------------------------------------------------------------
   // SECTION 2: Pinout

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -332,7 +332,13 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
     pDriver->rClipRect = *pRect;
   }
 
-  // TODO: For ILI9341, perhaps we can leverage m_disp.setAddrWindow(x0, y0, x1, y1)?
+  // Rendering within clipping region is only available
+  // with the inclusion of https://github.com/ImpulseAdventure/TFT_eSPI/tree/add_setClipRect
+  // which may be integrated into TFT_eSPI in the future
+  #if defined(DRV_DISP_TFT_ESPI_HAS_CLIPRECT)
+    m_disp.setClipRect(pDriver->rClipRect.x,pDriver->rClipRect.y,pDriver->rClipRect.w,pDriver->rClipRect.h);
+  #endif
+
   return true;
 }
 

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -332,11 +332,15 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
     pDriver->rClipRect = *pRect;
   }
 
-  // Rendering within clipping region is only available
-  // with the inclusion of https://github.com/ImpulseAdventure/TFT_eSPI/tree/add_setClipRect
-  // which may be integrated into TFT_eSPI in the future
-  #if defined(DRV_DISP_TFT_ESPI_HAS_CLIPRECT)
-    m_disp.setClipRect(pDriver->rClipRect.x,pDriver->rClipRect.y,pDriver->rClipRect.w,pDriver->rClipRect.h);
+  // Rendering within clipping regions is provided by TFT_eSPI's
+  // setViewport() API. Enabling this functionality provides
+  // greatly enhanced redraw performance when updating the
+  // entire page.
+  //
+  // NOTE: This function is only present in recent releases
+  //       of TFT_eSPI (>= v2.3.0)
+  #if defined(DRV_DISP_TFT_ESPI_HAS_SETVIEWPORT)
+    m_disp.setViewport(pDriver->rClipRect.x,pDriver->rClipRect.y,pDriver->rClipRect.w,pDriver->rClipRect.h,false);
   #endif
 
   return true;

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -336,10 +336,9 @@ bool gslc_DrvSetClipRect(gslc_tsGui* pGui,gslc_tsRect* pRect)
   // setViewport() API. Enabling this functionality provides
   // greatly enhanced redraw performance when updating the
   // entire page.
-  //
-  // NOTE: This function is only present in recent releases
-  //       of TFT_eSPI (>= v2.3.0)
-  #if defined(DRV_DISP_TFT_ESPI_HAS_SETVIEWPORT)
+  // The setViewport() API is only available in recent versions of
+  // TFT_eSPI (v2.3.2+).
+  #if (TFT_ESPI_FEATURES & 0x0001) // Bit 0 = Viewport capability
     m_disp.setViewport(pDriver->rClipRect.x,pDriver->rClipRect.y,pDriver->rClipRect.w,pDriver->rClipRect.h,false);
   #endif
 

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.15.0.11"
+#define GUISLICE_VER "0.15.0.12"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
Addressing #274 -- this enhancement takes advantage of the new viewport functionality within TFT_eSPI.
The enhancement enables redraw events within the TFT_eSPI display driver to utilize optimized clipping regions.
The result of this enhancement is very fast control redraw.

Note that this feature will only be activated if TFT_eSPI version v2.3.2 (or greater) has been installed (not yet available via Arduino IDE library manager, but is available directly from the [bodmer/TFT_eSPI](https://github.com/Bodmer/TFT_eSPI)'s latest repository). Big thanks to @bodmer for integrating this change in TFT_eSPI!
