### PR TITLE
Add support for ILI9488_JB

### DIFF
--- a/configs/ard-adagfx-ili9488-notouch.h
+++ b/configs/ard-adagfx-ili9488-notouch.h
@@ -1,0 +1,207 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration) for:
+//   - CPU:     Arduino UNO / MEGA / etc
+//   - Display: ILI9488
+//   - Touch:   None
+//   - Wiring:  Custom breakout
+//              - Pinout:
+//
+//   - Example display:
+//     -
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a breakout board, customization
+//   of the Pinout in SECTION 2 will be required to match your display.
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX             // Adafruit-GFX library
+  #define DRV_DISP_ADAGFX_ILI9488_JB  // jarretburkett/ILI9488
+  #define DRV_TOUCH_NONE              // No touch enabled
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For shields, the following pinouts are typically hardcoded
+  #define ADAGFX_PIN_CS       10    // Display chip select
+  #define ADAGFX_PIN_DC       9     // Display SPI data/command
+  #define ADAGFX_PIN_RST      0     // Display Reset
+
+  // Display interface type
+  #define ADAGFX_SPI_HW       1	    // Display uses SPI interface: 1=hardware 0=software
+
+  // Display interface software SPI
+  // - Hardware SPI: the following definitions are unused
+  // - Software SPI: the following pins need to be defined
+  #define ADAGFX_PIN_MOSI     11
+  #define ADAGFX_PIN_MISO     12
+  #define ADAGFX_PIN_CLK      13
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default: MAGENTA)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/configs/ard-shld-eastrising_35_ili9488_cap.h
+++ b/configs/ard-shld-eastrising_35_ili9488_cap.h
@@ -1,0 +1,220 @@
+#ifndef _GUISLICE_CONFIG_ARD_H_
+#define _GUISLICE_CONFIG_ARD_H_
+
+// =============================================================================
+// GUIslice library (example user configuration) for:
+//   - CPU:     Arduino MEGA / Due
+//   - Display: ILI9488
+//   - Touch:   FT6236 (Capacitive)
+//   - Wiring:  EastRising Arduino shield (ER-TFTM035-6-4123) with SPI
+//
+//   - Example display:
+//     - EastRising 3.5" TFT Arduino Touch Shield w/ ILI9488 (ER-TFTM035-6)
+//
+// DIRECTIONS:
+// - To use this example configuration, include in "GUIslice_config.h"
+//
+// WIRING:
+// - As this config file is designed for a breakout board, customization
+//   of the Pinout in SECTION 2 will be required to match your display.
+//
+// =============================================================================
+// - Calvin Hass
+// - https://github.com/ImpulseAdventure/GUIslice
+// =============================================================================
+//
+// The MIT License
+//
+// Copyright 2016-2019 Calvin Hass
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+// \file GUIslice_config_ard.h
+
+// =============================================================================
+// User Configuration
+// - This file can be modified by the user to match the
+//   intended target configuration
+// =============================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+
+  // =============================================================================
+  // USER DEFINED CONFIGURATION
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // SECTION 1: Device Mode Selection
+  // - The following defines the display and touch drivers
+  //   and should not require modifications for this example config
+  // -----------------------------------------------------------------------------
+  #define DRV_DISP_ADAGFX             // Adafruit-GFX library
+  #define DRV_DISP_ADAGFX_ILI9488_JB  // jarretburkett/ILI9488
+  #define DRV_TOUCH_ADA_FT6206        // Adafruit FT6206 touch driver
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 2: Pinout
+  // -----------------------------------------------------------------------------
+
+  // For shields, the following pinouts are typically hardcoded
+  #define ADAGFX_PIN_CS       10    // Display chip select
+  #define ADAGFX_PIN_DC       9     // Display SPI data/command
+  #define ADAGFX_PIN_RST      0     // Display Reset
+
+  // Display interface type
+  #define ADAGFX_SPI_HW       1	    // Display uses SPI interface: 1=hardware 0=software
+
+  // Display interface software SPI
+  // - Hardware SPI: the following definitions are unused
+  // - Software SPI: the following pins need to be defined
+  #define ADAGFX_PIN_MOSI     11
+  #define ADAGFX_PIN_MISO     12
+  #define ADAGFX_PIN_CLK      13
+
+  // SD Card
+  #define ADAGFX_PIN_SDCS     4     // SD card chip select (if GSLC_SD_EN=1)
+
+
+
+  // -----------------------------------------------------------------------------
+  // SECTION 3: Orientation
+  // -----------------------------------------------------------------------------
+
+  // Set Default rotation of the display
+  // - Values 0,1,2,3. Rotation is clockwise
+  #define GSLC_ROTATE     1
+
+  // -----------------------------------------------------------------------------
+  // SECTION 4: Touch Handling
+  // - Documentation for configuring touch support can be found at:
+  //   https://github.com/ImpulseAdventure/GUIslice/wiki/Configure-Touch-Support
+  // -----------------------------------------------------------------------------
+
+
+
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+  // SECTION 4D: Additional touch configuration
+  // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
+
+  // Touch sensitivity for DRV_TOUCH_FT6206 (capacitive touch)
+  #define ADATOUCH_SENSITIVITY 40
+
+  // -----------------------------------------------------------------------------
+  // SECTION 5: Diagnostics
+  // -----------------------------------------------------------------------------
+
+  // Error reporting
+  // - Set DEBUG_ERR to >0 to enable error reporting via the Serial connection
+  // - Enabling DEBUG_ERR increases FLASH memory consumption which may be
+  //   limited on the baseline Arduino (ATmega328P) devices.
+  //   - DEBUG_ERR 0 = Disable all error messaging
+  //   - DEBUG_ERR 1 = Enable critical error messaging (eg. init)
+  //   - DEBUG_ERR 2 = Enable verbose error messaging (eg. bad parameters, etc.)
+  // - For baseline Arduino UNO, recommended to disable this after one has
+  //   confirmed basic operation of the library is successful.
+  #define DEBUG_ERR               1   // 1,2 to enable, 0 to disable
+
+  // Debug initialization message
+  // - By default, GUIslice outputs a message in DEBUG_ERR mode
+  //   to indicate the initialization status, even during success.
+  // - To disable the messages during successful initialization,
+  //   uncomment the following line.
+  //#define INIT_MSG_DISABLE
+
+  // -----------------------------------------------------------------------------
+  // SECTION 6: Optional Features
+  // -----------------------------------------------------------------------------
+
+  // Enable of optional features
+  // - For memory constrained devices such as Arduino, it is best to
+  //   set the following features to 0 (to disable) unless they are
+  //   required.
+  #define GSLC_FEATURE_COMPOUND       0   // Compound elements (eg. XSelNum)
+  #define GSLC_FEATURE_XTEXTBOX_EMBED 0   // XTextbox control with embedded color
+  #define GSLC_FEATURE_INPUT          0   // Keyboard / GPIO input control
+
+  // Enable support for SD card
+  // - Set to 1 to enable, 0 to disable
+  // - Note that the inclusion of the SD library consumes considerable
+  //   RAM and flash memory which could be problematic for Arduino models
+  //   with limited resources.
+  #define GSLC_SD_EN    0
+
+
+  // =============================================================================
+  // SECTION 10: INTERNAL CONFIGURATION
+  // - The following settings should not require modification by users
+  // =============================================================================
+
+  // -----------------------------------------------------------------------------
+  // Touch Handling
+  // -----------------------------------------------------------------------------
+
+  // Define the maximum number of touch events that are handled
+  // per gslc_Update() call. Normally this can be set to 1 but certain
+  // displays may require a greater value (eg. 30) in order to increase
+  // responsiveness of the touch functionality.
+  #define GSLC_TOUCH_MAX_EVT    1
+
+  // -----------------------------------------------------------------------------
+  // Misc
+  // -----------------------------------------------------------------------------
+
+  // Define buffer size for loading images from SD
+  // - A larger buffer will be faster but at the cost of RAM
+  #define GSLC_SD_BUFFPIXEL   50
+
+  // Enable support for graphics clipping (DrvSetClipRect)
+  // - Note that this will impact performance of drawing graphics primitives
+  #define GSLC_CLIP_EN 1
+
+  // Enable for bitmap transparency and definition of color to use
+  #define GSLC_BMP_TRANS_EN     1               // 1 = enabled, 0 = disabled
+  #define GSLC_BMP_TRANS_RGB    0xFF,0x00,0xFF  // RGB color (default: MAGENTA)
+
+  #define GSLC_USE_FLOAT        0   // 1=Use floating pt library, 0=Fixed-point lookup tables
+
+  #define GSLC_DEV_TOUCH ""
+  #define GSLC_USE_PROGMEM      1
+
+  #define GSLC_LOCAL_STR        0   // 1=Use local strings (in element array), 0=External
+  #define GSLC_LOCAL_STR_LEN    30  // Max string length of text elements
+
+  // -----------------------------------------------------------------------------
+  // Debug diagnostic modes
+  // -----------------------------------------------------------------------------
+  // - Uncomment any of the following to enable specific debug modes
+  //#define DBG_LOG           // Enable debugging log output
+  //#define DBG_TOUCH         // Enable debugging of touch-presses
+  //#define DBG_FRAME_RATE    // Enable diagnostic frame rate reporting
+  //#define DBG_DRAW_IMM      // Enable immediate rendering of drawing primitives
+  //#define DBG_DRIVER        // Enable graphics driver debug reporting
+
+
+  // =============================================================================
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GUISLICE_CONFIG_ARD_H_

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -74,6 +74,12 @@
     // https://github.com/PaulStoffregen/ILI9341_t3
     #include <ILI9341_t3.h>
     #include <SPI.h>
+  #elif defined(DRV_DISP_ADAGFX_ILI9488_JB)
+    #include <ILI9488.h>
+    #if (GSLC_SD_EN)
+      #include <SD.h>   // Include support for SD card access
+    #endif
+    #include <SPI.h>
   #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)
     // https://github.com/marekburiak/ILI9341_due
     #include <ILI9341_due.h>
@@ -281,6 +287,16 @@ extern "C" {
   #else
     const char* m_acDrvDisp = "ADA_ILI9341_STM(SPI-SW)";
     Adafruit_ILI9341_STM m_disp = Adafruit_ILI9341_STM(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_MOSI, ADAGFX_PIN_CLK, ADAGFX_PIN_RST, ADAGFX_PIN_MISO);
+  #endif
+
+// ------------------------------------------------------------------------
+#elif defined(DRV_DISP_ADAGFX_ILI9488_JB)
+  #if (ADAGFX_SPI_HW) // Use hardware SPI or software SPI (with custom pins)
+    const char* m_acDrvDisp = "ILI9348_JB(SPI-HW)";
+    ILI9488 m_disp = ILI9488(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_RST);
+  #else
+    const char* m_acDrvDisp = "ILI9488_JB(SPI-SW)";
+    ILI9488 m_disp = ILI9488(ADAGFX_PIN_CS, ADAGFX_PIN_DC, ADAGFX_PIN_MOSI, ADAGFX_PIN_CLK, ADAGFX_PIN_RST, ADAGFX_PIN_MISO);
   #endif
 
 // ------------------------------------------------------------------------
@@ -610,6 +626,9 @@ bool gslc_DrvInit(gslc_tsGui* pGui)
     #elif defined(DRV_DISP_ADAGFX_ILI9341_T3)
       m_disp.begin();
 
+    #elif defined(DRV_DISP_ADAGFX_ILI9488_JB)
+      m_disp.begin();
+	  
     #elif defined(DRV_DISP_ADAGFX_SSD1306)
       m_disp.begin(SSD1306_SWITCHCAPVCC);
 
@@ -2948,6 +2967,18 @@ bool gslc_DrvRotate(gslc_tsGui* pGui, uint8_t nRotation)
     } else {
       pGui->nDispW = ILI9341_TFTHEIGHT;
       pGui->nDispH = ILI9341_TFTWIDTH;
+    }
+
+  #elif defined(DRV_DISP_ADAGFX_ILI9488_JB)
+    pGui->nDisp0W = ILI9488_TFTWIDTH;
+    pGui->nDisp0H = ILI9488_TFTHEIGHT;
+    m_disp.setRotation(pGui->nRotation);
+    if (!bSwap) {
+      pGui->nDispW = ILI9488_TFTWIDTH;
+      pGui->nDispH = ILI9488_TFTHEIGHT;
+    } else {
+      pGui->nDispW = ILI9488_TFTHEIGHT;
+      pGui->nDispH = ILI9488_TFTWIDTH;
     }
 
   #elif defined(DRV_DISP_ADAGFX_ILI9341_DUE_MB)

--- a/src/GUIslice_version.h
+++ b/src/GUIslice_version.h
@@ -36,7 +36,7 @@
 // Define current release (X.Y.Z) & build number
 // =======================================================================
 
-#define GUISLICE_VER "0.16.0.5"
+#define GUISLICE_VER "0.16.0.6"
 
 #endif // _GUISLICE_VERSION_H_
 


### PR DESCRIPTION
- Adds support for https://github.com/jaretburkett/ILI9488
- This can be used to drive the EastRising 3.5" display (ER-TFTM035)
