### PR TITLE
Fix random phantom touches

### DIFF
--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -1273,7 +1273,7 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pn
     uint8_t nSamples = 5;
     uint8_t nSamplesValid = 0;
     while (nSamples--) {
-      if (TFT_eSPI_validTouch(&nRawX, &nRawY, 20)) nSamplesValid++;
+      if (TFT_eSPI_validTouch(&nRawX, &nRawY, ADATOUCH_PRESS_MIN)) nSamplesValid++;
     }
     if (nSamplesValid < 1) {
       nRawPress = 0; // Invalidate the reading


### PR DESCRIPTION
There's an error in the parameters passed to the `TFT_eSPI_validTouch` function which results in some invalid ("phantom") touches if one sets `ADATOUCH_PRESS_MIN` > 20.

The `treshold` parameter was set to `20` instead of the `ADATOUCH_PRESS_MIN` value, which may be set by the user and has [default values set to e.g. 200](https://github.com/kinafu/GUIslice/commit/1f2ba7e62a985cb1b51e570a6a9313fe40863b3b#diff-0b72889c9886978253162249270bea6643efe2658c2393a1b17da7525a65d1fcR144).