### PR TITLE
docs: fix simple typo, secuence -> sequence

### DIFF
--- a/examples/arduino/ex21_ard_input_pin/EasyButton.cpp
+++ b/examples/arduino/ex21_ard_input_pin/EasyButton.cpp
@@ -117,7 +117,7 @@ bool EasyButton::read() {
 				_short_press_count = 0;
 				_first_press_time = 0;
 			}
-			// if secuence timeout, reset short presses counters.
+			// if sequence timeout, reset short presses counters.
 			else if (_press_sequence_duration <= (read_started_ms - _first_press_time)) {
 				_short_press_count = 0;
 				_first_press_time = 0;


### PR DESCRIPTION
There is a small typo in examples/arduino/ex21_ard_input_pin/EasyButton.cpp.

Should read `sequence` rather than `secuence`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md