### PR TITLE
Add support for capacitive display calibration

### DIFF
--- a/examples/arduino/diag_ard_touch_test/diag_ard_touch_test.ino
+++ b/examples/arduino/diag_ard_touch_test/diag_ard_touch_test.ino
@@ -396,7 +396,7 @@ void setup()
     GSLC_DEBUG_PRINT("\n=== Touch Testing ===\n\n", "");
   #endif
 
-  #if defined(DRV_TOUCH_TYPE_RES)
+  #if defined(DRV_TOUCH_CALIB)
     // Reset to calibration defaults from configuration
     m_nTouchCalXMin = ADATOUCH_X_MIN;
     m_nTouchCalXMax = ADATOUCH_X_MAX;
@@ -407,7 +407,7 @@ void setup()
     #else
       m_bRemapYX = false;
     #endif
-    GSLC_DEBUG_PRINT("CALIB: Config defaults: XMin=%u XMax=%u YMin=%u YMax=%u RemapYX=%u\n",
+    GSLC_DEBUG_PRINT("CALIB: Config defaults: XMin=%d XMax=%d YMin=%d YMax=%d RemapYX=%u\n",
       ADATOUCH_X_MIN, ADATOUCH_X_MAX, ADATOUCH_Y_MIN, ADATOUCH_Y_MAX,m_bRemapYX);
 
     #if defined(DRV_DISP_ADAGFX_MCUFRIEND)
@@ -416,7 +416,7 @@ void setup()
       GSLC_DEBUG_PRINT("%s ", m_acTxt);
     #endif
 
-  #endif // DRV_TOUCH_TYPE_RES
+  #endif // DRV_TOUCH_CALIB
   GSLC_DEBUG_PRINT("\n", "");
 }
 

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -729,10 +729,10 @@ typedef struct {
     uint8_t           nFlipX;          ///< Adafruit GFX Touch Flip x axis
     uint8_t           nFlipY;          ///< Adafruit GFX Touch Flip x axis
     // Calibration for resistive touch displays
-    uint16_t          nTouchCalXMin;   ///< Calibration X minimum reading
-    uint16_t          nTouchCalXMax;   ///< Calibration X maximum reading
-    uint16_t          nTouchCalYMin;   ///< Calibration Y minimum reading
-    uint16_t          nTouchCalYMax;   ///< Calibration Y maximum reading
+    int16_t           nTouchCalXMin;   ///< Calibration X minimum reading
+    int16_t           nTouchCalXMax;   ///< Calibration X maximum reading
+    int16_t           nTouchCalYMin;   ///< Calibration Y minimum reading
+    int16_t           nTouchCalYMax;   ///< Calibration Y maximum reading
   #endif
 
   gslc_tsFont*        asFont;           ///< Collection of loaded fonts

--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -2277,12 +2277,12 @@ bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
   (void)acDev; // Unused
 
   // Capture default calibration settings for resistive displays
-  #if defined(DRV_TOUCH_TYPE_RES)
+  #if defined(DRV_TOUCH_CALIB)
     pGui->nTouchCalXMin = ADATOUCH_X_MIN;
     pGui->nTouchCalXMax = ADATOUCH_X_MAX;
     pGui->nTouchCalYMin = ADATOUCH_Y_MIN;
     pGui->nTouchCalYMax = ADATOUCH_Y_MAX;
-  #endif // DRV_TOUCH_TYPE_RES
+  #endif // DRV_TOUCH_CALIB
 
   // Support touch controllers with swapped X & Y
   #if defined(ADATOUCH_REMAP_YX)
@@ -2925,7 +2925,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     nInputY = nRawY;
 
     // For resistive displays, perform constraint and scaling
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       if (pGui->bTouchRemapEn) {
         // Perform scaling from input to output
         // - Calibration done in native orientation (GSLC_ROTATE=0)
@@ -2953,14 +2953,14 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
       // No scaling from input to output
       nOutputX = nInputX;
       nOutputY = nInputY;
-    #endif  // DRV_TOUCH_TYPE_RES
+    #endif  // DRV_TOUCH_CALIB
   
     #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT("DBG: PreRotate: x=%u y=%u\n", nOutputX, nOutputY);
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       GSLC_DEBUG_PRINT("DBG: RotateCfg: remap=%u nSwapXY=%u nFlipX=%u nFlipY=%u\n",
         pGui->bTouchRemapEn,pGui->nSwapXY,pGui->nFlipX,pGui->nFlipY);
-    #endif // DRV_TOUCH_TYPE_RES
+    #endif // DRV_TOUCH_CALIB
     #endif // DBG_TOUCH
 
     // Perform remapping due to current orientation

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -97,6 +97,22 @@ extern "C" {
   #define DRV_TOUCH_CALIB
 #endif
 
+#if defined(DRV_TOUCH_CALIB)
+  // Ensure calibration settings are present in the config file
+  #if !defined(ADATOUCH_X_MIN)
+    // We didn't locate the calibration settings, so provide some
+    // temporary defaults. This typically only occurs if user has
+    // decided to force calibration on a capacitive display by
+    // adding DRV_TOUCH_CALIB, but hasn't yet added the calibration
+    // settings (ADATOUCH_X/Y_MIN/MAX) from the calibration sketch yet.
+    #warning Calibration settings (ADATOUCH_X/Y_MIN/MAX) need to be added to config. Using defaults.
+    #define ADATOUCH_X_MIN 0
+    #define ADATOUCH_X_MAX 4000
+    #define ADATOUCH_Y_MIN 0
+    #define ADATOUCH_Y_MAX 4000
+    #define ADATOUCH_REMAP_YX 0
+  #endif // ADATOUCH_X_MIN
+#endif // DRV_TOUCH_CALIB
 
 // =======================================================================
 // API support definitions

--- a/src/GUIslice_drv_adagfx.h
+++ b/src/GUIslice_drv_adagfx.h
@@ -89,6 +89,14 @@ extern "C" {
 #elif defined(DRV_TOUCH_NONE)
 #endif // DRV_TOUCH_*
 
+// Determine if calibration required
+// - Enable for resistive displays
+// - User config can also enable for capacitive displays by adding:
+//   #define DRV_TOUCH_CALIB
+#if defined(DRV_TOUCH_TYPE_RES)
+  #define DRV_TOUCH_CALIB
+#endif
+
 
 // =======================================================================
 // API support definitions

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -1204,12 +1204,12 @@ bool gslc_DrvInitTouch(gslc_tsGui* pGui, const char* acDev) {
   #endif
 
   // Load calibration settings for resistive displays from config
-  #if defined(DRV_TOUCH_TYPE_RES)
+  #if defined(DRV_TOUCH_CALIB)
     pGui->nTouchCalXMin = ADATOUCH_X_MIN;
     pGui->nTouchCalXMax = ADATOUCH_X_MAX;
     pGui->nTouchCalYMin = ADATOUCH_Y_MIN;
     pGui->nTouchCalYMax = ADATOUCH_Y_MAX;
-  #endif // DRV_TOUCH_TYPE_RES
+  #endif // DRV_TOUCH_CALIB
 
   // Support touch controllers with swapped X & Y
   #if defined(ADATOUCH_REMAP_YX)
@@ -1339,7 +1339,7 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pn
     nInputY = nRawY;
 
     // For resistive displays, perform constraint and scaling
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       if (pGui->bTouchRemapEn) {
         // Perform scaling from input to output
         // - Calibration done in native orientation (GSLC_ROTATE=0)
@@ -1378,7 +1378,7 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pn
       // No scaling from input to output
       nOutputX = nInputX;
       nOutputY = nInputY;
-    #endif  // DRV_TOUCH_TYPE_RES
+    #endif  // DRV_TOUCH_CALIB
   
     #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT("DBG: PreRotate: x=%u y=%u\n", nOutputX, nOutputY);
@@ -1571,12 +1571,12 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui, int16_t* pnX, int16_t* pnY, uint16_t* pn
 bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
 
   // Capture default calibration settings for resistive displays
-  #if defined(DRV_TOUCH_TYPE_RES)
+  #if defined(DRV_TOUCH_CALIB)
     pGui->nTouchCalXMin = ADATOUCH_X_MIN;
     pGui->nTouchCalXMax = ADATOUCH_X_MAX;
     pGui->nTouchCalYMin = ADATOUCH_Y_MIN;
     pGui->nTouchCalYMax = ADATOUCH_Y_MAX;
-  #endif // DRV_TOUCH_TYPE_RES
+  #endif // DRV_TOUCH_CALIB
 
   // Support touch controllers with swapped X & Y
   #if defined(ADATOUCH_REMAP_YX)
@@ -2017,7 +2017,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     nInputY = nRawY;
 
     // For resistive displays, perform constraint and scaling
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       if (pGui->bTouchRemapEn) {
         // Perform scaling from input to output
         // - Calibration done in native orientation (GSLC_ROTATE=0)
@@ -2045,14 +2045,14 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
       // No scaling from input to output
       nOutputX = nInputX;
       nOutputY = nInputY;
-    #endif  // DRV_TOUCH_TYPE_RES
+    #endif  // DRV_TOUCH_CALIB
   
     #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT("DBG: PreRotate: x=%u y=%u\n", nOutputX, nOutputY);
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       GSLC_DEBUG_PRINT("DBG: RotateCfg: remap=%u nSwapXY=%u nFlipX=%u nFlipY=%u\n",
         pGui->bTouchRemapEn,pGui->nSwapXY,pGui->nFlipX,pGui->nFlipY);
-    #endif // DRV_TOUCH_TYPE_RES
+    #endif // DRV_TOUCH_CALIB
     #endif // DBG_TOUCH
 
     // Perform remapping due to current orientation

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -79,6 +79,14 @@ extern "C" {
 #elif defined(DRV_TOUCH_NONE)
 #endif // DRV_TOUCH_*
 
+// Determine if calibration required
+// - Enable for resistive displays
+// - User config can also enable for capacitive displays by adding:
+//   #define DRV_TOUCH_CALIB
+#if defined(DRV_TOUCH_TYPE_RES)
+  #define DRV_TOUCH_CALIB
+#endif
+
 // Additional defines
 // - Provide default if not in config file
 #if !defined(GSLC_SPIFFS_EN)

--- a/src/GUIslice_drv_tft_espi.h
+++ b/src/GUIslice_drv_tft_espi.h
@@ -87,6 +87,23 @@ extern "C" {
   #define DRV_TOUCH_CALIB
 #endif
 
+#if defined(DRV_TOUCH_CALIB)
+  // Ensure calibration settings are present in the config file
+  #if !defined(ADATOUCH_X_MIN)
+    // We didn't locate the calibration settings, so provide some
+    // temporary defaults. This typically only occurs if user has
+    // decided to force calibration on a capacitive display by
+    // adding DRV_TOUCH_CALIB, but hasn't yet added the calibration
+    // settings (ADATOUCH_X/Y_MIN/MAX) from the calibration sketch yet.
+    #warning Calibration settings (ADATOUCH_X/Y_MIN/MAX) need to be added to config. Using defaults.
+    #define ADATOUCH_X_MIN 0
+    #define ADATOUCH_X_MAX 4000
+    #define ADATOUCH_Y_MIN 0
+    #define ADATOUCH_Y_MAX 4000
+    #define ADATOUCH_REMAP_YX 0
+  #endif // ADATOUCH_X_MIN
+#endif // DRV_TOUCH_CALIB
+
 // Additional defines
 // - Provide default if not in config file
 #if !defined(GSLC_SPIFFS_EN)

--- a/src/GUIslice_drv_utft.cpp
+++ b/src/GUIslice_drv_utft.cpp
@@ -978,12 +978,12 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPre
 bool gslc_TDrvInitTouch(gslc_tsGui* pGui,const char* acDev) {
 
   // Capture default calibration settings for resistive displays
-  #if defined(DRV_TOUCH_TYPE_RES)
+  #if defined(DRV_TOUCH_CALIB)
     pGui->nTouchCalXMin = ADATOUCH_X_MIN;
     pGui->nTouchCalXMax = ADATOUCH_X_MAX;
     pGui->nTouchCalYMin = ADATOUCH_Y_MIN;
     pGui->nTouchCalYMax = ADATOUCH_Y_MAX;
-  #endif // DRV_TOUCH_TYPE_RES
+  #endif // DRV_TOUCH_CALIB
 
   // Support touch controllers with swapped X & Y
   #if defined(ADATOUCH_REMAP_YX)
@@ -1157,7 +1157,7 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
     nInputY = nRawY;
 
     // For resistive displays, perform constraint and scaling
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       if (pGui->bTouchRemapEn) {
         // Perform scaling from input to output
         // - Calibration done in native orientation (GSLC_ROTATE=0)
@@ -1185,14 +1185,14 @@ bool gslc_TDrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPr
       // No scaling from input to output
       nOutputX = nInputX;
       nOutputY = nInputY;
-    #endif  // DRV_TOUCH_TYPE_RES
+    #endif  // DRV_TOUCH_CALIB
   
     #ifdef DBG_TOUCH
     GSLC_DEBUG_PRINT("DBG: PreRotate: x=%u y=%u\n", nOutputX, nOutputY);
-    #if defined(DRV_TOUCH_TYPE_RES)
+    #if defined(DRV_TOUCH_CALIB)
       GSLC_DEBUG_PRINT("DBG: RotateCfg: remap=%u nSwapXY=%u nFlipX=%u nFlipY=%u\n",
         pGui->bTouchRemapEn,pGui->nSwapXY,pGui->nFlipX,pGui->nFlipY);
-    #endif // DRV_TOUCH_TYPE_RES
+    #endif // DRV_TOUCH_CALIB
     #endif // DBG_TOUCH
 
     // Perform remapping due to current orientation

--- a/src/GUIslice_drv_utft.h
+++ b/src/GUIslice_drv_utft.h
@@ -70,6 +70,23 @@ extern "C" {
   #define DRV_TOUCH_CALIB
 #endif
 
+#if defined(DRV_TOUCH_CALIB)
+  // Ensure calibration settings are present in the config file
+  #if !defined(ADATOUCH_X_MIN)
+    // We didn't locate the calibration settings, so provide some
+    // temporary defaults. This typically only occurs if user has
+    // decided to force calibration on a capacitive display by
+    // adding DRV_TOUCH_CALIB, but hasn't yet added the calibration
+    // settings (ADATOUCH_X/Y_MIN/MAX) from the calibration sketch yet.
+    #warning Calibration settings (ADATOUCH_X/Y_MIN/MAX) need to be added to config. Using defaults.
+    #define ADATOUCH_X_MIN 0
+    #define ADATOUCH_X_MAX 4000
+    #define ADATOUCH_Y_MIN 0
+    #define ADATOUCH_Y_MAX 4000
+    #define ADATOUCH_REMAP_YX 0
+  #endif // ADATOUCH_X_MIN
+#endif // DRV_TOUCH_CALIB
+
 // =======================================================================
 // API support definitions
 // - These defines indicate whether the driver includes optimized

--- a/src/GUIslice_drv_utft.h
+++ b/src/GUIslice_drv_utft.h
@@ -62,6 +62,13 @@ extern "C" {
 #elif defined(DRV_TOUCH_NONE)
 #endif // DRV_TOUCH_*
 
+// Determine if calibration required
+// - Enable for resistive displays
+// - User config can also enable for capacitive displays by adding:
+//   #define DRV_TOUCH_CALIB
+#if defined(DRV_TOUCH_TYPE_RES)
+  #define DRV_TOUCH_CALIB
+#endif
 
 // =======================================================================
 // API support definitions


### PR DESCRIPTION
This enhancement adds support for calibration on capacitive displays.
By default, calibration is only enabled for resistive displays.

In order to use this feature, add the following to your config file: (eg. SECTION 4)
- `#define DRV_TOUCH_CALIB`

Then perform the calibration as follows:
- Run the **diag_ard_touch_calib** sketch
- Perform the calibration steps
- Add the new calibration lines (eg. `ADATOUCH_X/Y_MIN/MAX`) to SECTION 4 of your config file
- Run the **diag_ard_touch_test** sketch to confirm it works

