### PR TITLE
Support for enhanced external input navigation

### DIFF
--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -176,6 +176,7 @@ typedef enum {
 
 /// Element features type
 #define GSLC_ELEM_FEA_VALID     0x80      ///< Element record is valid
+#define GSLC_ELEM_FEA_EDIT_EN   0x20      ///< Element supports edit
 #define GSLC_ELEM_FEA_ROUND_EN  0x10      ///< Element is drawn with a rounded profile
 #define GSLC_ELEM_FEA_CLICK_EN  0x08      ///< Element accepts touch presses
 #define GSLC_ELEM_FEA_GLOW_EN   0x04      ///< Element supports glowing state
@@ -800,6 +801,7 @@ typedef struct {
   gslc_tsInputMap*    asInputMap;       ///< Array of input maps
   uint8_t             nInputMapMax;     ///< Maximum number of input maps
   uint8_t             nInputMapCnt;     ///< Current number of input maps
+  uint8_t             nInputMode;       ///< Input mode: 0=navigate, 1=edit
 
 } gslc_tsGui;
 

--- a/src/elem/XListbox.c
+++ b/src/elem/XListbox.c
@@ -803,8 +803,13 @@ bool gslc_ElemXListboxTouch(void* pvGui, void* pvElemRef, gslc_teTouch eTouch, i
       // instead of touch coordinates
 
       if (eTouch == GSLC_TOUCH_SET_REL) {
-        // Overload the "nRelY" parameter as an increment value
-        nItemCurSel = nItemCurSelOld + nRelY;
+        // If nothing has been selected, force to select first entry
+        if (nItemCurSelOld == XLISTBOX_SEL_NONE) {
+          nItemCurSel = 0;
+        } else {
+          // Overload the "nRelY" parameter as an increment value
+          nItemCurSel = nItemCurSelOld + nRelY;
+        }
       }
       else if (eTouch == GSLC_TOUCH_SET_ABS) {
         // Overload the "nRelY" parameter as an absolute value

--- a/src/elem/XListbox.h
+++ b/src/elem/XListbox.h
@@ -52,7 +52,7 @@ extern "C" {
 #define  GSLC_TYPEX_LISTBOX GSLC_TYPE_BASE_EXTEND + 10
 
 // Define constants specific to the control
-#define XLISTBOX_SEL_NONE       -1  // Indicator for "no selection"
+#define XLISTBOX_SEL_NONE       -9  // Indicator for "no selection"
 #define XLISTBOX_SIZE_AUTO      -1  // Indicator for "auto-size"
 #define XLISTBOX_BUF_OH_R        2  // Listbox buffer overhead per row
 
@@ -90,6 +90,7 @@ typedef struct {
   int16_t         nItemCurSelLast;  ///< Old selected item to redraw (XLISTBOX_SEL_NONE for none)
   int16_t         nItemSavedSel;    ///< Persistent selected item (ie. saved selection)
   int16_t         nItemTop;         ///< Item to show at top of list after scrolling (0 is default)
+  uint8_t         nGlowLast;        ///< Last glow state (0=false, 1=true)
 
   // Callbacks
   GSLC_CB_XLISTBOX_SEL pfuncXSel; ///< Callback func ptr for selection update

--- a/src/elem/XSlider.c
+++ b/src/elem/XSlider.c
@@ -90,6 +90,7 @@ gslc_tsElemRef* gslc_ElemXSliderCreate(gslc_tsGui* pGui,int16_t nElemId,int16_t 
   sElem.nFeatures        |= GSLC_ELEM_FEA_FILL_EN;
   sElem.nFeatures        |= GSLC_ELEM_FEA_CLICK_EN;
   sElem.nFeatures        |= GSLC_ELEM_FEA_GLOW_EN;
+  sElem.nFeatures        |= GSLC_ELEM_FEA_EDIT_EN;
 
   sElem.nGroup            = GSLC_GROUP_ID_NONE;
 


### PR DESCRIPTION
This enhancement adds support for external button/pin input control over the GUI:
- Widgets now include an "edit" attribute (eg. XListbox, XSlider)
- Using a "select" external input over a widget with "edit" capability will toggle between navigate and edit mode
- Ability to change selection of XListbox in "edit" mode
- Ability to change value of a XSlider in "edit" mode
