### PR TITLE
Reduced redraw regions #328

### DIFF
--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -810,6 +810,11 @@ typedef struct {
                                         ///< element has been updated prior to next
                                         ///< page redraw command.
 
+  // Pending events
+  bool                bEventPending;    ///< Is there an event pending?
+  gslc_tsEventTouch   sEventTouchPend;  ///< A touch event that has been deferred (if bEventPending=true)
+  gslc_tsEvent        sEventPend;       ///< An event that has been deferred (if bEventPending=true)
+
   // Primary surface definitions
   gslc_tsImgRef       sImgRefBkgnd;     ///< Image reference for background
 


### PR DESCRIPTION
This feature enhancement adds the ability to support a "pending redraw" event, enabling improved redraw optimization for certain scenarios discussed in #328.

- Touch events often trigger a callback function which can in turn result in other UI updates (eg. text field updates)
- This enhancement places the touch event callbacks into a pending state, which enables button redraws (eg. from glow to normal) to be completed in a different update cycle than any side-effects of the callback.
- The net result is that the update regions can be significantly reduced in some scenarios, providing better performance.