### PR TITLE
fixes for drawing monochromic bmp images

### DIFF
--- a/src/GUIslice_drv_adagfx.cpp
+++ b/src/GUIslice_drv_adagfx.cpp
@@ -1791,7 +1791,6 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
   nCol.r  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.g  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.b  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
-  bmap_base++;
 
   int16_t i, j, byteWidth = (w + 7) / 8;
   uint8_t nByte = 0;

--- a/src/GUIslice_drv_m5stack.cpp
+++ b/src/GUIslice_drv_m5stack.cpp
@@ -580,7 +580,6 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
   nCol.r  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.g  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.b  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
-  bmap_base++;
 
   int16_t i, j, byteWidth = (w + 7) / 8;
   uint8_t nByte = 0;

--- a/src/GUIslice_drv_tft_espi.cpp
+++ b/src/GUIslice_drv_tft_espi.cpp
@@ -759,7 +759,6 @@ void gslc_DrvDrawMonoFromMem(gslc_tsGui* pGui,int16_t nDstX, int16_t nDstY,
   nCol.r  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.g  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
   nCol.b  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
-  bmap_base++;
 
   int16_t i, j, byteWidth = (w + 7) / 8;
   uint8_t nByte = 0;


### PR DESCRIPTION
Testing of gslc_DrvDrawMonoFromMem shows it been broken for while.
Debugging I found that after
  nCol.r  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
  nCol.g  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
  nCol.b  =   (bProgMem)? pgm_read_byte(bmap_base++) : *(bmap_base++);
  bmap_base++; <-- we are moving one byte ahead in our image
I larger image might show up correctly or seemly so.
Testing with 24x24 image has the last 1/3 of image display first followed by the beginning 2/3.
Deleting ` bmap_base++;` fixed the problem.

