### PR TITLE
add glsc_EnTouch to enable/disable processing of touch events

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -157,6 +157,7 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
       pGui->nTouchCalYMin = 100;
       pGui->nTouchCalYMax = 1000;
       pGui->bTouchRemapYX = false;
+      pGui->bEnTouch = true;
     #endif // !DRV_TOUCH_NONE
 
   #endif
@@ -689,8 +690,9 @@ void gslc_Update(gslc_tsGui* pGui)
 
     // --------------------------------------------------------------
     // If event found, handle it
+    // Skip if reaction to touch is disabled
     // --------------------------------------------------------------
-    if (bEvent) {
+    if (bEvent && pGui->bEnTouch) {
       // Track and handle the input events
       // - Handle the events on the current page
       switch (eInputEvent) {
@@ -5139,7 +5141,24 @@ void gslc_SetTouchRemapYX(gslc_tsGui* pGui, bool bSwap)
   }
   pGui->bTouchRemapYX = bSwap;
 }
-
+void gslc_EnTouch(gslc_tsGui* pGui, bool en)
+{
+  if (pGui == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "EnTouch";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return;
+  }
+  pGui->bEnTouch = en;
+}
+bool gslc_GetEnTouch(gslc_tsGui* pGui)
+{
+  if (pGui == NULL) {
+    static const char GSLC_PMEM FUNCSTR[] = "GetEnTouch";
+    GSLC_DEBUG2_PRINT_CONST(ERRSTR_NULL, FUNCSTR);
+    return false;
+  }
+  return pGui->bEnTouch;
+}
 
 #endif // !DRV_TOUCH_NONE
 

--- a/src/GUIslice.h
+++ b/src/GUIslice.h
@@ -807,6 +807,7 @@ typedef struct {
   uint16_t            nTouchLastPress;  ///< Last touch event pressure (0=none))
   bool                bTouchRemapEn;    ///< Enable touch remapping?
   bool                bTouchRemapYX;    ///< Enable touch controller swapping of X & Y
+  bool                bEnTouch;         ///< Enable reaction to touch events
 
 
   void*               pvDriver;         ///< Driver-specific members (gslc_tsDriver*)
@@ -2651,6 +2652,27 @@ void gslc_SetTouchPressCal(gslc_tsGui* pGui,uint16_t nPressMin, uint16_t nPressM
 /// \return none
 ///
 void gslc_SetTouchRemapYX(gslc_tsGui* pGui, bool bSwap);
+
+
+///
+/// Make touchscreen sensitive (GUI reacts to touch events) or
+/// insensitive (GUI ignores touch events)
+///
+/// \param[in]  pGui:        Pointer to GUI
+/// \param[in]  en:          Enable GUI reaction to touch events
+///
+/// \return none
+///
+void gslc_EnTouch(gslc_tsGui *pGui, bool en);
+
+///
+/// Get whether the GUI will react to touch events or not
+///
+/// \param[in]  pGui:        Pointer to GUI
+///
+/// \return whether the GUI is sensitive for touch events
+///
+bool gslc_GetEnTouch(gslc_tsGui *pGui);
 
 #endif // !DRV_TOUCH_NONE
 


### PR DESCRIPTION
This PR implements the most basic feature asked for in #510: it adds a function to enable/disable the processing of touch events. Basically, the GUI becomes sensitive/insensitive for touch. This PR does *not* provide an interface to intercept and manipulate touch events. It enables/disables touch entirely.

All touch events during an insensitive period are discarded. They are *not* processed later.

Tested on my little project with ESP32, ILI9341, XPT2046: works exactly as expected.

As a side note: Thank you so much @ImpulseAdventure for providing this library. Implementing this feature was a piece of cake with the well-structured and DRY codebase which allows for a straight-forward implementation of new features. I was really expecting this task to consume much more time.

I am looking forward to feedback, this is my first contribution to a project running on embedded.