### PR TITLE
fix for flash version of XTogglebtn having a groupID of 0

### DIFF
--- a/src/elem/XToggleImgbtn.c
+++ b/src/elem/XToggleImgbtn.c
@@ -94,6 +94,9 @@ gslc_tsElemRef* gslc_ElemXToggleImgbtnCreate(gslc_tsGui* pGui,int16_t nElemId,in
   sElem.nFeatures        |= GSLC_ELEM_FEA_FOCUS_EN;
   sElem.nFeatures        |= GSLC_ELEM_FEA_NOSHRINK; // Can't shrink due to image
 
+  // Default group assignment. Can override later with ElemSetGroup()
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+
   // Define other extended data
   sElem.pXData            = (void*)(pXData);
   pXData->bOn             = bOn;    // save on/off status

--- a/src/elem/XToggleImgbtn.h
+++ b/src/elem/XToggleImgbtn.h
@@ -195,7 +195,7 @@ gslc_tsElemRef* gslc_ElemXToggleImgbtnFindSelected(gslc_tsGui* pGui,int16_t nGro
       nFeatures##nElemId,                                         \
       GSLC_TYPEX_TOGGLEIMGBTN,                                       \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      0,                                                          \
+      -6999,                                                      \
       GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
       sImgRef_,           \
       sImgRefSel_,           \
@@ -233,7 +233,7 @@ gslc_tsElemRef* gslc_ElemXToggleImgbtnFindSelected(gslc_tsGui* pGui,int16_t nGro
       nFeatures##nElemId,                                         \
       GSLC_TYPEX_TOGGLEIMGBTN,                                       \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      0,                                                          \
+      -6999,                                                      \
       GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
       sImgRef_,           \
       sImgRefSel_,           \

--- a/src/elem/XTogglebtn.c
+++ b/src/elem/XTogglebtn.c
@@ -95,6 +95,9 @@ gslc_tsElemRef* gslc_ElemXTogglebtnCreate(gslc_tsGui* pGui,int16_t nElemId,int16
   sElem.nFeatures        |= GSLC_ELEM_FEA_GLOW_EN;
   sElem.nFeatures        |= GSLC_ELEM_FEA_FOCUS_EN;
 
+  // Default group assignment. Can override later with ElemSetGroup()
+  sElem.nGroup            = GSLC_GROUP_ID_NONE;
+
   // Define other extended data
   sElem.pXData            = (void*)(pXData);
   pXData->bOn             = bChecked;    // save on/off status

--- a/src/elem/XTogglebtn.h
+++ b/src/elem/XTogglebtn.h
@@ -208,7 +208,7 @@ gslc_tsElemRef* gslc_ElemXTogglebtnFindSelected(gslc_tsGui* pGui,int16_t nGroupI
       nFeatures##nElemId,                                         \
       GSLC_TYPEX_TOGGLEBTN,                                       \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      0,                                                          \
+      -6999,                                                      \
       GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
@@ -250,7 +250,7 @@ gslc_tsElemRef* gslc_ElemXTogglebtnFindSelected(gslc_tsGui* pGui,int16_t nGroupI
       nFeatures##nElemId,                                         \
       GSLC_TYPEX_TOGGLEBTN,                                       \
       (gslc_tsRect){nX,nY,nW,nH},                                 \
-      0,                                                          \
+      -6999,                                                      \
       GSLC_COL_GRAY,GSLC_COL_BLACK,GSLC_COL_WHITE,GSLC_COL_BLACK, \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \
       (gslc_tsImgRef){NULL,NULL,GSLC_IMGREF_NONE,NULL},           \


### PR DESCRIPTION
I made a mistake in defining the flash versions of XTogglebtn giving them a default nGroupId of 0 when it should have been GSLC_GROUP_ID_NONE or -6999
