### PR TITLE
Fix 2 SDL bugs

### DIFF
--- a/src/GUIslice.c
+++ b/src/GUIslice.c
@@ -161,7 +161,11 @@ bool gslc_Init(gslc_tsGui* pGui,void* pvDriver,gslc_tsPage* asPage,uint8_t nMaxP
     #endif // !DRV_TOUCH_NONE
 
   #endif
-
+  // Enable touch input for SDL driver
+  #if defined(DRV_TOUCH_SDL)
+    pGui->bTouchEn = true;
+  #endif
+	
   // Default to remapping enabled
   pGui->bTouchRemapEn = true;
 

--- a/src/GUIslice_drv_sdl.c
+++ b/src/GUIslice_drv_sdl.c
@@ -922,6 +922,12 @@ bool gslc_DrvGetTouch(gslc_tsGui* pGui,int16_t* pnX,int16_t* pnY,uint16_t* pnPre
   *peInputEvent = GSLC_INPUT_NONE;
 
   if (SDL_PollEvent(&sEvent)) {
+    #if defined(DRV_DISP_SDL1)
+      nKeyVal = (int16_t)(sEvent.key.keysym.sym);
+    #elif defined(DRV_DISP_SDL2)
+	  // In SDL2, the type of sym is int32.
+      nKeyVal = (int16_t)(sEvent.key.keysym.scancode);
+    #endif
     nKeyVal = (int16_t)(sEvent.key.keysym.sym);
 
     // Handle Key presses


### PR DESCRIPTION
1. Input is not working in SDL.
2. In SDL2, Event.key.keysym.sym is of type int32.