### PR TITLE
Fix XGraph: scale data values into pixel height using configured range

### DIFF
--- a/src/elem/XGraph.c
+++ b/src/elem/XGraph.c
@@ -312,6 +312,17 @@ bool gslc_ElemXGraphDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
   // Initialize color state
   colGraph  = pBox->colGraph;
 
+  // Precompute the plot value range used to scale each data value into
+  // the visible pixel height [0,nWndHeight]. In the default case
+  // (nPlotValMin=0, nPlotValMax=nWndHeight, ie. before any call to
+  // gslc_ElemXGraphSetRange()) this reduces to the legacy 1:1 value->pixel
+  // mapping.
+  int32_t nPlotRange = (int32_t)pBox->nPlotValMax - (int32_t)pBox->nPlotValMin;
+  if (nPlotRange <= 0) {
+    GSLC_DEBUG2_PRINT("ERROR: ElemXGraphDraw() Zero/negative graph range [%d,%d]\n",
+      pBox->nPlotValMin, pBox->nPlotValMax);
+  }
+
   // Calculate the current window position based on
   // the current buffer write pointer and scroll
   // position
@@ -353,8 +364,6 @@ bool gslc_ElemXGraphDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
     //   points and the X coordinate
     nCurX = nPlotInd;
 
-    // TODO: Scale data value
-
     // TODO: Consider supporting various color mapping modes
     //colGraph = gslc_ColorBlend2(GSLC_COL_BLACK,GSLC_COL_WHITE,500,nDataVal*500/200);
 
@@ -362,8 +371,16 @@ bool gslc_ElemXGraphDraw(void* pvGui,void* pvElemRef,gslc_teRedrawType eRedraw)
     nPixX       = pElem->rElem.x + pBox->nMargin + nCurX;
     nPixYBase   = pElem->rElem.y - pBox->nMargin + pElem->rElem.h-1;
 
-    // Calculate Y value
-    nPixYOffset = (nDataVal >= 0)? nDataVal : 0;
+    // Scale the (already clipped) data value from the configured plot
+    // range into the visible pixel height (see nPlotRange calc above)
+    if (nPlotRange > 0) {
+      // NOTE: cast operands to int32_t before subtracting so this is safe
+      // on platforms (eg. AVR) where int is only 16 bits wide
+      nPixYOffset = (uint16_t)((((int32_t)nDataVal - (int32_t)pBox->nPlotValMin) * (int32_t)pBox->nWndHeight) / nPlotRange);
+    } else {
+      // Misconfigured range (nPlotValMax <= nPlotValMin): avoid divide-by-zero
+      nPixYOffset = 0;
+    }
     // Clip plot Y value
     if (nPixYOffset > pBox->nWndHeight) { nPixYOffset = pBox->nWndHeight; }
 


### PR DESCRIPTION
## Problem

`gslc_ElemXGraphSetRange()` doesn't actually work: `gslc_ElemXGraphDraw()` clips each data value to `[nPlotValMin,nPlotValMax]` but then uses the raw clipped value directly as the pixel offset, right after a `// TODO: Scale data value` comment -- it never maps the configured range into the widget's pixel height.

This happens to look correct in the default construction case (`nPlotValMin=0`, `nPlotValMax=nWndHeight`, i.e. before any call to `gslc_ElemXGraphSetRange()`), which is a 1:1 mapping by coincidence. But calling `SetRange()` with any other range breaks: e.g. with `nWndHeight=65` and `SetRange(0,1000)`, every value from 500 to 1000 renders at the same pixel row (both clip visually to the top of the widget), and with a negative-inclusive range like `SetRange(-1000,1000)`, every negative value collapses to pixel offset 0.

This matches the behavior reported in #590, where a maintainer confirmed `gslc_ElemXGraphSetRange()` "does seem broken."

## Fix

Add the missing linear scale from `[nPlotValMin,nPlotValMax]` into `[0,nWndHeight]`, guarded against divide-by-zero on a degenerate/misconfigured range (`nPlotValMax <= nPlotValMin`). This mirrors the existing `int32_t` widen-then-scale pattern already used for the equivalent value->pixel problem in `XGauge.c`.

Operands are cast to `int32_t` *before* subtracting (not after), which matters on 16-bit-`int` platforms such as AVR: `nDataVal` and `nPlotValMin` are both `int16_t`, and their difference can exceed the range of a 16-bit `int` for extreme values, silently wrapping if computed in 16-bit domain first.

## Testing

Extracted the relevant struct fields and the old vs. new scaling logic verbatim into a standalone C program and ran it natively:
- Confirmed the new formula is byte-for-byte identical to the old one in the default (no `SetRange()`) construction case, across the full range of values -- fully backward compatible.
- Reproduced the bug with the geometry from #590 (`nWndHeight=65`) and `SetRange(0,1000)`: old code puts both `val=500` and `val=1000` at pixel offset 65; new code correctly produces 0/32/65 for `val=0/500/1000`.
- Confirmed correct proportional scaling for a negative-inclusive range (`SetRange(-1000,1000)`).
- Confirmed the degenerate-range guard (`nPlotValMax <= nPlotValMin`) avoids divide-by-zero and returns offset 0.
- Confirmed the `int32_t`-cast-before-subtract ordering avoids the 16-bit wraparound that a naive 16-bit-domain subtraction would hit at extreme `int16_t` values.

Closes #590.